### PR TITLE
Add seeking, shuffle and repeat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ version = "0.11.1"
 default-features = false
 
 [features]
+pulseaudio_backend = ["librespot/pulseaudio-backend"]
 rodio_backend = ["librespot/rodio-backend"]
 portaudio_backend = ["librespot/portaudio-backend"]
 termion_backend = ["cursive/termion-backend"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ tokio-core = "0.1"
 tokio-timer = "0.2"
 unicode-width = "0.1.5"
 dbus = { version = "0.6.4", optional = true }
+rand = "0.6.5"
 
 [dependencies.librespot]
 git = "https://github.com/librespot-org/librespot.git"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -5,7 +5,7 @@ use cursive::event::{Event, Key};
 use cursive::Cursive;
 
 use playlists::{Playlist, Playlists};
-use queue::Queue;
+use queue::{Queue, RepeatSetting};
 use spotify::Spotify;
 use track::Track;
 use ui::layout::Layout;
@@ -84,7 +84,7 @@ impl CommandManager {
                 "next",
                 Vec::new(),
                 Box::new(move |_s, _args| {
-                    queue.next();
+                    queue.next(true);
                     Ok(None)
                 }),
             );
@@ -240,7 +240,7 @@ impl CommandManager {
                     {
                         let queue = queue.clone();
                         s.call_on_id("queue_list", |v: &mut ListView<Track>| {
-                            queue.play(v.get_selected_index());
+                            queue.play(v.get_selected_index(), true);
                         });
                     }
 
@@ -248,8 +248,8 @@ impl CommandManager {
                         let queue = queue.clone();
                         s.call_on_id("list", |v: &mut ListView<Track>| {
                             v.with_selected(Box::new(move |t| {
-                                let index = queue.append_next(t);
-                                queue.play(index);
+                                let index = queue.append_next(vec![t]);
+                                queue.play(index, true);
                             }));
                         });
                     }
@@ -258,11 +258,8 @@ impl CommandManager {
                         let queue = queue.clone();
                         s.call_on_id("list", |v: &mut ListView<Playlist>| {
                             v.with_selected(Box::new(move |pl| {
-                                let indices: Vec<usize> =
-                                    pl.tracks.iter().map(|t| queue.append_next(t)).collect();
-                                if let Some(i) = indices.get(0) {
-                                    queue.play(*i)
-                                }
+                                let index = queue.append_next(pl.tracks.iter().collect());
+                                queue.play(index, true);
                             }));
                         });
                     }
@@ -290,6 +287,57 @@ impl CommandManager {
                         let queue = queue.clone();
                         s.call_on_id("queue_list", |v: &mut ListView<Track>| {
                             queue.remove(v.get_selected_index());
+                        });
+                    }
+
+                    Ok(None)
+                }),
+            );
+        }
+
+        {
+            let queue = queue.clone();
+            self.register(
+                "shuffle",
+                Vec::new(),
+                Box::new(move |_s, args| {
+                    if let Some(arg) = args.get(0) {
+                        queue.set_shuffle(match arg.as_ref() {
+                            "on" => true,
+                            "off" => false,
+                            _ => {
+                                return Err("Unknown shuffle setting.".to_string());
+                            }
+                        });
+                    } else {
+                        queue.set_shuffle(!queue.get_shuffle());
+                    }
+
+                    Ok(None)
+                }),
+            );
+        }
+
+        {
+            let queue = queue.clone();
+            self.register(
+                "repeat",
+                vec!["loop"],
+                Box::new(move |_s, args| {
+                    if let Some(arg) = args.get(0) {
+                        queue.set_repeat(match arg.as_ref() {
+                            "list" | "playlist" | "queue" => RepeatSetting::RepeatPlaylist,
+                            "track" | "once" => RepeatSetting::RepeatTrack,
+                            "none" | "off" => RepeatSetting::None,
+                            _ => {
+                                return Err("Unknown loop setting.".to_string());
+                            }
+                        });
+                    } else {
+                        queue.set_repeat(match queue.get_repeat() {
+                            RepeatSetting::None => RepeatSetting::RepeatPlaylist,
+                            RepeatSetting::RepeatPlaylist => RepeatSetting::RepeatTrack,
+                            RepeatSetting::RepeatTrack => RepeatSetting::None,
                         });
                     }
 
@@ -387,6 +435,8 @@ impl CommandManager {
         kb.insert("/".into(), "search".into());
         kb.insert(".".into(), "seek +500".into());
         kb.insert(",".into(), "seek -500".into());
+        kb.insert("r".into(), "repeat".into());
+        kb.insert("z".into(), "shuffle".into());
 
         kb.insert("F1".into(), "queue".into());
         kb.insert("F2".into(), "search".into());

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -297,6 +297,28 @@ impl CommandManager {
                 }),
             );
         }
+
+        {
+            let spotify = spotify.clone();
+            self.register(
+                "seek",
+                Vec::new(),
+                Box::new(move |_s, args| {
+                    if let Some(arg) = args.get(0) {
+                        match arg.chars().next().unwrap() {
+                            '+' | '-' => {
+                                spotify.seek_relative(arg.parse::<i32>().unwrap_or(0));
+                            },
+                            _ => {
+                                spotify.seek(arg.parse::<u32>().unwrap_or(0));
+                            }
+                        }
+                    }
+
+                    Ok(None)
+                }),
+            );
+        }
     }
 
     fn handle_aliases(&self, name: &String) -> String {
@@ -308,7 +330,7 @@ impl CommandManager {
     }
 
     pub fn handle(&self, s: &mut Cursive, cmd: String) {
-        let components: Vec<String> = cmd.split(' ').map(|s| s.to_string()).collect();
+        let components: Vec<String> = cmd.trim().split(' ').map(|s| s.to_string()).collect();
 
         let result = if let Some(cb) = self.commands.get(&self.handle_aliases(&components[0])) {
             cb(s, components[1..].to_vec())
@@ -363,6 +385,8 @@ impl CommandManager {
         kb.insert("Enter".into(), "play selected".into());
         kb.insert("d".into(), "delete selected".into());
         kb.insert("/".into(), "search".into());
+        kb.insert(".".into(), "seek +500".into());
+        kb.insert(",".into(), "seek -500".into());
 
         kb.insert("F1".into(), "queue".into());
         kb.insert("F2".into(), "search".into());

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ pub struct Config {
     pub password: String,
     pub keybindings: Option<HashMap<String, String>>,
     pub theme: Option<ConfigTheme>,
+    pub use_nerdfont: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -172,6 +172,14 @@ fn main() {
         });
     });
 
+    layout.cmdline.set_on_edit(move |s, cmd, _| {
+        s.call_on_id("main", |v: &mut ui::layout::Layout| {
+            if cmd.len() == 0 {
+                v.clear_cmdline();
+            }
+        });
+    });
+
     {
         let ev = event_manager.clone();
         layout.cmdline.set_on_submit(move |s, cmd| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,8 @@ extern crate log;
 extern crate chrono;
 extern crate fern;
 
+extern crate rand;
+
 use std::process;
 use std::sync::Arc;
 use std::thread;
@@ -122,8 +124,8 @@ fn main() {
 
     let spotify = Arc::new(spotify::Spotify::new(
         event_manager.clone(),
-        cfg.username,
-        cfg.password,
+        cfg.username.clone(),
+        cfg.password.clone(),
     ));
 
     let queue = Arc::new(queue::Queue::new(spotify.clone()));
@@ -154,7 +156,7 @@ fn main() {
 
     let queueview = ui::queue::QueueView::new(queue.clone(), playlists.clone());
 
-    let status = ui::statusbar::StatusBar::new(queue.clone(), spotify.clone());
+    let status = ui::statusbar::StatusBar::new(queue.clone(), spotify.clone(), &cfg);
 
     let mut layout = ui::layout::Layout::new(status, &event_manager, theme)
         .view("search", search.with_id("search"), "Search")
@@ -196,7 +198,7 @@ fn main() {
             match event {
                 Event::Player(state) => {
                     if state == PlayerEvent::FinishedTrack {
-                        queue.next();
+                        queue.next(false);
                     }
                     spotify.update_status(state);
 

--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -35,7 +35,7 @@ fn get_metadata(queue: Arc<Queue>) -> HashMap<String, Variant<Box<RefArg>>> {
     );
     hm.insert(
         "mpris:length".to_string(),
-        Variant(Box::new(track.map(|t| t.duration * 1_000_000).unwrap_or(0))),
+        Variant(Box::new(track.map(|t| t.duration * 1_000).unwrap_or(0))),
     );
     hm.insert(
         "mpris:artUrl".to_string(),

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -146,7 +146,9 @@ impl Queue {
             }
         }
 
-        self.generate_random_order();
+        if self.get_shuffle() {
+            self.generate_random_order();
+        }
     }
 
     pub fn clear(&self) {
@@ -168,7 +170,7 @@ impl Queue {
             self.spotify.update_track();
         }
 
-        if reshuffle {
+        if reshuffle && self.get_shuffle() {
             self.generate_random_order()
         }
     }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -1,11 +1,22 @@
 use std::sync::{Arc, RwLock};
 
+use rand::prelude::*;
+
 use spotify::Spotify;
 use track::Track;
 
+#[derive(Clone, Copy, PartialEq)]
+pub enum RepeatSetting {
+    None,
+    RepeatPlaylist,
+    RepeatTrack,
+}
+
 pub struct Queue {
     pub queue: Arc<RwLock<Vec<Track>>>,
+    random_order: RwLock<Option<Vec<usize>>>,
     current_track: RwLock<Option<usize>>,
+    repeat: RwLock<RepeatSetting>,
     spotify: Arc<Spotify>,
 }
 
@@ -14,15 +25,26 @@ impl Queue {
         Queue {
             queue: Arc::new(RwLock::new(Vec::new())),
             current_track: RwLock::new(None),
+            repeat: RwLock::new(RepeatSetting::None),
+            random_order: RwLock::new(None),
             spotify: spotify,
         }
     }
 
     pub fn next_index(&self) -> Option<usize> {
         match *self.current_track.read().unwrap() {
-            Some(index) => {
-                let next_index = index + 1;
+            Some(mut index) => {
+                let random_order = self.random_order.read().unwrap();
+                if let Some(order) = random_order.as_ref() {
+                    index = order.iter().position(|&i| i == index).unwrap();
+                }
+
+                let mut next_index = index + 1;
                 if next_index < self.queue.read().unwrap().len() {
+                    if let Some(order) = random_order.as_ref() {
+                        next_index = order[next_index];
+                    }
+
                     Some(next_index)
                 } else {
                     None
@@ -34,9 +56,19 @@ impl Queue {
 
     pub fn previous_index(&self) -> Option<usize> {
         match *self.current_track.read().unwrap() {
-            Some(index) => {
+            Some(mut index) => {
+                let random_order = self.random_order.read().unwrap();
+                if let Some(order) = random_order.as_ref() {
+                    index = order.iter().position(|&i| i == index).unwrap();
+                }
+
                 if index > 0 {
-                    Some(index - 1)
+                    let mut next_index = index - 1;
+                    if let Some(order) = random_order.as_ref() {
+                        next_index = order[next_index];
+                    }
+
+                    Some(next_index)
                 } else {
                     None
                 }
@@ -53,21 +85,38 @@ impl Queue {
     }
 
     pub fn append(&self, track: &Track) {
+        let mut random_order = self.random_order.write().unwrap();
+        if let Some(order) = random_order.as_mut() {
+            let index = order.len() - 1;
+            order.push(index);
+        }
+
         let mut q = self.queue.write().unwrap();
         q.push(track.clone());
     }
 
-    pub fn append_next(&self, track: &Track) -> usize {
-        let next = self.next_index();
+    pub fn append_next(&self, tracks: Vec<&Track>) -> usize {
         let mut q = self.queue.write().unwrap();
 
-        if let Some(next_index) = next {
-            q.insert(next_index, track.clone());
-            next_index
-        } else {
-            q.push(track.clone());
-            q.len() - 1
+        {
+            let mut random_order = self.random_order.write().unwrap();
+            if let Some(order) = random_order.as_mut() {
+                order.extend((q.len() - 1)..(q.len() + tracks.len()));
+            }
         }
+
+        let first = match *self.current_track.read().unwrap() {
+            Some(index) => index + 1,
+            None => q.len()
+        };
+
+        let mut i = first;
+        for track in tracks {
+            q.insert(i, track.clone());
+            i += 1;
+        }
+
+        first
     }
 
     pub fn remove(&self, index: usize) {
@@ -90,12 +139,14 @@ impl Queue {
         let current = *self.current_track.read().unwrap();
         if let Some(current_track) = current {
             if index == current_track {
-                self.play(index);
+                self.play(index, false);
             } else if index < current_track {
                 let mut current = self.current_track.write().unwrap();
                 current.replace(current_track - 1);
             }
         }
+
+        self.generate_random_order();
     }
 
     pub fn clear(&self) {
@@ -103,15 +154,22 @@ impl Queue {
 
         let mut q = self.queue.write().unwrap();
         q.clear();
+
+        let mut random_order = self.random_order.write().unwrap();
+        random_order.as_mut().map(|o| o.clear());
     }
 
-    pub fn play(&self, index: usize) {
+    pub fn play(&self, index: usize, reshuffle: bool) {
         if let Some(track) = &self.queue.read().unwrap().get(index) {
             self.spotify.load(&track);
             let mut current = self.current_track.write().unwrap();
             current.replace(index);
             self.spotify.play();
             self.spotify.update_track();
+        }
+
+        if reshuffle {
+            self.generate_random_order()
         }
     }
 
@@ -125,9 +183,20 @@ impl Queue {
         self.spotify.stop();
     }
 
-    pub fn next(&self) {
-        if let Some(index) = self.next_index() {
-            self.play(index);
+    pub fn next(&self, manual: bool) {
+        let q = self.queue.read().unwrap();
+        let current = *self.current_track.read().unwrap();
+        let repeat = *self.repeat.read().unwrap();
+
+        if repeat == RepeatSetting::RepeatTrack && !manual {
+            if let Some(index) = current {
+                self.play(index, false);
+            }
+        } else if let Some(index) = self.next_index() {
+            self.play(index, false);
+        } else if repeat == RepeatSetting::RepeatPlaylist && q.len() > 0 {
+            let random_order = self.random_order.read().unwrap();
+            self.play(random_order.as_ref().map(|o| o[0]).unwrap_or(0), false);
         } else {
             self.spotify.stop();
         }
@@ -135,9 +204,51 @@ impl Queue {
 
     pub fn previous(&self) {
         if let Some(index) = self.previous_index() {
-            self.play(index);
+            self.play(index, false);
         } else {
             self.spotify.stop();
+        }
+    }
+
+    pub fn get_repeat(&self) -> RepeatSetting {
+        let repeat = self.repeat.read().unwrap();
+        *repeat
+    }
+
+    pub fn set_repeat(&self, new: RepeatSetting) {
+        let mut repeat = self.repeat.write().unwrap();
+        *repeat = new;
+    }
+
+    pub fn get_shuffle(&self) -> bool {
+        let random_order = self.random_order.read().unwrap();
+        random_order.is_some()
+    }
+
+    fn generate_random_order(&self) {
+        let q = self.queue.read().unwrap();
+        let mut order: Vec<usize> = Vec::with_capacity(q.len());
+        let mut random: Vec<usize> = (0..q.len()).collect();
+
+        if let Some(current) = *self.current_track.read().unwrap() {
+            order.push(current);
+            random.remove(current);
+        }
+
+        let mut rng = rand::thread_rng();
+        random.shuffle(&mut rng);
+        order.extend(random);
+
+        let mut random_order = self.random_order.write().unwrap();
+        *random_order = Some(order);
+    }
+
+    pub fn set_shuffle(&self, new: bool) {
+        if new {
+            self.generate_random_order();
+        } else {
+            let mut random_order = self.random_order.write().unwrap();
+            *random_order = None;
         }
     }
 }

--- a/src/track.rs
+++ b/src/track.rs
@@ -44,7 +44,7 @@ impl Track {
             title: track.name.clone(),
             track_number: track.track_number,
             disc_number: track.disc_number,
-            duration: track.duration_ms / 1000,
+            duration: track.duration_ms,
             artists: artists,
             album: track.album.name.clone(),
             album_artists: album_artists,
@@ -54,8 +54,8 @@ impl Track {
     }
 
     pub fn duration_str(&self) -> String {
-        let minutes = self.duration / 60;
-        let seconds = self.duration % 60;
+        let minutes = self.duration / 60_000;
+        let seconds = (self.duration / 1000) % 60;
         format!("{:02}:{:02}", minutes, seconds)
     }
 }

--- a/src/ui/statusbar.rs
+++ b/src/ui/statusbar.rs
@@ -8,21 +8,24 @@ use cursive::vec::Vec2;
 use cursive::Printer;
 use unicode_width::UnicodeWidthStr;
 
-use queue::Queue;
+use config::Config;
+use queue::{Queue, RepeatSetting};
 use spotify::{PlayerEvent, Spotify};
 
 pub struct StatusBar {
     queue: Arc<Queue>,
     spotify: Arc<Spotify>,
     last_size: Vec2,
+    use_nerdfont: bool,
 }
 
 impl StatusBar {
-    pub fn new(queue: Arc<Queue>, spotify: Arc<Spotify>) -> StatusBar {
+    pub fn new(queue: Arc<Queue>, spotify: Arc<Spotify>, cfg: &Config) -> StatusBar {
         StatusBar {
             queue: queue,
             spotify: spotify,
             last_size: Vec2::new(0, 0),
+            use_nerdfont: cfg.use_nerdfont.unwrap_or(false)
         }
     }
 }
@@ -53,16 +56,44 @@ impl View for StatusBar {
             );
         });
 
-        let state_icon = match self.spotify.get_current_status() {
-            PlayerEvent::Playing => "▶ ",
-            PlayerEvent::Paused => "▮▮",
-            PlayerEvent::Stopped | PlayerEvent::FinishedTrack => "◼ ",
+        let state_icon = if self.use_nerdfont {
+            match self.spotify.get_current_status() {
+                PlayerEvent::Playing => "\u{f909} ",
+                PlayerEvent::Paused => "\u{f8e3} ",
+                PlayerEvent::Stopped | PlayerEvent::FinishedTrack => "\u{f9da} ",
+            }
+        } else {
+            match self.spotify.get_current_status() {
+                PlayerEvent::Playing => "▶ ",
+                PlayerEvent::Paused => "▮▮",
+                PlayerEvent::Stopped | PlayerEvent::FinishedTrack => "◼ ",
+            }
         }
         .to_string();
 
         printer.with_color(style, |printer| {
-            printer.print((0, 1), &state_icon);
+            printer.print((1, 1), &state_icon);
         });
+
+        let repeat = if self.use_nerdfont {
+            match self.queue.get_repeat() {
+                RepeatSetting::None => "",
+                RepeatSetting::RepeatPlaylist => "\u{f955} ",
+                RepeatSetting::RepeatTrack => "\u{f957} ",
+            }
+        } else {
+            match self.queue.get_repeat() {
+                RepeatSetting::None => "",
+                RepeatSetting::RepeatPlaylist => "[R] ",
+                RepeatSetting::RepeatTrack => "[R1] ",
+            }
+        }.to_string();
+
+        let shuffle = if self.use_nerdfont {
+            if self.queue.get_shuffle() { "\u{f99c} " } else { "" }
+        } else {
+            if self.queue.get_shuffle() { "[Z] " } else { "" }
+        }.to_string();
 
         if let Some(ref t) = self.queue.get_current() {
             let elapsed = self.spotify.get_current_progress();
@@ -74,12 +105,12 @@ impl View for StatusBar {
                 elapsed.as_secs() % 60
             );
 
-            let duration = format!("{} / {} ", formatted_elapsed, t.duration_str());
-            let offset = HAlign::Right.get_offset(duration.width(), printer.size.x);
+            let right = repeat + &shuffle + &format!("{} / {} ", formatted_elapsed, t.duration_str());
+            let offset = HAlign::Right.get_offset(right.width(), printer.size.x);
 
             printer.with_color(style, |printer| {
                 printer.print((4, 1), &t.to_string());
-                printer.print((offset, 1), &duration);
+                printer.print((offset, 1), &right);
             });
 
             printer.with_color(style_bar, |printer| {
@@ -89,6 +120,13 @@ impl View for StatusBar {
                 printer.print((0, 0), &format!("{}{}", "=".repeat(duration_width), ">"));
             });
         } else {
+            let right = repeat + &shuffle;
+            let offset = HAlign::Right.get_offset(right.width(), printer.size.x);
+
+            printer.with_color(style, |printer| {
+                printer.print((offset, 1), &right);
+            });
+
             printer.with_color(style_bar, |printer| {
                 printer.print((0, 0), &"—".repeat(printer.size.x));
             });


### PR DESCRIPTION
Adds seeking (both with commands/keys and mouse events in the progress bar), shuffle and repeat. All in one PR mostly because I wanted seeking to test it. Let me know if you want me to split these up into multiple PRs.

Since there are no proper Unicode characters for repeat/shuffle, I added a config setting to use NerdFont characters for shuffle, repeat and playback status:

![](https://i.imgur.com/dv4cL6T.png)

I also reintroduced the PulseAudio backend since Rodio didn't work on my system (other people with similar setups seem to have issues as well: https://github.com/tomaka/rodio/issues/173). I was working on a build script to set a sensible backend at compile time, but I still have some kinks to work out there.