### PR TITLE
Add playlist-shuffle command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ tokio-timer = "0.2"
 unicode-width = "0.1.5"
 dbus = { version = "0.6.4", optional = true }
 dbus-tokio = { version = "0.3.0", optional = true }
+rand = "0.6.5"
 
 [dependencies.librespot]
 git = "https://github.com/librespot-org/librespot.git"

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ extern crate tokio;
 extern crate tokio_core;
 extern crate tokio_timer;
 extern crate unicode_width;
+extern crate rand;
 
 #[cfg(feature = "mpris")]
 extern crate dbus;
@@ -219,6 +220,18 @@ fn main() {
             Vec::new(),
             Box::new(move |_s, _args| {
                 queue.lock().expect("could not lock queue").stop();
+                Ok(None)
+            }),
+        );
+    }
+
+    {
+        let queue = queue.clone();
+        cmd_manager.register(
+            "playlist-shuffle",
+            Vec::new(),
+            Box::new(move |_s, _args| {
+                queue.lock().expect("could not lock queue").shuffle();
                 Ok(None)
             }),
         );

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -1,6 +1,8 @@
 use std::slice::Iter;
 use std::sync::Arc;
 
+use rand::prelude::*;
+
 use events::{Event, EventManager};
 use spotify::Spotify;
 use track::Track;
@@ -21,6 +23,13 @@ impl Queue {
             spotify: spotify,
             ev: ev,
         }
+    }
+
+    pub fn shuffle(&mut self) {
+        let mut rng = rand::thread_rng();
+        self.queue.shuffle(&mut rng);
+
+        self.ev.send(Event::ScreenChange("queue".to_owned()));
     }
 
     pub fn next_index(&self) -> Option<usize> {


### PR DESCRIPTION
I opted not to add a keyboard shortcut for now. The command interface by itself is useful since shuffling is not a common operation. As it stands, the position in the playlist is maintained since it's referenced by index. This means that the next position in the playlist will be continued. I considered resetting the position, but I wasn't certain.