### PR TITLE
Refactor command handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -133,8 +133,6 @@ fn main() {
     #[cfg(feature = "mpris")]
     let mpris_manager = Arc::new(mpris::MprisManager::new(spotify.clone(), queue.clone()));
 
-    let search = ui::search::SearchView::new(spotify.clone(), queue.clone());
-
     let playlists = Arc::new(Playlists::new(&event_manager, &spotify));
 
     {
@@ -151,6 +149,14 @@ fn main() {
             playlists.save_cache();
         });
     }
+
+    let mut cmd_manager = CommandManager::new();
+    cmd_manager.register_all(spotify.clone(), queue.clone(), playlists.clone());
+
+    let cmd_manager = Arc::new(cmd_manager);
+    CommandManager::register_keybindings(cmd_manager.clone(), &mut cursive, cfg.keybindings.clone());
+
+    let search = ui::search::SearchView::new(spotify.clone(), queue.clone());
 
     let playlistsview = ui::playlists::PlaylistView::new(&playlists, queue.clone());
 
@@ -191,12 +197,6 @@ fn main() {
     }
 
     cursive.add_fullscreen_layer(layout.with_id("main"));
-
-    let mut cmd_manager = CommandManager::new();
-    cmd_manager.register_all(spotify.clone(), queue.clone(), playlists.clone());
-
-    let cmd_manager = Arc::new(cmd_manager);
-    CommandManager::register_keybindings(cmd_manager.clone(), &mut cursive, cfg.keybindings);
 
     // cursive event loop
     while cursive.is_running() {

--- a/src/playlists.rs
+++ b/src/playlists.rs
@@ -48,6 +48,17 @@ impl ListItem for Playlist {
     fn display_right(&self) -> String {
         format!("{} tracks", self.tracks.len())
     }
+
+    fn play(&self, queue: Arc<Queue>) {
+        let index = queue.append_next(self.tracks.iter().collect());
+        queue.play(index, true);
+    }
+
+    fn queue(&self, queue: Arc<Queue>) {
+        for track in self.tracks.iter() {
+            queue.append(track);
+        }
+    }
 }
 
 impl Playlists {

--- a/src/track.rs
+++ b/src/track.rs
@@ -91,4 +91,13 @@ impl ListItem for Track {
     fn display_right(&self) -> String {
         self.duration_str()
     }
+
+    fn play(&self, queue: Arc<Queue>) {
+        let index = queue.append_next(vec![self]);
+        queue.play(index, true);
+    }
+
+    fn queue(&self, queue: Arc<Queue>) {
+        queue.append(self);
+    }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,9 +1,48 @@
 use std::sync::Arc;
 
+use cursive::view::{View, ViewWrapper};
+use cursive::views::IdView;
+use cursive::Cursive;
+
+use commands::CommandResult;
 use queue::Queue;
 
 pub trait ListItem {
     fn is_playing(&self, queue: Arc<Queue>) -> bool;
     fn display_left(&self) -> String;
     fn display_right(&self) -> String;
+    fn play(&self, queue: Arc<Queue>);
+    fn queue(&self, queue: Arc<Queue>);
+}
+
+pub trait ViewExt: View {
+    fn on_command(&mut self,
+        _s: &mut Cursive,
+        _cmd: &String,
+        _args: &[String]
+    ) -> Result<CommandResult, String> {
+        Ok(CommandResult::Ignored)
+    }
+}
+
+impl<V: ViewExt> ViewExt for IdView<V> {
+    fn on_command(&mut self,
+        s: &mut Cursive,
+        cmd: &String,
+        args: &[String]
+    ) -> Result<CommandResult, String> {
+        self.with_view_mut(move |v| {
+            v.on_command(s, cmd, args)
+        }).unwrap()
+    }
+}
+
+pub trait IntoBoxedViewExt {
+    fn as_boxed_view_ext(self) -> Box<dyn ViewExt>;
+}
+
+impl<V: ViewExt> IntoBoxedViewExt for V {
+    fn as_boxed_view_ext(self) -> Box<dyn ViewExt> {
+        Box::new(self)
+    }
 }

--- a/src/ui/playlists.rs
+++ b/src/ui/playlists.rs
@@ -5,8 +5,10 @@ use cursive::view::ViewWrapper;
 use cursive::views::{Dialog, IdView};
 use cursive::Cursive;
 
+use commands::CommandResult;
 use playlists::{Playlist, Playlists};
 use queue::Queue;
+use traits::ViewExt;
 use ui::listview::ListView;
 use ui::modal::Modal;
 
@@ -51,4 +53,22 @@ impl PlaylistView {
 
 impl ViewWrapper for PlaylistView {
     wrap_impl!(self.list: IdView<ListView<Playlist>>);
+}
+
+impl ViewExt for PlaylistView {
+    fn on_command(&mut self,
+        s: &mut Cursive,
+        cmd: &String,
+        args: &[String]
+    ) -> Result<CommandResult, String> {
+        if cmd == "delete" {
+            if let Some(dialog) = self.delete_dialog() {
+                s.add_layer(dialog);
+            }
+            return Ok(CommandResult::Consumed(None));
+        }
+
+        self.list.on_command(s, cmd, args)
+
+    }
 }

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -1,34 +1,34 @@
 use cursive::event::{Callback, Event, EventResult};
 use cursive::traits::{Boxable, Identifiable, View};
 use cursive::view::ViewWrapper;
-use cursive::views::{Dialog, EditView, IdView, ScrollView, SelectView};
+use cursive::views::{Dialog, EditView, ScrollView, SelectView};
 use cursive::Cursive;
 
 use std::sync::Arc;
 
+use commands::CommandResult;
 use playlists::Playlists;
 use queue::Queue;
 use track::Track;
+use traits::ViewExt;
 use ui::listview::ListView;
 use ui::modal::Modal;
 
 pub struct QueueView {
-    list: IdView<ListView<Track>>,
+    list: ListView<Track>,
     playlists: Arc<Playlists>,
+    queue: Arc<Queue>,
 }
 
-pub const LIST_ID: &str = "queue_list";
 impl QueueView {
     pub fn new(queue: Arc<Queue>, playlists: Arc<Playlists>) -> QueueView {
-        let list = ListView::new(queue.queue.clone(), queue.clone()).with_id(LIST_ID);
+        let list = ListView::new(queue.queue.clone(), queue.clone());
 
-        QueueView { list, playlists }
+        QueueView { list, playlists, queue }
     }
 
-    fn save_dialog_cb(s: &mut Cursive, playlists: Arc<Playlists>, id: Option<String>) {
-        let tracks = s
-            .call_on_id(LIST_ID, |view: &mut ListView<_>| view.content().clone())
-            .unwrap();
+    fn save_dialog_cb(s: &mut Cursive, queue: Arc<Queue>, playlists: Arc<Playlists>, id: Option<String>) {
+        let tracks = queue.queue.read().unwrap().clone();
         match id {
             Some(id) => {
                 playlists.overwrite_playlist(&id, &tracks);
@@ -53,7 +53,7 @@ impl QueueView {
         }
     }
 
-    fn save_dialog(playlists: Arc<Playlists>) -> Modal<Dialog> {
+    fn save_dialog(queue: Arc<Queue>, playlists: Arc<Playlists>) -> Modal<Dialog> {
         let mut list_select: SelectView<Option<String>> = SelectView::new().autojump();
         list_select.add_item("[Create new]", None);
 
@@ -62,7 +62,7 @@ impl QueueView {
         }
 
         list_select.set_on_submit(move |s, selected| {
-            Self::save_dialog_cb(s, playlists.clone(), selected.clone())
+            Self::save_dialog_cb(s, queue.clone(), playlists.clone(), selected.clone())
         });
 
         let dialog = Dialog::new()
@@ -75,20 +75,47 @@ impl QueueView {
 }
 
 impl ViewWrapper for QueueView {
-    wrap_impl!(self.list: IdView<ListView<Track>>);
+    wrap_impl!(self.list: ListView<Track>);
 
     fn wrap_on_event(&mut self, ch: Event) -> EventResult {
         match ch {
             Event::Char('s') => {
                 debug!("save list");
+                let queue = self.queue.clone();
                 let playlists = self.playlists.clone();
                 let cb = move |s: &mut Cursive| {
-                    let dialog = Self::save_dialog(playlists.clone());
+                    let dialog = Self::save_dialog(queue.clone(), playlists.clone());
                     s.add_layer(dialog)
                 };
                 EventResult::Consumed(Some(Callback::from_fn(cb)))
             }
             _ => self.list.on_event(ch),
         }
+    }
+}
+
+impl ViewExt for QueueView {
+    fn on_command(&mut self,
+        s: &mut Cursive,
+        cmd: &String,
+        args: &[String]
+    ) -> Result<CommandResult, String> {
+        if cmd == "play" {
+            self.queue.play(self.list.get_selected_index(), true);
+            return Ok(CommandResult::Consumed(None));
+        }
+
+        if cmd == "queue" {
+            return Ok(CommandResult::Ignored);
+        }
+
+        if cmd == "delete" {
+            self.queue.remove(self.list.get_selected_index());
+            return Ok(CommandResult::Consumed(None));
+        }
+
+        self.with_view_mut(move |v| {
+            v.on_command(s, cmd, args)
+        }).unwrap()
     }
 }


### PR DESCRIPTION
I refactored the command handling to use a system similar to Cursive's event handling. Commands are sent to views recursively via a new trait before they are handled globally. This implements the original search bar focus behaviour with rebindable keys and makes command handling for currently selected items a bit easier. The default play/queue behaviour is implemented by `ListView` and can be prevented if necessary (e.g. in `QueueView`). This should scale better for more types (artists, albums) and list views.

I also changed the main focus keybindings (F1, F2, F3) to use a seperate `focus` command to avoid unnecessarily polluting the command namespace, so the "x selected" stuff isn't necessary anymore.