### PR TITLE
Added OpenUri D-BUS MPRIS support.

### DIFF
--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -819,7 +819,7 @@ impl URIType {
             Some(URIType::Artist)
         } else if s.starts_with("spotify:track:") {
             Some(URIType::Track)
-        } else if s.starts_with("spotify:user:") && s.contains(":playlist:") {
+        } else if s.starts_with("spotify:") && s.contains(":playlist:") {
             Some(URIType::Playlist)
         } else {
             None


### PR DESCRIPTION
I have been working on a music bot project, and recently I found the ncspot project and wanted to add support to play Spotify songs via ncspot, because the regular Spotify client eats up so much RAM, the bot doesn't always work properly on low-end machines.
All was good until I finished implementing the new functionality and then I noticed that even though ncspot supports most of the mpris protocol, OpenUri method call was missing, which is one of the most important ones for my bot.
I then took a crash course in Rust and implemented it myself. You might want to review my code since I have never done Rust until now...