### PR TITLE
Vim like search

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ depending on your desktop environment settings. Have a look at the
   * `F3`: Library
     * `d` deletes the currently selected playlist
 * Tracks and playlists can be played using `Return` and queued using `Space`
-* `n` will play the selected item after the currently playing track
-* `.` will move to the currently playing track in the queue
+* `.` will play the selected item after the currently playing track
+* `p` will move to the currently playing track in the queue
 * `s` will save, `d` will remove the currently selected track to/from your
   library
 * `o` will open a detail view or context menu for the selected item
@@ -102,6 +102,9 @@ depending on your desktop environment settings. Have a look at the
 * `x` copies a sharable URL of the song to the system clipboard
 * `Shift-x` copies a sharable URL of the currently selected item to the system clipboard
 
+Use `/` to open a Vim-like search bar, you can use `n` and `N` to go for the next/previous
+search occurrence, respectivly.
+
 You can also open a Vim style commandprompt using `:`, the following commands
 are supported:
 
@@ -115,6 +118,8 @@ are supported:
 The screens can be opened with `queue`, `search`, `playlists` and `log`, whereas
 `search` can be supplied with a search term that will be entered after opening
 the search view.
+
+To close the commandprompt at any time, press `esc`. 
 
 ## Configuration
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -44,6 +44,14 @@ impl Default for MoveAmount {
 
 #[derive(Display, Clone, Serialize, Deserialize, Debug)]
 #[strum(serialize_all = "lowercase")]
+pub enum JumpMode {
+    Previous,
+    Next,
+    Query(String),
+}
+
+#[derive(Display, Clone, Serialize, Deserialize, Debug)]
+#[strum(serialize_all = "lowercase")]
 pub enum ShiftMode {
     Up,
     Down,
@@ -102,7 +110,7 @@ pub enum Command {
     Move(MoveMode, MoveAmount),
     Shift(ShiftMode, Option<i32>),
     Search(String),
-    Jump(String),
+    Jump(JumpMode),
     Help,
     ReloadConfig,
     Noop,
@@ -226,7 +234,7 @@ pub fn parse(input: &str) -> Option<Command> {
                 _ => None,
             })
             .map(Command::Open),
-        "jump" => Some(Command::Jump(args.join(" "))),
+        "jump" => Some(Command::Jump(JumpMode::Query(args.join(" ")))),
         "search" => args
             .get(0)
             .map(|query| Command::Search((*query).to_string())),

--- a/src/command.rs
+++ b/src/command.rs
@@ -102,6 +102,7 @@ pub enum Command {
     Move(MoveMode, MoveAmount),
     Shift(ShiftMode, Option<i32>),
     Search(String),
+    Jump(String),
     Help,
     ReloadConfig,
     Noop,
@@ -157,6 +158,7 @@ impl fmt::Display for Command {
             Command::Move(mode, MoveAmount::Integer(amount)) => format!("move {} {}", mode, amount),
             Command::Shift(mode, amount) => format!("shift {} {}", mode, amount.unwrap_or(1)),
             Command::Search(term) => format!("search {}", term),
+            Command::Jump(term) => format!("jump {}", term),
             Command::Help => "help".to_string(),
             Command::ReloadConfig => "reload".to_string(),
         };
@@ -224,6 +226,7 @@ pub fn parse(input: &str) -> Option<Command> {
                 _ => None,
             })
             .map(Command::Open),
+        "jump" => Some(Command::Jump(args.join(" "))),
         "search" => args
             .get(0)
             .map(|query| Command::Search((*query).to_string())),

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::command::{
-    parse, Command, GotoMode, MoveAmount, MoveMode, SeekDirection, ShiftMode, TargetMode,
+    parse, Command, GotoMode, MoveAmount, MoveMode, SeekDirection, ShiftMode, TargetMode, JumpMode,
 };
 use crate::config::Config;
 use crate::library::Library;
@@ -273,7 +273,8 @@ impl CommandManager {
         kb.insert("Space".into(), Command::Queue);
         kb.insert(".".into(), Command::PlayNext);
         kb.insert("Enter".into(), Command::Play);
-        kb.insert("n".into(), Command::Jump(String::from("")));
+        kb.insert("n".into(), Command::Jump(JumpMode::Next));
+        kb.insert("Shift+n".into(), Command::Jump(JumpMode::Previous));
         kb.insert("s".into(), Command::Save);
         kb.insert("Ctrl+s".into(), Command::SaveQueue);
         kb.insert("d".into(), Command::Delete);

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::command::{
-    parse, Command, GotoMode, MoveAmount, MoveMode, SeekDirection, ShiftMode, TargetMode, JumpMode,
+    parse, Command, GotoMode, JumpMode, MoveAmount, MoveMode, SeekDirection, ShiftMode, TargetMode,
 };
 use crate::config::Config;
 use crate::library::Library;

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -174,6 +174,7 @@ impl CommandManager {
                 Ok(None)
             }
             Command::Search(_)
+            | Command::Jump(_)
             | Command::Move(_, _)
             | Command::Shift(_, _)
             | Command::Play
@@ -270,12 +271,12 @@ impl CommandManager {
         kb.insert(">".into(), Command::Next);
         kb.insert("c".into(), Command::Clear);
         kb.insert("Space".into(), Command::Queue);
-        kb.insert("n".into(), Command::PlayNext);
+        kb.insert(".".into(), Command::PlayNext);
         kb.insert("Enter".into(), Command::Play);
+        kb.insert("n".into(), Command::Jump(String::from("")));
         kb.insert("s".into(), Command::Save);
         kb.insert("Ctrl+s".into(), Command::SaveQueue);
         kb.insert("d".into(), Command::Delete);
-        kb.insert("/".into(), Command::Focus("search".into()));
         kb.insert("f".into(), Command::Seek(SeekDirection::Relative(1000)));
         kb.insert("b".into(), Command::Seek(SeekDirection::Relative(-1000)));
         kb.insert(
@@ -306,7 +307,7 @@ impl CommandManager {
 
         kb.insert("Up".into(), Command::Move(MoveMode::Up, Default::default()));
         kb.insert(
-            ".".into(),
+            "p".into(),
             Command::Move(MoveMode::Playing, Default::default()),
         );
         kb.insert(

--- a/src/main.rs
+++ b/src/main.rs
@@ -288,6 +288,14 @@ fn main() {
         }
     });
 
+    cursive.add_global_callback(cursive::event::Key::Esc , move |s| {
+        if s.find_name::<ContextMenu>("contextmenu").is_none() {
+            s.call_on_name("main", |v: &mut ui::layout::Layout| {
+                v.clear_cmdline();
+            });
+        }
+    });
+
     layout.cmdline.set_on_edit(move |s, cmd, _| {
         s.call_on_name("main", |v: &mut ui::layout::Layout| {
             if cmd.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,7 @@ mod ui;
 mod mpris;
 
 use crate::commands::CommandManager;
-use crate::command::Command;
+use crate::command::{Command, JumpMode};
 use crate::events::{Event, EventManager};
 use crate::library::Library;
 use crate::spotify::PlayerEvent;
@@ -305,7 +305,7 @@ fn main() {
             }
             if cmd.starts_with("/") {
                 let query = &cmd[1..];
-                let command = Command::Jump(query.to_string());
+                let command = Command::Jump(JumpMode::Query(query.to_string()));
                 if let Some(data) = s.user_data::<UserData>().cloned() {
                     data.cmd.handle(s, command);
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,8 +74,8 @@ mod ui;
 #[cfg(feature = "mpris")]
 mod mpris;
 
-use crate::commands::CommandManager;
 use crate::command::{Command, JumpMode};
+use crate::commands::CommandManager;
 use crate::events::{Event, EventManager};
 use crate::library::Library;
 use crate::spotify::PlayerEvent;
@@ -288,7 +288,7 @@ fn main() {
         }
     });
 
-    cursive.add_global_callback(cursive::event::Key::Esc , move |s| {
+    cursive.add_global_callback(cursive::event::Key::Esc, move |s| {
         if s.find_name::<ContextMenu>("contextmenu").is_none() {
             s.call_on_name("main", |v: &mut ui::layout::Layout| {
                 v.clear_cmdline();

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -67,6 +67,13 @@ impl Layout {
         }
     }
 
+    pub fn enable_jump(&mut self) {
+        if !self.cmdline_focus {
+            self.cmdline.set_content("/");
+            self.cmdline_focus = true;
+        }
+    }
+
     pub fn add_view<S: Into<String>, T: IntoBoxedViewExt>(&mut self, id: S, view: T, title: S) {
         let s = id.into();
         let screen = Screen {


### PR DESCRIPTION
To start searching (only from `display_left`) just press `/` and begin typing the query.

`p` - go to currently playing
`.` - play next
`n` - search next
`N` - search previous
`esc` - close command line

Those are the keybindings I use on my fork, I guess you'd want to change some of them. 
