### PR TITLE
Include new build requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ future. Contributions welcome, but please be kind ;)
 * Rust
 * `libpulse-dev` (or `portaudio-dev`, if you want to use the PortAudio backend)
 * `libncurses-dev` and `libssl-dev`
+* `libdbus-1-dev`
 * A Spotify premium account
 * pkg-config
 


### PR DESCRIPTION
It took me a little while to figure out it was `libdbus-1-dev` so noting it in the README