### PR TITLE
Refactor DBus server, implement PropertiesChanged

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ tokio-core = "0.1"
 tokio-timer = "0.2"
 unicode-width = "0.1.5"
 dbus = { version = "0.6.4", optional = true }
-dbus-tokio = { version = "0.3.0", optional = true }
 
 [dependencies.librespot]
 git = "https://github.com/librespot-org/librespot.git"
@@ -42,5 +41,5 @@ features = ["pancurses-backend"]
 [features]
 pulseaudio_backend = ["librespot/pulseaudio-backend"]
 portaudio_backend = ["librespot/portaudio-backend"]
-mpris = ["dbus", "dbus-tokio"]
+mpris = ["dbus"]
 default = ["pulseaudio_backend", "mpris"]


### PR DESCRIPTION
Refactored the DBus server, yanking out all the `dbus-tokio` stuff since it failed in interesting and annoying ways when I tried to implement a manual poll loop and manually sending out `PropertiesChanged` signals when needed.

I also fixed a typo in the interface name and the artists being strings instead of arrays (this caused an error in the GNOME shell on top of the missing events).

![](https://i.imgur.com/fW8uk3J.png)