### PR TITLE
Added configuration option for initial shuffle, repeat, volume

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,14 @@ pub struct Config {
     pub keybindings: Option<HashMap<String, String>>,
     pub theme: Option<ConfigTheme>,
     pub use_nerdfont: Option<bool>,
+    pub saved_state: Option<SavedState>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+pub struct SavedState {
+    pub volume: Option<u16>,
+    pub shuffle: Option<bool>,
+    pub repeat: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,7 +17,7 @@ pub struct Config {
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct SavedState {
-    pub volume: Option<u16>,
+    pub volume: Option<u8>,
     pub shuffle: Option<bool>,
     pub repeat: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,7 +178,7 @@ fn main() {
 
     let event_manager = EventManager::new(cursive.cb_sink().clone());
 
-    let spotify = Arc::new(spotify::Spotify::new(event_manager.clone(), credentials));
+    let spotify = Arc::new(spotify::Spotify::new(event_manager.clone(), credentials, &cfg));
 
     let queue = Arc::new(queue::Queue::new(spotify.clone()));
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -23,13 +23,16 @@ pub struct Queue {
 
 impl Queue {
     pub fn new(spotify: Arc<Spotify>) -> Queue {
-        Queue {
+        let q = Queue {
             queue: Arc::new(RwLock::new(Vec::new())),
+            spotify,
             current_track: RwLock::new(None),
             repeat: RwLock::new(RepeatSetting::None),
             random_order: RwLock::new(None),
-            spotify,
-        }
+        };
+        q.set_repeat(q.spotify.repeat);
+        q.set_shuffle(q.spotify.shuffle);
+        q
     }
 
     pub fn next_index(&self) -> Option<usize> {

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -223,7 +223,7 @@ impl Spotify {
         let (user_tx, user_rx) = oneshot::channel();
         let volume = match &cfg.saved_state {
             Some(state) => match state.volume {
-                Some(vol) => vol,
+                Some(vol) => ((std::cmp::min(vol, 100) as f32)/100.0 * (0xFFFF as f32)).ceil() as u16,
                 None => 0xFFFF as u16,
             },
             None => 0xFFFF as u16,


### PR DESCRIPTION
I was a bit annoyed, that by default ncspot starts with shuffle and repeat turned off and volume at 100% so I thought why not change that.
This change lets ncspot read these options from the config.toml:
```
[saved_state]
volume = 0 - 65535
repeat = "track" | "playlist" | anything else defaults to no
shuffle = true | false
```

Those values are read at the start of the program and set the initial values of the respective variables.

Anyways, I love the app and I'm happy to contribute!

In the future I might write something to sync changes to these values made in the app with what's in the config file

PS: My first time writing in rust. Hope it's okayish code. There were many confusing hurdles for me as a newbie.