### PR TITLE
Shuffle: Start with a random track if not selecting track directly

### DIFF
--- a/src/album.rs
+++ b/src/album.rs
@@ -177,7 +177,7 @@ impl ListItem for Album {
         if let Some(tracks) = self.tracks.as_ref() {
             let tracks: Vec<&Track> = tracks.iter().collect();
             let index = queue.append_next(tracks);
-            queue.play(index, true);
+            queue.play(index, true, true);
         }
     }
 

--- a/src/artist.rs
+++ b/src/artist.rs
@@ -172,7 +172,7 @@ impl ListItem for Artist {
 
         if let Some(tracks) = self.tracks() {
             let index = queue.append_next(tracks);
-            queue.play(index, true);
+            queue.play(index, true, true);
         }
     }
 

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -140,7 +140,7 @@ impl ListItem for Playlist {
 
         if let Some(tracks) = self.tracks.as_ref() {
             let index = queue.append_next(tracks.iter().collect());
-            queue.play(index, true);
+            queue.play(index, true, true);
         }
     }
 

--- a/src/track.rs
+++ b/src/track.rs
@@ -174,7 +174,7 @@ impl ListItem for Track {
 
     fn play(&mut self, queue: Arc<Queue>) {
         let index = queue.append_next(vec![self]);
-        queue.play(index, true);
+        queue.play(index, true, false);
     }
 
     fn queue(&mut self, queue: Arc<Queue>) {

--- a/src/ui/listview.rs
+++ b/src/ui/listview.rs
@@ -148,7 +148,7 @@ impl<I: ListItem> ListView<I> {
         if let Some(tracks) = any.downcast_ref::<Vec<Track>>() {
             let tracks: Vec<&Track> = tracks.iter().collect();
             let index = self.queue.append_next(tracks);
-            self.queue.play(index + self.selected, true);
+            self.queue.play(index + self.selected, true, false);
             true
         } else {
             false

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -92,7 +92,7 @@ impl ViewExt for QueueView {
     fn on_command(&mut self, s: &mut Cursive, cmd: &Command) -> Result<CommandResult, String> {
         match cmd {
             Command::Play => {
-                self.queue.play(self.list.get_selected_index(), true);
+                self.queue.play(self.list.get_selected_index(), true, false);
                 return Ok(CommandResult::Consumed(None));
             }
             Command::Queue => {


### PR DESCRIPTION
Starting a playlist, album or artist with shuffle enabled always
starts on the first track in it and then plays the rest of the
queue shuffled.
This changes it so unless a track is picked directly, playback
will start on a random track of the selection.

This matches the behavior of most music players that I am aware of,
as well as the official Spotify client.