### PR TITLE
Fix last tab to fill entire width correctly

### DIFF
--- a/src/ui/tabview.rs
+++ b/src/ui/tabview.rs
@@ -74,7 +74,7 @@ impl View for TabView {
             };
 
             let mut width = tabwidth;
-            if i == self.tabs.len() {
+            if i == self.tabs.len() - 1 {
                 width += printer.size.x % self.tabs.len();
             }
 


### PR DESCRIPTION
Condition to check if the tab is the last one was never met. Because of that the last tab wasn't well aligned when terminal width wasn't divisible by the number of tabs.