### PR TITLE
Add ALSA backend and fix typo in README.md

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ default-features = false
 git = "https://github.com/overdrivenpotato/winapi-rs"
 
 [features]
+alsa_backend = ["librespot/alsa-backend"]
 pulseaudio_backend = ["librespot/pulseaudio-backend"]
 rodio_backend = ["librespot/rodio-backend"]
 portaudio_backend = ["librespot/portaudio-backend"]

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ https://github.com/hrkfdn/ncspot/pull/40.
 
 ## Audio backends
 
-By default ncspot is built using the Rudio backend.  To make it use the
+By default ncspot is built using the Rodio backend.  To make it use the
 PortAudio backend (e.g. *BSD), you need to recompile ncspot with the
 `portaudio_backend` feature:
 


### PR DESCRIPTION
ncspot consumes ~40 % cpu when I use the rodio backend, when I switch to alsa it uses ~0-1% cpu instead.

The ncspot thread that is responsible for the 40 % cpu usage is the audio backend (playback) thread.

With rodio it consumes 40 % even though a song is not playing, but with alsa it just consumes the 40 % cpu during playback. So I prefer to compile it using the alsa backend so my cpu can rest a little when I'm not listening to anything :-)

This occurs on my Carbon X1 6th gen laptop with a Linux 4.15.0-47-generic kernel.