### PR TITLE
Add snap build info

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,12 @@
 [![Crates.io](https://img.shields.io/crates/v/ncspot.svg)](https://crates.io/crates/ncspot)
 [![Gitter](https://badges.gitter.im/ncspot/community.svg)](https://gitter.im/ncspot/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![Build Status](https://travis-ci.com/hrkfdn/ncspot.svg?token=DoBH2xZ13CfuTfqgEyp7&branch=master)](https://travis-ci.com/hrkfdn/ncspot)
+[![Snap Status](https://build.snapcraft.io/badge/popey/ncspot-snap.svg)](https://build.snapcraft.io/user/popey/ncspot-snap)
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/ncspot.svg)](https://repology.org/project/ncspot/versions)
+
+[![ncspot](https://snapcraft.io//ncspot/badge.svg)](https://snapcraft.io/ncspot)
+[![ncspot](https://snapcraft.io//ncspot/trending.svg?name=0)](https://snapcraft.io/ncspot)
 
 ncurses Spotify client written in Rust using librespot. It is heavily inspired
 by ncurses MPD clients, such as ncmpc.  My motivation was to provide a simple


### PR DESCRIPTION
Hello! I added ncspot to the snap store - see https://snapcraft.io/ncspot - which has automated builds for i386, amd64, arm64, ppc64el and s390x (know anyone with an IBM mainframe who wants to listen to Spotify on it? :D )

This merge simply adds the build status as you have for repology. Sorry it doesn't line up. I'll start a conversation with repology to see if they can support snapcraft too. 

Thanks for making a great spotify client <3