### PR TITLE
Various Changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ rand = "0.6.5"
 webbrowser = "0.5"
 
 [dependencies.rspotify]
-git = "https://github.com/samrayleung/rspotify"
-rev = "9d9cf7c"
+git = "https://github.com/KoffeinFlummi/rspotify"
+rev = "9d6c544"
 
 [dependencies.librespot]
 git = "https://github.com/librespot-org/librespot.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ rand = "0.6.5"
 webbrowser = "0.5"
 
 [dependencies.rspotify]
-git = "https://github.com/KoffeinFlummi/rspotify"
-rev = "9d6c544"
+git = "https://github.com/samrayleung/rspotify"
+rev = "8f8dc17"
 
 [dependencies.librespot]
 git = "https://github.com/librespot-org/librespot.git"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use cursive::event::{Event, Key};
 use cursive::views::ViewRef;
@@ -85,10 +86,15 @@ impl CommandManager {
 
         {
             let queue = queue.clone();
+            let spotify = spotify.clone();
             self.register_command(
                 "previous",
                 Some(Box::new(move |_s, _args| {
-                    queue.previous();
+                    if spotify.get_current_progress() < Duration::from_secs(5) {
+                        queue.previous();
+                    } else {
+                        spotify.seek(0);
+                    }
                     Ok(None)
                 })),
             );

--- a/src/library.rs
+++ b/src/library.rs
@@ -111,6 +111,8 @@ impl Library {
 
                 let mut is_done = library.is_done.write().unwrap();
                 *is_done = true;
+
+                library.ev.trigger();
             });
         }
 

