### PR TITLE
add pkg-config as a requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ future. Contributions welcome, but please be kind ;)
 * `libpulse-dev` (or `portaudio-dev`, if you want to use the PortAudio backend)
 * `libncurses-dev` and `libssl-dev`
 * A Spotify premium account
+* pkg-config
 
 ## Usage
 


### PR DESCRIPTION
tried installing on Mac and pkg-config needed to be separately installed