### PR TITLE
Only allow owner read/write to credentials.toml

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -115,11 +115,21 @@ fn main() {
 
     let credentials: Credentials = {
         let path = config::config_path("credentials.toml");
-        ::config::load_or_generate_default(path, authentication::create_credentials, true)
+        let creds =
+            ::config::load_or_generate_default(&path, authentication::create_credentials, true)
+                .unwrap_or_else(|e| {
+                    eprintln!("{}", e);
+                    process::exit(1);
+                });
+
+        #[cfg(target_family = "unix")]
+        std::fs::set_permissions(path, std::os::unix::fs::PermissionsExt::from_mode(0o600))
             .unwrap_or_else(|e| {
                 eprintln!("{}", e);
                 process::exit(1);
-            })
+            });
+
+        creds
     };
 
     let theme = theme::load(&cfg);


### PR DESCRIPTION
This PR sets the file mode bits to 600 for credentials.toml. 

The `from_mode` (https://doc.rust-lang.org/std/os/unix/fs/trait.PermissionsExt.html#tymethod.from_mode) function is only available on Unix systems and since I don't have access to a Windows box I decided to set the target_family to unix.

Thanks for an awesome project!