### PR TITLE
Better queue behavior 

### DIFF
--- a/src/queue.rs
+++ b/src/queue.rs
@@ -155,10 +155,14 @@ impl Queue {
         if let Some(current_track) = current {
             match current_track.cmp(&index) {
                 Ordering::Equal => {
-                    // stop playback if we have the deleted the last item and it
-                    // was playing
+                    // if we have deleted the last item and it was playing
+                    // stop playback, unless repeat playlist is on, play next
                     if current_track == len {
-                        self.stop();
+                        if self.get_repeat() == RepeatSetting::RepeatPlaylist {
+                            self.next(false);
+                        } else {
+                            self.stop();
+                        }
                     } else {
                         self.play(index, false, false);
                     }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -256,6 +256,9 @@ impl Queue {
             }
         } else if let Some(index) = self.next_index() {
             self.play(index, false, false);
+            if repeat == RepeatSetting::RepeatTrack && manual {
+                self.set_repeat(RepeatSetting::RepeatPlaylist);
+            }
         } else if repeat == RepeatSetting::RepeatPlaylist && q.len() > 0 {
             let random_order = self.random_order.read().unwrap();
             self.play(

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -272,7 +272,12 @@ impl Queue {
         if let Some(index) = self.previous_index() {
             self.play(index, false, false);
         } else {
-            self.spotify.stop();
+            let current = *self.current_track.read().unwrap();
+            if let Some(index) = current {
+                self.play(index, false, false);
+            } else {
+                self.spotify.stop();
+            }
         }
     }
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -269,15 +269,25 @@ impl Queue {
     }
 
     pub fn previous(&self) {
+        let q = self.queue.read().unwrap();
+        let current = *self.current_track.read().unwrap();
+        let repeat = *self.repeat.read().unwrap();
+
         if let Some(index) = self.previous_index() {
             self.play(index, false, false);
-        } else {
-            let current = *self.current_track.read().unwrap();
-            if let Some(index) = current {
-                self.play(index, false, false);
+        } else if repeat == RepeatSetting::RepeatPlaylist && q.len() > 0 {
+            if self.get_shuffle() {
+                let random_order = self.random_order.read().unwrap();
+                self.play(
+                    random_order.as_ref().map(|o| o[q.len() - 1]).unwrap_or(0),
+                    false,
+                    false,
+                );
             } else {
-                self.spotify.stop();
+                self.play(q.len() - 1, false, false);
             }
+        } else if let Some(index) = current {
+            self.play(index, false, false);
         }
     }
 

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -99,7 +99,13 @@ impl ViewExt for QueueView {
                 return Ok(CommandResult::Ignored);
             }
             Command::Delete => {
-                self.queue.remove(self.list.get_selected_index());
+                let selected = self.list.get_selected_index();
+                let len = self.queue.len();
+
+                self.queue.remove(selected);
+                if selected == len.saturating_sub(1) {
+                    self.list.move_focus(-1);
+                }
                 return Ok(CommandResult::Consumed(None));
             }
             Command::Shift(mode, amount) => {


### PR DESCRIPTION
- When deleting the last song, update the ui focus (the actual cause for #253).
- Play next song when deleting the currently playing song from queue.
- When skipping to next song the `RepeatTrack` turns into a `RepeatPlaylist`.
- You can now play the expected previous track when shuffle is turned on . 