### PR TITLE
Credentials helper if config not present or unparseable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ maintenance = { status = "experimental" }
 [dependencies]
 clap = "2.32.0"
 chrono = "0.4"
+reqwest = "0.9.11"
 crossbeam-channel = "0.3.8"
 directories = "1.0"
 failure = "0.1.3"
@@ -34,12 +35,15 @@ rand = "0.6.5"
 
 [dependencies.librespot]
 git = "https://github.com/librespot-org/librespot.git"
-rev = "2fb901a743906a5b49b3148dbfa85074964dd745"
+rev = "14721f4"
 default-features = false
 
 [dependencies.cursive]
 version = "0.11.1"
 default-features = false
+
+[dependencies.winapi]
+git = "https://github.com/overdrivenpotato/winapi-rs"
 
 [features]
 pulseaudio_backend = ["librespot/pulseaudio-backend"]

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -1,0 +1,169 @@
+use std::path::Path;
+
+use cursive::view::Identifiable;
+use cursive::views::*;
+use cursive::{CbSink, Cursive};
+
+use librespot::core::authentication::Credentials as RespotCredentials;
+use librespot::protocol::authentication::AuthenticationType;
+
+pub fn create_credentials(path: &Path) -> Result<RespotCredentials, String> {
+    let mut login_cursive = Cursive::default();
+    let mut info_buf = TextContent::new("Failed to authenticate\n");
+    info_buf.append(format!(
+        "Cannot read config file from {}\n",
+        path.to_str().unwrap()
+    ));
+    let info_view = Dialog::around(TextView::new_with_content(info_buf.clone()))
+        .button("Login", move |s| {
+            let login_view = Dialog::new()
+                .title("Login with Spotify username and password")
+                .content(
+                    ListView::new()
+                        .child("username", EditView::new().with_id("spotify_user"))
+                        .child(
+                            "password",
+                            EditView::new().secret().with_id("spotify_password"),
+                        ),
+                )
+                .button("Login", |s| {
+                    let username = s
+                        .call_on_id("spotify_user", |view: &mut EditView| view.get_content())
+                        .unwrap()
+                        .to_string();
+                    let auth_data = s
+                        .call_on_id("spotify_password", |view: &mut EditView| view.get_content())
+                        .unwrap()
+                        .to_string()
+                        .as_bytes()
+                        .to_vec();
+                    s.set_user_data::<Result<RespotCredentials, String>>(Ok(RespotCredentials {
+                        username,
+                        auth_type: AuthenticationType::AUTHENTICATION_USER_PASS,
+                        auth_data,
+                    }));
+                    s.quit();
+                })
+                .button("Quit", |s| s.quit());
+            s.pop_layer();
+            s.add_layer(login_view);
+        })
+        .button("Login with Facebook", |s| {
+            let urls: std::collections::HashMap<String, String> =
+                reqwest::get("https://login2.spotify.com/v1/config")
+                    .expect("didn't connect")
+                    .json()
+                    .expect("didn't parse");
+            // not a dialog to let people copy & paste the URL
+            let url_notice = TextView::new(format!("Browse to {}", urls.get("login_url").unwrap()));
+
+            let controls = Button::new("Quit", |s| s.quit());
+
+            let login_view = LinearLayout::new(cursive::direction::Orientation::Vertical)
+                .child(url_notice)
+                .child(controls);
+            url_open(urls.get("login_url").unwrap().to_string());
+            crappy_poller(urls.get("credentials_url").unwrap(), &s.cb_sink());
+            s.pop_layer();
+            s.add_layer(login_view)
+        })
+        .button("Quit", |s| s.quit());
+
+    login_cursive.add_layer(info_view);
+    login_cursive.run();
+
+    login_cursive
+        .user_data()
+        .cloned()
+        .unwrap_or(Err("Didn't obtain any credentials".to_string()))
+}
+
+// TODO: better with futures?
+fn crappy_poller(url: &str, app_sink: &CbSink) {
+    let app_sink = app_sink.clone();
+    let url = url.to_string();
+    std::thread::spawn(move || {
+        let timeout = std::time::Duration::from_secs(5 * 60);
+        let start_time = std::time::SystemTime::now();
+        while std::time::SystemTime::now()
+            .duration_since(start_time)
+            .unwrap_or(timeout)
+            < timeout
+        {
+            if let Ok(mut response) = reqwest::get(&url) {
+                if response.status() != reqwest::StatusCode::ACCEPTED {
+                    let result = match response.status() {
+                        reqwest::StatusCode::OK => {
+                            let creds = response
+                                .json::<AuthResponse>()
+                                .expect("Unable to parse")
+                                .credentials;
+                            Ok(creds)
+                        }
+
+                        _ => Err(format!(
+                            "Facebook auth failed with code {}: {}",
+                            response.status(),
+                            response.text().unwrap()
+                        )),
+                    };
+                    app_sink
+                        .send(Box::new(|s: &mut Cursive| {
+                            s.set_user_data(result);
+                            s.quit();
+                        }))
+                        .unwrap();
+                    return;
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(1000));
+        }
+
+        app_sink
+            .send(Box::new(|s: &mut Cursive| {
+                s.set_user_data::<Result<RespotCredentials, String>>(Err(
+                    "Timed out authenticating".to_string(),
+                ));
+                s.quit();
+            }))
+            .unwrap();
+    });
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct AuthResponse {
+    pub credentials: RespotCredentials,
+    pub error: Option<String>,
+}
+
+// Thanks to Marko Mijalkovic for this, but I don't want the url crate
+
+#[cfg(target_os = "windows")]
+pub fn url_open(url: String) {
+    extern crate shell32;
+    extern crate winapi;
+
+    use std::ffi::CString;
+    use std::ptr;
+
+    unsafe {
+        shell32::ShellExecuteA(
+            ptr::null_mut(),
+            CString::new("open").unwrap().as_ptr(),
+            CString::new(url.replace("\n", "%0A")).unwrap().as_ptr(),
+            ptr::null(),
+            ptr::null(),
+            winapi::SW_SHOWNORMAL,
+        );
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub fn url_open(url: String) {
+    let _ = std::process::Command::new("open").arg(url).output();
+}
+
+#[cfg(target_os = "linux")]
+pub fn url_open(url: String) {
+    let _ = std::process::Command::new("xdg-open").arg(url).output();
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,7 +42,10 @@ pub fn config_path(file: &str) -> PathBuf {
     let proj_dirs = proj_dirs();
     let cfg_dir = proj_dirs.config_dir();
     trace!("{:?}", cfg_dir);
-    if !cfg_dir.exists() || !cfg_dir.is_dir() {
+    if !cfg_dir.is_dir() {
+        fs::remove_file(cfg_dir).expect("unable to remove old config file");
+    }
+    if !cfg_dir.exists() {
         fs::create_dir(cfg_dir).expect("can't create config folder");
     }
     let mut cfg = cfg_dir.to_path_buf();

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use directories::ProjectDirs;
 
@@ -8,8 +8,6 @@ pub const CLIENT_ID: &str = "d420a117a32841c2b3474932e49fb54b";
 
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct Config {
-    pub username: String,
-    pub password: String,
     pub keybindings: Option<HashMap<String, String>>,
     pub theme: Option<ConfigTheme>,
     pub use_nerdfont: Option<bool>,
@@ -42,7 +40,7 @@ pub fn config_path(file: &str) -> PathBuf {
     let proj_dirs = proj_dirs();
     let cfg_dir = proj_dirs.config_dir();
     trace!("{:?}", cfg_dir);
-    if !cfg_dir.is_dir() {
+    if cfg_dir.exists() && !cfg_dir.is_dir() {
         fs::remove_file(cfg_dir).expect("unable to remove old config file");
     }
     if !cfg_dir.exists() {
@@ -62,4 +60,55 @@ pub fn cache_path(file: &str) -> PathBuf {
     let mut pb = cache_dir.to_path_buf();
     pb.push(file);
     pb
+}
+
+/// Configuration and credential file helper
+/// Creates a default configuration if none exist, otherwise will optionally overwrite
+/// the file if it fails to parse
+pub fn load_or_generate_default<
+    P: AsRef<Path>,
+    T: serde::Serialize + serde::de::DeserializeOwned,
+    F: Fn(&Path) -> Result<T, String>,
+>(
+    path: P,
+    default: F,
+    default_on_parse_failure: bool,
+) -> Result<T, String> {
+    let path = path.as_ref();
+    // Nothing exists so just write the default and return it
+    if !path.exists() {
+        let value = default(&path)?;
+        return write_content_helper(&path, value);
+    }
+
+    // load the serialized content. Always report this failure
+    let contents = std::fs::read_to_string(&path)
+        .map_err(|e| format!("Unable to read {}: {}", path.to_string_lossy(), e))?;
+
+    // Deserialize the content, optionally fall back to default if it fails
+    let result = toml::from_str(&contents);
+    if default_on_parse_failure {
+        if let Err(_) = result {
+            let value = default(&path)?;
+            return write_content_helper(&path, value);
+        }
+    }
+    result.map_err(|e| format!("Unable to parse {}: {}", path.to_string_lossy(), e))
+}
+
+fn write_content_helper<P: AsRef<Path>, T: serde::Serialize>(
+    path: P,
+    value: T,
+) -> Result<T, String> {
+    let content =
+        toml::to_string_pretty(&value).map_err(|e| format!("Failed serializing value: {}", e))?;
+    fs::write(path.as_ref(), content)
+        .map(|_| value)
+        .map_err(|e| {
+            format!(
+                "Failed writing content to {}: {}",
+                path.as_ref().display(),
+                e
+            )
+        })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,7 +156,11 @@ fn main() {
 
     let queueview = ui::queue::QueueView::new(queue.clone(), playlists.clone());
 
-    let status = ui::statusbar::StatusBar::new(queue.clone(), spotify.clone(), &cfg);
+    let status = ui::statusbar::StatusBar::new(
+        queue.clone(),
+        spotify.clone(),
+        cfg.use_nerdfont.unwrap_or(false),
+    );
 
     let mut layout = ui::layout::Layout::new(status, &event_manager, theme)
         .view("search", search.with_id("search"), "Search")

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -184,13 +184,13 @@ impl futures::Future for Worker {
 }
 
 impl Spotify {
-    pub fn new(events: EventManager, user: String, password: String) -> Spotify {
+    pub fn new(events: EventManager, credentials: Credentials) -> Spotify {
         let player_config = PlayerConfig {
             bitrate: Bitrate::Bitrate320,
             normalisation: false,
             normalisation_pregain: 0.0,
         };
-        let credentials = Credentials::with_password(user.clone(), password.clone());
+        let user = credentials.username.clone();
 
         let (tx, rx) = mpsc::unbounded();
         {

--- a/src/ui/statusbar.rs
+++ b/src/ui/statusbar.rs
@@ -8,7 +8,6 @@ use cursive::vec::Vec2;
 use cursive::Printer;
 use unicode_width::UnicodeWidthStr;
 
-use config::Config;
 use queue::{Queue, RepeatSetting};
 use spotify::{PlayerEvent, Spotify};
 
@@ -20,12 +19,12 @@ pub struct StatusBar {
 }
 
 impl StatusBar {
-    pub fn new(queue: Arc<Queue>, spotify: Arc<Spotify>, cfg: &Config) -> StatusBar {
+    pub fn new(queue: Arc<Queue>, spotify: Arc<Spotify>, use_nerdfont: bool) -> StatusBar {
         StatusBar {
             queue,
             spotify,
             last_size: Vec2::new(0, 0),
-            use_nerdfont: cfg.use_nerdfont.unwrap_or(false),
+            use_nerdfont,
         }
     }
 }


### PR DESCRIPTION
Fixes #1 but requires librespot-org/librespot#313 (though I can probably make a workaround)

This PR introduces a login helper interface (authentication.rs) that is invoked if there is no config file or the config file fails to parse. It proposes a breaking change to the config file format to match librespot credentials. *Note:* it also writes to the config file, so back it up if this is a concern.

It requires a bit of work before I'm happy with it:
* improve login interface caller process (it's a mess right now, and doesn't verify the credentials before fully launching ncspot)
  * probably allows the login helper to return `Credentials` instead of its serialization
* Login vs Login /w Facebook have different layouts (to allow URL copy/pasta)
* polling should probably be done with a future instead
* winapi dependency is copy/pasta, probably there are no ncurses backends that support windows so I can remove it

At this point my biggest feedback request is:
* Are we ok changing the config file?
* Is this way of doing logins OK, or would we rather have the login interface part of the main cursive application?