### PR TITLE
Add python3 dependency for building rust-xcb

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ future. Contributions welcome, but please be kind ;)
 ## Requirements
 
 * Rust
+* Python 3 (needed for building `rust-xcb` dependency)
 * `libasound2-dev` (or `portaudio-dev`, if you want to use the PortAudio backend)
 * `libncurses-dev` and `libssl-dev`
 * `libdbus-1-dev`


### PR DESCRIPTION
When I tried to compile ncspot on my machine (without python installed) it couldn't run the rust-xcb build script. This is because the rust-xcb build script is written in python 3, see: https://github.com/rtbo/rust-xcb/blob/master/rs_client.py.

I have added the python 3 requirement to the readme.