### PR TITLE
removed unnecessary parentheses

### DIFF
--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -370,7 +370,7 @@ impl Spotify {
             .elapsed
             .read()
             .expect("could not acquire read lock on elapsed time");
-        (*elapsed)
+        *elapsed
     }
 
     fn set_since(&self, new_since: Option<SystemTime>) {
@@ -386,7 +386,7 @@ impl Spotify {
             .since
             .read()
             .expect("could not acquire read lock on since time");
-        (*since)
+        *since
     }
 
     pub fn refresh_token(&self) {


### PR DESCRIPTION
This one's a small change that doesn't really affect functionality and just gets rid of a warning during building, but ¯\_(ツ)_/¯

Buillding the program was successful on my end.