### PR TITLE
Replace "directories" crate with "platform_dirs"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,16 +806,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "directories"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551a778172a450d7fc12e629ca3b0428d00f6afa9a43da1b630d54604e97371c"
-dependencies = [
- "cfg-if",
- "dirs-sys",
-]
-
-[[package]]
 name = "dirs"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,10 +817,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-sys"
-version = "0.3.5"
+name = "dirs-next"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
+checksum = "1cbcf9241d9e8d106295bd496bbe2e9cffd5fa098f2a8c9e2bbcbf09773c11a8"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c60f7b8a8953926148223260454befb50c751d3c50e1c178c4fd1ace4083c9a"
 dependencies = [
  "libc",
  "redox_users",
@@ -1908,7 +1908,6 @@ dependencies = [
  "crossbeam-channel",
  "cursive",
  "dbus",
- "directories",
  "failure",
  "fern",
  "futures 0.1.30",
@@ -1920,6 +1919,7 @@ dependencies = [
  "librespot-protocol",
  "log 0.4.11",
  "notify-rust",
+ "platform-dirs",
  "rand 0.7.3",
  "regex",
  "reqwest 0.9.24",
@@ -2320,6 +2320,15 @@ name = "pkg-config"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
+
+[[package]]
+name = "platform-dirs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e188d043c1a692985f78b5464853a263f1a27e5bd6322bad3a4078ee3c998a38"
+dependencies = [
+ "dirs-next",
+]
 
 [[package]]
 name = "portaudio-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ clap = "2.33.0"
 chrono = "0.4"
 reqwest = "0.9"
 crossbeam-channel = "0.4"
-directories = "2.0"
+platform-dirs = "0.3.0"
 failure = "0.1"
 fern = "0.5"
 futures = { version = "0.3", features = ["compat"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,6 @@ extern crate crossbeam_channel;
 extern crate cursive;
 #[cfg(feature = "share_clipboard")]
 extern crate clipboard;
-extern crate directories;
 extern crate failure;
 extern crate futures;
 #[macro_use]


### PR DESCRIPTION
The `directories` create is no longer maintained.
Also it uses `~/Library/Preferences` on MacOS (https://github.com/dirs-dev/directories-rs/issues/62), but Apple advises against [creating files in `Preferences` sufolder](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html#//apple_ref/doc/uid/TP40010672-CH2-SW1):
>This directory contains app-specific preference files. You should not create files in this directory yourself. Instead, use the NSUserDefaults class or CFPreferences API to get and set preference values for your app.In iOS, the contents of this directory are backed up by iTunes and iCloud.

[`platform-dirs`](https://github.com/cjbassi/platform-dirs-rs) allows to use `~/.config` on MacOS.