### PR TITLE
Add debian packages for libxcb development headers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ future. Contributions welcome, but please be kind ;)
 * A Spotify premium account
 * pkg-config
 
-On Debian based system you want following packages for `libxcb` developement headers:
+On Debian based systems you need following packages for `libxcb` developement headers:
 ```
 sudo apt install libxcb1-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev
 ```

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ future. Contributions welcome, but please be kind ;)
 * A Spotify premium account
 * pkg-config
 
+On Debian based system you want following packages for `libxcb` developement headers:
+```
+sudo apt install libxcb1-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev
+```
+
+
 ## Usage
 
 * Build using `cargo build --release`


### PR DESCRIPTION
As discussed in #84, this is just to document the list of packages one needs to install in Debian based systems for libxcb-*.