--- a/src/library.rs
+++ b/src/library.rs
@@ -236,7 +236,8 @@ impl Library {
 
                 if self.needs_download(remote) {
                     info!("updating playlist {}", remote.name);
-                    let playlist = Playlist::from_simplified_playlist(remote, &self.spotify);
+                    let mut playlist: Playlist = remote.into();
+                    playlist.load_tracks(self.spotify.clone());
                     self.append_or_update(&playlist);
                     // trigger redraw
                     self.ev.trigger();
@@ -722,6 +723,9 @@ impl Library {
         {
             return;
         }
+
+        let mut playlist = playlist.clone();
+        playlist.load_tracks(self.spotify.clone());
 
         {
             let mut store = self.playlists.write().unwrap();

--- a/src/library.rs
+++ b/src/library.rs
@@ -29,6 +29,7 @@ pub struct Library {
     pub artists: Arc<RwLock<Vec<Artist>>>,
     pub playlists: Arc<RwLock<Vec<Playlist>>>,
     is_done: Arc<RwLock<bool>>,
+    user_id: Option<String>,
     ev: EventManager,
     spotify: Arc<Spotify>,
     pub use_nerdfont: bool,
@@ -36,12 +37,15 @@ pub struct Library {
 
 impl Library {
     pub fn new(ev: &EventManager, spotify: Arc<Spotify>, use_nerdfont: bool) -> Self {
+        let user_id = spotify.current_user().map(|u| u.id);
+
         let library = Self {
             tracks: Arc::new(RwLock::new(Vec::new())),
             albums: Arc::new(RwLock::new(Vec::new())),
             artists: Arc::new(RwLock::new(Vec::new())),
             playlists: Arc::new(RwLock::new(Vec::new())),
             is_done: Arc::new(RwLock::new(false)),
+            user_id,
             ev: ev.clone(),
             spotify,
             use_nerdfont,
@@ -697,6 +701,13 @@ impl Library {
 
         let playlists = self.playlists.read().unwrap();
         playlists.iter().any(|p| p.id == playlist.id)
+    }
+
+    pub fn is_followed_playlist(&self, playlist: &Playlist) -> bool {
+        self.user_id
+            .as_ref()
+            .map(|id| id != &playlist.owner_id)
+            .unwrap_or(false)
     }
 
     pub fn follow_playlist(&self, playlist: &Playlist) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,7 +185,7 @@ fn main() {
 
     let status = ui::statusbar::StatusBar::new(
         queue.clone(),
-        spotify.clone(),
+        library.clone(),
         cfg.use_nerdfont.unwrap_or(false),
     );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -194,8 +194,8 @@ fn main() {
         .view("library", libraryview.with_id("library"), "Library")
         .view("queue", queueview, "Queue");
 
-    // initial view is queue
-    layout.set_view("queue");
+    // initial view is library
+    layout.set_view("library");
 
     cursive.add_global_callback(':', move |s| {
         s.call_on_id("main", |v: &mut ui::layout::Layout| {

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -1,8 +1,11 @@
 use std::iter::Iterator;
 use std::sync::Arc;
 
+use rspotify::spotify::model::playlist::{FullPlaylist, SimplifiedPlaylist};
+
 use library::Library;
 use queue::Queue;
+use spotify::Spotify;
 use track::Track;
 use traits::{IntoBoxedViewExt, ListItem, ViewExt};
 use ui::playlist::PlaylistView;
@@ -14,6 +17,67 @@ pub struct Playlist {
     pub owner_id: String,
     pub snapshot_id: String,
     pub tracks: Vec<Track>,
+}
+
+impl Playlist {
+    pub fn from_simplified_playlist(list: &SimplifiedPlaylist, spotify: &Spotify) -> Playlist {
+        Self::_process_playlist(
+            list.id.clone(),
+            list.name.clone(),
+            list.owner.id.clone(),
+            list.snapshot_id.clone(),
+            spotify,
+        )
+    }
+
+    pub fn from_full_playlist(list: &FullPlaylist, spotify: &Spotify) -> Playlist {
+        Self::_process_playlist(
+            list.id.clone(),
+            list.name.clone(),
+            list.owner.id.clone(),
+            list.snapshot_id.clone(),
+            spotify,
+        )
+    }
+
+    fn _process_playlist(
+        id: String,
+        name: String,
+        owner_id: String,
+        snapshot_id: String,
+        spotify: &Spotify,
+    ) -> Playlist {
+        let mut collected_tracks = Vec::new();
+
+        let mut tracks_result = spotify.user_playlist_tracks(&id, 100, 0);
+        while let Some(ref tracks) = tracks_result.clone() {
+            for listtrack in &tracks.items {
+                collected_tracks.push((&listtrack.track).into());
+            }
+            debug!("got {} tracks", tracks.items.len());
+
+            // load next batch if necessary
+            tracks_result = match tracks.next {
+                Some(_) => {
+                    debug!("requesting tracks again..");
+                    spotify.user_playlist_tracks(
+                        &id,
+                        100,
+                        tracks.offset + tracks.items.len() as u32,
+                    )
+                }
+                None => None,
+            }
+        }
+
+        Playlist {
+            id,
+            name,
+            owner_id,
+            snapshot_id,
+            tracks: collected_tracks,
+        }
+    }
 }
 
 impl ListItem for Playlist {

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -122,7 +122,11 @@ impl ListItem for Playlist {
             ""
         };
 
-        let num_tracks = self.tracks.as_ref().map(|t| t.len()).unwrap_or(self.num_tracks);
+        let num_tracks = self
+            .tracks
+            .as_ref()
+            .map(|t| t.len())
+            .unwrap_or(self.num_tracks);
 
         format!("{}{:>4} tracks", followed, num_tracks)
     }

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -104,7 +104,7 @@ impl ListItem for Playlist {
     }
 
     fn display_right(&self, library: Arc<Library>) -> String {
-        let saved = if library.is_saved_playlist(self) {
+        let followed = if library.is_followed_playlist(self) {
             if library.use_nerdfont {
                 "\u{f62b} "
             } else {
@@ -113,7 +113,7 @@ impl ListItem for Playlist {
         } else {
             ""
         };
-        format!("{}{:>3} tracks", saved, self.tracks.len())
+        format!("{}{:>3} tracks", followed, self.tracks.len())
     }
 
     fn play(&mut self, queue: Arc<Queue>) {

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -128,6 +128,11 @@ impl ListItem for Playlist {
     }
 
     fn toggle_saved(&mut self, library: Arc<Library>) {
+        // Don't allow users to unsave their own playlists with one keypress
+        if !library.is_followed_playlist(self) {
+            return;
+        }
+
         if library.is_saved_playlist(self) {
             library.delete_playlist(&self.id);
         } else {

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -21,6 +21,7 @@ use rspotify::spotify::model::search::{
     SearchAlbums, SearchArtists, SearchPlaylists, SearchTracks,
 };
 use rspotify::spotify::model::track::{FullTrack, SavedTrack};
+use rspotify::spotify::model::user::PrivateUser;
 
 use failure::Error;
 
@@ -588,6 +589,10 @@ impl Spotify {
     pub fn artist_related_artists(&self, id: String) -> Option<Vec<Artist>> {
         self.api_with_retry(|api| api.artist_related_artists(&id))
             .map(|fa| fa.artists.iter().map(|a| a.into()).collect())
+    }
+
+    pub fn current_user(&self) -> Option<PrivateUser> {
+        self.api_with_retry(|api| api.current_user())
     }
 
     pub fn load(&self, track: &Track) {

--- a/src/ui/listview.rs
+++ b/src/ui/listview.rs
@@ -283,6 +283,8 @@ impl<I: ListItem + Clone> ViewExt for ListView<I> {
         args: &[String],
     ) -> Result<CommandResult, String> {
         if cmd == "play" {
+            self.queue.clear();
+
             if !self.attempt_play_all_tracks() {
                 let mut content = self.content.write().unwrap();
                 if let Some(item) = content.get_mut(self.selected) {

--- a/src/ui/playlist.rs
+++ b/src/ui/playlist.rs
@@ -28,11 +28,7 @@ impl PlaylistView {
             Vec::new()
         };
 
-        let list = ListView::new(
-            Arc::new(RwLock::new(tracks)),
-            queue,
-            library,
-        );
+        let list = ListView::new(Arc::new(RwLock::new(tracks)), queue, library);
 
         Self { playlist, list }
     }

--- a/src/ui/playlist.rs
+++ b/src/ui/playlist.rs
@@ -18,9 +18,18 @@ pub struct PlaylistView {
 
 impl PlaylistView {
     pub fn new(queue: Arc<Queue>, library: Arc<Library>, playlist: &Playlist) -> Self {
-        let playlist = playlist.clone();
+        let mut playlist = playlist.clone();
+
+        playlist.load_tracks(queue.get_spotify());
+
+        let tracks = if let Some(t) = playlist.tracks.as_ref() {
+            t.clone()
+        } else {
+            Vec::new()
+        };
+
         let list = ListView::new(
-            Arc::new(RwLock::new(playlist.tracks.clone())),
+            Arc::new(RwLock::new(tracks)),
             queue,
             library,
         );

--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -225,7 +225,7 @@ impl SearchView {
         _append: bool,
     ) -> u32 {
         if let Some(results) = spotify.playlist(&query) {
-            let pls = vec![Library::process_full_playlist(&results, &&spotify)];
+            let pls = vec![Playlist::from_full_playlist(&results, &&spotify)];
             let mut r = playlists.write().unwrap();
             *r = pls;
             return 1;
@@ -245,7 +245,7 @@ impl SearchView {
                 .playlists
                 .items
                 .iter()
-                .map(|sp| Library::process_simplified_playlist(sp, &&spotify))
+                .map(|sp| Playlist::from_simplified_playlist(sp, &&spotify))
                 .collect();
             let mut r = playlists.write().unwrap();
 

--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -224,8 +224,8 @@ impl SearchView {
         _offset: usize,
         _append: bool,
     ) -> u32 {
-        if let Some(results) = spotify.playlist(&query) {
-            let pls = vec![Playlist::from_full_playlist(&results, &&spotify)];
+        if let Some(result) = spotify.playlist(&query).as_ref() {
+            let pls = vec![result.into()];
             let mut r = playlists.write().unwrap();
             *r = pls;
             return 1;
@@ -245,7 +245,7 @@ impl SearchView {
                 .playlists
                 .items
                 .iter()
-                .map(|sp| Playlist::from_simplified_playlist(sp, &&spotify))
+                .map(|sp| sp.into())
                 .collect();
             let mut r = playlists.write().unwrap();
 

--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -241,12 +241,7 @@ impl SearchView {
         append: bool,
     ) -> u32 {
         if let Some(results) = spotify.search_playlist(&query, 50, offset as u32) {
-            let mut pls = results
-                .playlists
-                .items
-                .iter()
-                .map(|sp| sp.into())
-                .collect();
+            let mut pls = results.playlists.items.iter().map(|sp| sp.into()).collect();
             let mut r = playlists.write().unwrap();
 
             if append {


### PR DESCRIPTION
- Moved some of the playlist stuff out of library.rs to reduce that file in size a bit and bring playlists in line with all the other models.
- Displaying the following indicator only for playlists the user didn't create himself (#56).
- Prevented the `s` key from immediately deleting created playlists.
- Changed playlists to lazy-loading to avoid huge search delays (#62), the tracks are loaded when playing, saving or opening. It's probably unnecessary to download tracks for all search results since the user will in most cases not play any of them, or one/two at most.
- Displaying the saved indicator in the statusbar for the current track.
- Changed the `previous` command's behaviour to rewind to the start unless within the first 5 seconds of the track.
- Made the `play` command clear the queue as discussed.
- Made the library the default view on start.

The `current_user` endpoint from rspotify was bugged since it didn't handle `birthdate` and `email` being absent, so I implemented those on my fork again. I'll try to upstream that as well.