### PR TITLE
Add main layout view and status bar

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -1,13 +1,16 @@
 use crossbeam_channel::{unbounded, Receiver, Sender, TryIter};
 use cursive::{CbFunc, Cursive};
 
+use rspotify::spotify::model::track::FullTrack;
+use spotify::PlayerStatus;
+
 use queue::QueueChange;
-use spotify::PlayerState;
 use ui::playlist::PlaylistEvent;
 
 pub enum Event {
     Queue(QueueChange),
-    Player(PlayerState),
+    PlayerStatus(PlayerStatus),
+    PlayerTrack(Option<FullTrack>),
     Playlist(PlaylistEvent),
 }
 

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -1,0 +1,91 @@
+use std::collections::{HashMap};
+
+use cursive::direction::Direction;
+use cursive::event::{Event, EventResult, AnyCb};
+use cursive::traits::View;
+use cursive::view::{IntoBoxedView, Selector};
+use cursive::vec::Vec2;
+use cursive::Printer;
+
+pub struct Layout {
+    views: HashMap<String, Box<dyn View>>,
+    statusbar: Box<dyn View>,
+    focus: Option<String>
+}
+
+impl Layout {
+    pub fn new<T: IntoBoxedView>(status: T) -> Layout {
+        Layout {
+            views: HashMap::new(),
+            statusbar: status.as_boxed_view(),
+            focus: None
+        }
+    }
+
+    pub fn add_view<S: Into<String>, T: IntoBoxedView>(&mut self, id: S, view: T) {
+        let s = id.into();
+        self.views.insert(s.clone(), view.as_boxed_view());
+        self.focus = Some(s);
+    }
+
+    pub fn view<S: Into<String>, T: IntoBoxedView>(mut self, id: S, view: T) -> Self {
+        (&mut self).add_view(id, view);
+        self
+    }
+
+    pub fn set_view<S: Into<String>>(&mut self, id: S) {
+        let s = id.into();
+        self.focus = Some(s);
+    }
+}
+
+impl View for Layout {
+    fn draw(&self, printer: &Printer<'_, '_>) {
+        if let Some(ref id) = self.focus {
+            let v = self.views.get(id).unwrap();
+            let printer = &printer
+                .offset((0, 0))
+                .cropped((printer.size.x, printer.size.y - 2))
+                .focused(true);
+            v.draw(printer);
+        }
+
+        self.statusbar.draw(&printer.offset((0, printer.size.y - 2)));
+    }
+
+    fn required_size(&mut self, constraint: Vec2) -> Vec2 {
+        Vec2::new(constraint.x, constraint.y)
+    }
+
+    fn on_event(&mut self, event: Event) -> EventResult {
+        if let Some(ref id) = self.focus {
+            let v = self.views.get_mut(id).unwrap();
+            v.on_event(event)
+        } else {
+            EventResult::Ignored
+        }
+    }
+
+    fn layout(&mut self, size: Vec2) {
+        if let Some(ref id) = self.focus {
+            let v = self.views.get_mut(id).unwrap();
+            v.layout(Vec2::new(size.x, size.y - 1));
+        }
+    }
+
+    fn call_on_any<'a>(&mut self, s: &Selector, c: AnyCb<'a>) {
+        if let Some(ref id) = self.focus {
+            let v = self.views.get_mut(id).unwrap();
+            v.call_on_any(s, c);
+        }
+    }
+
+    fn take_focus(&mut self, source: Direction) -> bool {
+        if let Some(ref id) = self.focus {
+            let v = self.views.get_mut(id).unwrap();
+            v.take_focus(source)
+        } else {
+            false
+        }
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2,3 +2,5 @@ pub mod playlist;
 pub mod queue;
 pub mod search;
 pub mod trackbutton;
+pub mod statusbar;
+pub mod layout;

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -8,7 +8,6 @@ use cursive::Cursive;
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use librespot::core::spotify_id::SpotifyId;
 use rspotify::spotify::model::track::FullTrack;
 
 use queue::{Queue, QueueChange};
@@ -47,8 +46,7 @@ impl QueueView {
         if let Some(queuelist) = view_ref {
             let index = queuelist.get_focus_index();
             let track = queue.remove(index).expect("could not dequeue track");
-            let trackid = SpotifyId::from_base62(&track.id).expect("could not load track");
-            spotify.load(trackid);
+            spotify.load(track);
             spotify.play();
         }
     }

--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -7,8 +7,6 @@ use cursive::Cursive;
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use librespot::core::spotify_id::SpotifyId;
-
 use queue::Queue;
 use spotify::Spotify;
 use ui::trackbutton::TrackButton;
@@ -33,12 +31,12 @@ impl SearchView {
         if let Ok(tracks) = tracks {
             for track in tracks.tracks.items {
                 let s = spotify.clone();
-                let trackid = SpotifyId::from_base62(&track.id).expect("could not load track");
                 let mut button = TrackButton::new(&track);
 
                 // <enter> plays the selected track
+                let t = track.clone();
                 button.add_callback(Key::Enter, move |_cursive| {
-                    s.load(trackid);
+                    s.load(t.clone());
                     s.play();
                 });
 

--- a/src/ui/statusbar.rs
+++ b/src/ui/statusbar.rs
@@ -1,0 +1,78 @@
+use std::sync::Arc;
+
+use cursive::align::HAlign;
+use cursive::theme::{ColorStyle, ColorType, Color, BaseColor};
+use cursive::traits::View;
+use cursive::vec::Vec2;
+use cursive::Printer;
+use unicode_width::UnicodeWidthStr;
+
+use spotify::{PlayerStatus, Spotify};
+
+pub struct StatusBar {
+    spotify: Arc<Spotify>
+}
+
+impl StatusBar {
+    pub fn new(spotify: Arc<Spotify>) -> StatusBar {
+        StatusBar {
+            spotify: spotify
+        }
+    }
+}
+
+impl View for StatusBar {
+    fn draw(&self, printer: &Printer<'_, '_>) {
+        if printer.size.x == 0 {
+            return;
+        }
+
+        let front = ColorType::Color(Color::Dark(BaseColor::Black));
+        let back = ColorType::Color(Color::Dark(BaseColor::Green));
+        let style = ColorStyle::new(front, back);
+
+        printer.print((0, 0), &vec![' '; printer.size.x].into_iter().collect::<String>());
+        printer.with_color(style, |printer| {
+            printer.print((0, 1), &vec![' '; printer.size.x].into_iter().collect::<String>());
+        });
+
+        let state_icon = match self.spotify.get_current_status() {
+            PlayerStatus::Playing => " ▶ ",
+            PlayerStatus::Paused => " ▮▮ ",
+            PlayerStatus::Stopped => " ◼  ",
+        }.to_string();
+
+        printer.with_color(style, |printer| {
+            printer.print((0, 1), &state_icon);
+        });
+
+        if let Some(ref t) = self.spotify.get_current_track() {
+            let name = format!("{} - {}",
+                t.artists.iter().map(|ref artist| artist.name.clone()).collect::<Vec<String>>().join(", "),
+                t.name).to_string();
+
+            let minutes = t.duration_ms / 60000;
+            let seconds = (t.duration_ms % 60000) / 1000;
+            let formatted_duration = format!("{:02}:{:02}", minutes, seconds);
+
+            let elapsed = self.spotify.get_current_progress();
+            let formatted_elapsed = format!("{:02}:{:02}", elapsed.as_secs() / 60, elapsed.as_secs() % 60);
+
+            let duration = format!("{} / {} ", formatted_elapsed, formatted_duration);
+            let offset = HAlign::Right.get_offset(duration.width(), printer.size.x);
+
+            printer.with_color(style, |printer| {
+                printer.print((4, 1), &name);
+                printer.print((offset, 1), &duration);
+            });
+
+            printer.with_color(ColorStyle::new(back, front), |printer| {
+                printer.print_hline((0, 0), (((printer.size.x as u32) * (elapsed.as_millis() as u32)) / t.duration_ms) as usize, "=")
+            });
+        }
+    }
+
+    fn required_size(&mut self, constraint: Vec2) -> Vec2 {
+        Vec2::new(constraint.x, 2)
+    }
+}


### PR DESCRIPTION
![](https://giant.gfycat.com/ActualMeaslyIndianspinyloach.gif)

I added a status bar containing playback status, name and duration with a progress bar spanning the entire line above. I'm not sure yet whether that's a good use of space, or if that should be integrated into the single line (this might look odd because of being off-center). It could potentially automatically be removed if the window height drops below a certain treshold.

To accomplish this, I also made some other changes:
- Wrapping all main views inside a custom layout for view switching
- Changing the load command to use `FullTrack` instead of `SpotifyId`
- Keeping track of the currently playing track in `Spotify`
- Renaming `PlayerState` to `PlayerStatus` to prevent misunderstandings, since the state of the entire player consists of that status, the current track and other data.
- Keeping track of the elapsed time of the current song. This is really hacky, but unless I missed it there's currently no easy way to get this from `librespot`. This should probably be added upstream. As you can see in the gif, my method is not perfect and sometimes goes beyond the total duration.
- Adding getters and setters for the `RwLock`s in `Spotify` to increase readability.