### PR TITLE
Changed 'seek' keybinding to match ncmpcpp and added fast-seek

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ have them configurable.
 * `Shift-s` stops a track
 * `Shift-u` updates the library cache (tracks, artists, albums, playlists)
 * `<` and `>` play the previous or next track
-* `,` and `.` to rewind or skip forward
+* `f` and `b` to seek forward or backward
+* `Shift-f` and `Shift-b` to seek forward or backward in steps of 10s
 * `-` and `+` decrease or increase the volume
 * `r` to toggle repeat mode
 * `z` to toggle shuffle playback

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -211,8 +211,10 @@ impl CommandManager {
         kb.insert("Ctrl+s".into(), Command::SaveQueue);
         kb.insert("d".into(), Command::Delete);
         kb.insert("/".into(), Command::Focus("search".into()));
-        kb.insert(".".into(), Command::Seek(SeekDirection::Relative(500)));
-        kb.insert(",".into(), Command::Seek(SeekDirection::Relative(-500)));
+        kb.insert("f".into(), Command::Seek(SeekDirection::Relative(1000)));
+        kb.insert("b".into(), Command::Seek(SeekDirection::Relative(-1000)));
+        kb.insert("Shift+f".into(), Command::Seek(SeekDirection::Relative(10000)));
+        kb.insert("Shift+b".into(), Command::Seek(SeekDirection::Relative(-10000)));
         kb.insert("+".into(), Command::VolumeUp);
         kb.insert("-".into(), Command::VolumeDown);
         kb.insert("r".into(), Command::Repeat(None));


### PR DESCRIPTION
Since you compare your app to 'mpd', I thought it would make sense to align the keybindings for the seek command with ncmpcpp, which is probably the most common mpd client:
- 'f' to seek forward
- 'b' to seek backward

I also implemented a fast-seek option, which would fix #104 