### PR TITLE
[feat] add Command::Noop

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -102,11 +102,13 @@ pub enum Command {
     Shift(ShiftMode, Option<i32>),
     Search(String),
     Help,
+    Noop,
 }
 
 impl fmt::Display for Command {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let repr = match self {
+            Command::Noop => "noop".to_string(),
             Command::Quit => "quit".to_string(),
             Command::TogglePlay => "playpause".to_string(),
             Command::Stop => "stop".to_string(),
@@ -324,6 +326,7 @@ pub fn parse(input: &str) -> Option<Command> {
         "volup" => Some(Command::VolumeUp),
         "voldown" => Some(Command::VolumeDown),
         "help" => Some(Command::Help),
+        "noop" => Some(Command::Noop),
         _ => None,
     }
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -83,6 +83,7 @@ impl CommandManager {
         cmd: &Command,
     ) -> Result<Option<String>, String> {
         match cmd {
+            Command::Noop => Ok(None),
             Command::Quit => {
                 s.quit();
                 Ok(None)


### PR DESCRIPTION
## Details
This pull request introduces a Noop command allowing the user to override default keybindings.

### Example
In the configuration a user can override a keybinding in the following way:
```toml
[keybindings]
"s" = "noop" # Disable default save keybinding
"d" = "noop" # Disable default delete keybinding
```