### PR TITLE
Added config option for bitrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Possible configuration values are:
 * `default_keybindings`: If disabled, the default keybindings are discarded, off
   by default <true/false>
 * `notify`: Enable or disable desktop notifications, off by default <true/false>
+* `bitrate`: The audio bitrate to use for streaming, can be 96, 160, or 320 (default is 320)
 
 
 Keybindings can be configured in `[keybindings]` section in `config.toml`, e.g. as such:

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,7 @@ pub struct Config {
     pub volnorm: Option<bool>,
     pub volnorm_pregain: Option<f32>,
     pub notify: Option<bool>,
+    pub bitrate: Option<u32>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -51,6 +51,7 @@ use std::sync::RwLock;
 use std::thread;
 use std::time::{Duration, SystemTime};
 use std::{env, io};
+use std::str::FromStr;
 
 use crate::artist::Artist;
 use crate::config;
@@ -398,9 +399,15 @@ impl Spotify {
         user_tx: Option<oneshot::Sender<String>>,
         volume: u16,
     ) {
+        let bitrate_str = cfg.bitrate.unwrap_or(320).to_string();
+        let bitrate = Bitrate::from_str(&bitrate_str);
+        if bitrate.is_err(){
+            error!("invalid bitrate, will use 320 instead")
+        }
+
         let player_config = PlayerConfig {
             gapless: false,
-            bitrate: Bitrate::Bitrate320,
+            bitrate: bitrate.unwrap_or(Bitrate::Bitrate320),
             normalisation: cfg.volnorm.unwrap_or(false),
             normalisation_pregain: cfg.volnorm_pregain.unwrap_or(0.0),
         };


### PR DESCRIPTION
Added a config option `bitrate` that allows the bitrate to be set to 96, 160 or 320.

Implements #269 