### PR TITLE
[feat] add Command::Help to command.parse

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -323,6 +323,7 @@ pub fn parse(input: &str) -> Option<Command> {
         }),
         "volup" => Some(Command::VolumeUp),
         "voldown" => Some(Command::VolumeDown),
+        "help" => Some(Command::Help),
         _ => None,
     }
 }


### PR DESCRIPTION
## Details
This pull request allows the help keybinding to be configured to a different key in a user's configuration.

### Example
```toml
[keybindings]
"z" = "help"
```