### PR TITLE
Add support for Spotify URI searches

### DIFF
--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -14,11 +14,13 @@ use librespot::playback::player::Player;
 use rspotify::spotify::client::ApiError;
 use rspotify::spotify::client::Spotify as SpotifyAPI;
 use rspotify::spotify::model::album::{FullAlbum, SimplifiedAlbum};
+use rspotify::spotify::model::artist::FullArtist;
 use rspotify::spotify::model::page::Page;
-use rspotify::spotify::model::playlist::{PlaylistTrack, SimplifiedPlaylist};
+use rspotify::spotify::model::playlist::{FullPlaylist, PlaylistTrack, SimplifiedPlaylist};
 use rspotify::spotify::model::search::{
     SearchAlbums, SearchArtists, SearchPlaylists, SearchTracks,
 };
+use rspotify::spotify::model::track::FullTrack;
 
 use failure::Error;
 
@@ -444,6 +446,22 @@ impl Spotify {
             api.user_playlist_create(&self.user, name, public, description.clone())
         });
         result.map(|r| r.id)
+    }
+
+    pub fn album(&self, album_id: &str) -> Option<FullAlbum> {
+        self.api_with_retry(|api| api.album(album_id))
+    }
+
+    pub fn artist(&self, artist_id: &str) -> Option<FullArtist> {
+        self.api_with_retry(|api| api.artist(artist_id))
+    }
+
+    pub fn playlist(&self, playlist_id: &str) -> Option<FullPlaylist> {
+        self.api_with_retry(|api| api.playlist(playlist_id, None, None))
+    }
+
+    pub fn track(&self, track_id: &str) -> Option<FullTrack> {
+        self.api_with_retry(|api| api.track(track_id))
     }
 
     pub fn search_track(&self, query: &str, limit: u32, offset: u32) -> Option<SearchTracks> {

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -576,4 +576,20 @@ impl Spotify {
         let new = (progress.as_secs() * 1000) as i32 + progress.subsec_millis() as i32 + delta;
         self.seek(std::cmp::max(0, new) as u32);
     }
+
+    pub fn is_album(s: &str) -> bool {
+        s.starts_with("spotify:album:")
+    }
+
+    pub fn is_artist(s: &str) -> bool {
+        s.starts_with("spotify:artist:")
+    }
+
+    pub fn is_track(s: &str) -> bool {
+        s.starts_with("spotify:track:")
+    }
+
+    pub fn is_playlist(s: &str) -> bool {
+        s.starts_with("spotify:user:") && s.contains(":playlist:")
+    }
 }

--- a/src/ui/playlists.rs
+++ b/src/ui/playlists.rs
@@ -35,7 +35,7 @@ impl PlaylistView {
 
         if let Some(playlist) = current {
             let playlists = self.playlists.clone();
-            let id = playlist.meta.id.clone();
+            let id = playlist.id.clone();
             let dialog = Dialog::text("Are you sure you want to delete this playlist?")
                 .padding((1, 1, 1, 0))
                 .title("Delete playlist")

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -68,7 +68,7 @@ impl QueueView {
         list_select.add_item("[Create new]", None);
 
         for list in playlists.items().iter() {
-            list_select.add_item(list.meta.name.clone(), Some(list.meta.id.clone()));
+            list_select.add_item(list.name.clone(), Some(list.id.clone()));
         }
 
         list_select.set_on_submit(move |s, selected| {

--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -129,7 +129,7 @@ impl SearchView {
                 .playlists
                 .items
                 .iter()
-                .map(|sp| Playlists::process_playlist(sp, &&spotify))
+                .map(|sp| Playlists::process_simplified_playlist(sp, &&spotify))
                 .collect();
             let mut r = playlists.write().unwrap();
             *r = pls;

--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -182,6 +182,19 @@ impl SearchView {
         let is_track = Spotify::is_track(&query);
         let is_spotify_uri = is_album || is_artist || is_playlist || is_track;
 
+        // Set the active tab if the query is either one of the following
+        // cases.
+        let mut tab_idx = 0;
+        if is_album {
+            tab_idx = 1;
+        } else if is_artist {
+            tab_idx = 2;
+        } else if is_playlist {
+            tab_idx = 3;
+        }
+        let mut tab_view = self.list.get_mut();
+        tab_view.move_focus_to(tab_idx);
+
         self.edit_focused = false;
 
         {


### PR DESCRIPTION
With this PR it's now possible to enter Spotify URIs in the search box.

I had to refactor the `process_playlist` function since it expected a `SimplifiedPlaylist` object to be passed and the method that fetches a specific playlist returns it as a `FullPlaylist`.

The refactoring lead me to store the specific values that was used from the playlist on the internal `Playlist` struct instead of the whole object that was return by the Spotify API.

We are only using `id`, `name` and `snapshot_id` from the playlist object, so I think that this should be an OK solution.