### PR TITLE
Display album name for playable objects 

### DIFF
--- a/src/album.rs
+++ b/src/album.rs
@@ -159,6 +159,10 @@ impl ListItem for Album {
         format!("{}", self)
     }
 
+    fn display_center(&self) -> String {
+        "".to_string()
+    }
+
     fn display_right(&self, library: Arc<Library>) -> String {
         let saved = if library.is_saved_album(self) {
             if library.use_nerdfont {

--- a/src/artist.rs
+++ b/src/artist.rs
@@ -148,6 +148,10 @@ impl ListItem for Artist {
         format!("{}", self)
     }
 
+    fn display_center(&self) -> String {
+        "".to_string()
+    }
+
     fn display_right(&self, library: Arc<Library>) -> String {
         let followed = if library.is_followed_artist(self) {
             if library.use_nerdfont {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -268,7 +268,7 @@ impl CommandManager {
         kb.insert("<".into(), Command::Previous);
         kb.insert(">".into(), Command::Next);
         kb.insert("c".into(), Command::Clear);
-        kb.insert(" ".into(), Command::Queue);
+        kb.insert("Space".into(), Command::Queue);
         kb.insert("Enter".into(), Command::Play);
         kb.insert("s".into(), Command::Save);
         kb.insert("Ctrl+s".into(), Command::SaveQueue);
@@ -375,6 +375,7 @@ impl CommandManager {
     fn parse_key(key: &str) -> Event {
         match key {
             "Enter" => Event::Key(Key::Enter),
+            "Space" => Event::Char(" ".chars().next().unwrap()),
             "Tab" => Event::Key(Key::Tab),
             "Backspace" => Event::Key(Key::Backspace),
             "Esc" => Event::Key(Key::Esc),

--- a/src/episode.rs
+++ b/src/episode.rs
@@ -71,6 +71,10 @@ impl ListItem for Episode {
         self.name.clone()
     }
 
+    fn display_center(&self) -> String {
+        "".to_string()
+    }
+
     fn display_right(&self, _library: Arc<Library>) -> String {
         format!("{} [{}]", self.duration_str(), self.release_date)
     }

--- a/src/playable.rs
+++ b/src/playable.rs
@@ -76,6 +76,10 @@ impl ListItem for Playable {
         self.as_listitem().display_left()
     }
 
+    fn display_center(&self) -> String {
+        self.as_listitem().display_center()
+    }
+
     fn display_right(&self, library: Arc<Library>) -> String {
         self.as_listitem().display_right(library)
     }

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -128,6 +128,10 @@ impl ListItem for Playlist {
         self.name.clone()
     }
 
+    fn display_center(&self) -> String {
+        "".to_string()
+    }
+
     fn display_right(&self, library: Arc<Library>) -> String {
         let saved = if library.is_saved_playlist(self) {
             if library.use_nerdfont {

--- a/src/show.rs
+++ b/src/show.rs
@@ -92,6 +92,10 @@ impl ListItem for Show {
         format!("{}", self)
     }
 
+    fn display_center(&self) -> String {
+        "".to_string()
+    }
+
     fn display_right(&self, library: Arc<Library>) -> String {
         let saved = if library.is_saved_show(self) {
             if library.use_nerdfont {

--- a/src/track.rs
+++ b/src/track.rs
@@ -153,6 +153,10 @@ impl ListItem for Track {
         format!("{}", self)
     }
 
+    fn display_center(&self) -> String {
+        format!("{}", self.album)
+    }
+
     fn display_right(&self, library: Arc<Library>) -> String {
         let saved = if library.is_saved_track(&Playable::Track(self.clone())) {
             if library.use_nerdfont {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -15,6 +15,7 @@ use crate::track::Track;
 pub trait ListItem: Sync + Send + 'static {
     fn is_playing(&self, queue: Arc<Queue>) -> bool;
     fn display_left(&self) -> String;
+    fn display_center(&self) -> String;
     fn display_right(&self, library: Arc<Library>) -> String;
     fn play(&mut self, queue: Arc<Queue>);
     fn queue(&mut self, queue: Arc<Queue>);

--- a/src/ui/listview.rs
+++ b/src/ui/listview.rs
@@ -205,7 +205,7 @@ impl<I: ListItem> View for ListView<I> {
                 let center = item.display_center();
                 let right = item.display_right(self.library.clone());
 
-                let center_offset = printer.size.x / 3 * 2;
+                let center_offset = printer.size.x / 2;
 
                 // draw left string
                 printer.with_color(style, |printer| {

--- a/src/ui/listview.rs
+++ b/src/ui/listview.rs
@@ -202,7 +202,10 @@ impl<I: ListItem> View for ListView<I> {
                 };
 
                 let left = item.display_left();
+                let center = item.display_center();
                 let right = item.display_right(self.library.clone());
+
+                let center_offset = printer.size.x / 3 * 2;
 
                 // draw left string
                 printer.with_color(style, |printer| {
@@ -210,9 +213,22 @@ impl<I: ListItem> View for ListView<I> {
                     printer.print((0, 0), &left);
                 });
 
-                // draw ".." to indicate a cut off string
-                let max_length = printer.size.x.saturating_sub(right.width() + 1);
+                // left string cut off indicator
+                let max_length = center_offset.saturating_sub(1);
                 if max_length < left.width() {
+                    let offset = max_length.saturating_sub(1);
+                    printer.with_color(style, |printer| {
+                        printer.print((offset, 0), "..");
+                    });
+                }
+
+                printer.with_color(style, |printer| {
+                    printer.print((center_offset, 0), &center);
+                });
+
+                // center string cut off indicator
+                let max_length = printer.size.x.saturating_sub(right.width() + 1);
+                if max_length < center_offset + center.width() {
                     let offset = max_length.saturating_sub(1);
                     printer.with_color(style, |printer| {
                         printer.print((offset, 0), "..");


### PR DESCRIPTION
Adds information about the album in a separate column, here's a picture for example:

![image](https://user-images.githubusercontent.com/18540571/93648465-858aa500-fa13-11ea-85f6-82df50bccd65.png)

This also appears in the queue.
Comes to implement #267 