### PR TITLE
Add a vim-style command line

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,0 +1,49 @@
+use std::collections::HashMap;
+
+use cursive::Cursive;
+
+pub struct CommandManager {
+    commands: HashMap<String, Box<dyn Fn(&mut Cursive, Vec<String>) -> Result<Option<String>, String>>>,
+    aliases: HashMap<String, String>,
+}
+
+impl CommandManager {
+    pub fn new() -> CommandManager {
+        CommandManager {
+            commands: HashMap::new(),
+            aliases: HashMap::new(),
+        }
+    }
+
+    pub fn register<S: Into<String>>(
+        &mut self,
+        name: S,
+        aliases: Vec<S>,
+        cb: Box<dyn Fn(&mut Cursive, Vec<String>) -> Result<Option<String>, String>>
+    ) {
+        let name = name.into();
+        for a in aliases {
+            self.aliases.insert(a.into(), name.clone());
+        }
+        self.commands.insert(name, cb);
+    }
+
+    fn handle_aliases(&self, name: &String) -> String {
+        if let Some(s) = self.aliases.get(name) {
+            self.handle_aliases(s)
+        } else {
+            name.clone()
+        }
+    }
+
+    pub fn handle(&self, s: &mut Cursive, cmd: String) -> Result<Option<String>, String> {
+        // TODO: handle quoted arguments
+        let components: Vec<String> = cmd.split(' ').map(|s| s.to_string()).collect();
+
+        if let Some(cb) = self.commands.get(&self.handle_aliases(&components[0])) {
+            cb(s, components[1..].to_vec())
+        } else {
+            Err("Unknown command.".to_string())
+        }
+    }
+}

--- a/src/events.rs
+++ b/src/events.rs
@@ -9,6 +9,7 @@ pub enum Event {
     Queue(QueueEvent),
     Player(PlayerEvent),
     Playlist(PlaylistEvent),
+    Command(String),
 }
 
 pub type EventSender = Sender<Event>;

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -1,3 +1,4 @@
+use std::time::{SystemTime, Duration};
 use std::collections::HashMap;
 
 use cursive::align::HAlign;
@@ -7,6 +8,7 @@ use cursive::theme::ColorStyle;
 use cursive::traits::View;
 use cursive::vec::Vec2;
 use cursive::view::{IntoBoxedView, Selector};
+use cursive::views::EditView;
 use cursive::Printer;
 use unicode_width::UnicodeWidthStr;
 
@@ -20,6 +22,10 @@ pub struct Layout {
     title: String,
     statusbar: Box<dyn View>,
     focus: Option<String>,
+    pub cmdline: EditView,
+    cmdline_focus: bool,
+    error: Option<String>,
+    error_time: Option<SystemTime>,
 }
 
 impl Layout {
@@ -29,6 +35,17 @@ impl Layout {
             title: String::new(),
             statusbar: status.as_boxed_view(),
             focus: None,
+            cmdline: EditView::new().filler(" "),
+            cmdline_focus: false,
+            error: None,
+            error_time: None,
+        }
+    }
+
+    pub fn enable_cmdline(&mut self) {
+        if !self.cmdline_focus {
+            self.cmdline.set_content(":");
+            self.cmdline_focus = true;
         }
     }
 
@@ -53,11 +70,41 @@ impl Layout {
         let title = &self.views.get(&s).unwrap().title;
         self.title = title.clone();
         self.focus = Some(s);
+        self.cmdline_focus = false;
+    }
+
+    pub fn set_error<S: Into<String>>(&mut self, error: S) {
+        self.error = Some(error.into());
+        self.error_time = Some(SystemTime::now());
+    }
+
+    pub fn clear_cmdline(&mut self) {
+        self.cmdline.set_content("");
+        self.cmdline_focus = false;
+        self.error = None;
+        self.error_time = None;
+    }
+
+    fn get_error(&self) -> Option<String> {
+        if let Some(t) = self.error_time {
+            if t.elapsed().unwrap() > Duration::from_secs(5) {
+                return None;
+            }
+        }
+        self.error.clone()
     }
 }
 
 impl View for Layout {
     fn draw(&self, printer: &Printer<'_, '_>) {
+        let error = self.get_error();
+
+        let cmdline_visible = self.cmdline.get_content().len() > 0;
+        let mut cmdline_height = if cmdline_visible { 1 } else { 0 };
+        if error.is_some() {
+            cmdline_height += 1;
+        }
+
         // screen title
         printer.with_color(ColorStyle::title_primary(), |printer| {
             let offset = HAlign::Center.get_offset(self.title.width(), printer.size.x);
@@ -69,13 +116,26 @@ impl View for Layout {
             let screen = self.views.get(id).unwrap();
             let printer = &printer
                 .offset((0, 1))
-                .cropped((printer.size.x, printer.size.y - 3))
+                .cropped((printer.size.x, printer.size.y - 3 - cmdline_height))
                 .focused(true);
             screen.view.draw(printer);
         }
 
         self.statusbar
-            .draw(&printer.offset((0, printer.size.y - 2)));
+            .draw(&printer.offset((0, printer.size.y - 2 - cmdline_height)));
+
+        if let Some(e) = error {
+            printer.with_color(ColorStyle::highlight(), |printer| {
+                printer.print_hline((0, printer.size.y - cmdline_height), printer.size.x, " ");
+                printer.print((0, printer.size.y - cmdline_height), &format!("ERROR: {}", e));
+            });
+        }
+
+        if cmdline_visible {
+            let printer = &printer
+                .offset((0, printer.size.y - 1));
+            self.cmdline.draw(&printer);
+        }
     }
 
     fn required_size(&mut self, constraint: Vec2) -> Vec2 {
@@ -83,6 +143,10 @@ impl View for Layout {
     }
 
     fn on_event(&mut self, event: Event) -> EventResult {
+        if self.cmdline_focus {
+            return self.cmdline.on_event(event);
+        }
+
         if let Some(ref id) = self.focus {
             let screen = self.views.get_mut(id).unwrap();
             screen.view.on_event(event)
@@ -92,6 +156,8 @@ impl View for Layout {
     }
 
     fn layout(&mut self, size: Vec2) {
+        self.cmdline.layout(Vec2::new(size.x, 1));
+
         if let Some(ref id) = self.focus {
             let screen = self.views.get_mut(id).unwrap();
             screen.view.layout(Vec2::new(size.x, size.y - 3));
@@ -106,6 +172,10 @@ impl View for Layout {
     }
 
     fn take_focus(&mut self, source: Direction) -> bool {
+        if self.cmdline_focus {
+            return self.cmdline.take_focus(source);
+        }
+
         if let Some(ref id) = self.focus {
             let screen = self.views.get_mut(id).unwrap();
             screen.view.take_focus(source)


### PR DESCRIPTION
As promised, adds a basic vim-style command line. I replaced all the existing (global) keybindings with commands. This allows easy rebinding, although at the moment they remain hardcoded.

Command callbacks return `Result<Option<String>, String>`. If an error is returned, the text is displayed above the command line.

The `:search` command allows entering the query directly, although the `on_submit` callback is currently not called, so you still have to press Enter.

![](https://giant.gfycat.com/RepulsiveNearIlsamochadegu.gif)