### PR TITLE
Increase/Decrease volume by 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 *.log
 
 tags
+
+/.vscode/

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ depending on your desktop environment settings. Have a look at the
 * `<` and `>` play the previous or next track
 * `f` and `b` to seek forward or backward
 * `Shift-f` and `Shift-b` to seek forward or backward in steps of 10s
-* `-` and `+` decrease or increase the volume
+* `-` and `+` decrease or increase the volume by 1
+* `[` and `]` decrease of increase the volume by 5
 * `r` to toggle repeat mode
 * `z` to toggle shuffle playback
 * `q` quits ncspot

--- a/src/command.rs
+++ b/src/command.rs
@@ -99,8 +99,8 @@ pub enum Command {
     Delete,
     Focus(String),
     Seek(SeekDirection),
-    VolumeUp,
-    VolumeDown,
+    VolumeUp(u16),
+    VolumeDown(u16),
     Repeat(Option<RepeatSetting>),
     Shuffle(Option<bool>),
     Share(TargetMode),
@@ -136,8 +136,8 @@ impl fmt::Display for Command {
             Command::Delete => "delete".to_string(),
             Command::Focus(tab) => format!("focus {}", tab),
             Command::Seek(direction) => format!("seek {}", direction),
-            Command::VolumeUp => "volup".to_string(),
-            Command::VolumeDown => "voldown".to_string(),
+            Command::VolumeUp(amount) => format!("volup {}", amount),
+            Command::VolumeDown(amount) => format!("voldown {}", amount),
             Command::Repeat(mode) => {
                 let param = match mode {
                     Some(mode) => format!("{}", mode),
@@ -344,8 +344,8 @@ pub fn parse(input: &str) -> Option<Command> {
                 _ => Command::Save,
             })
             .or(Some(Command::Save)),
-        "volup" => Some(Command::VolumeUp),
-        "voldown" => Some(Command::VolumeDown),
+        "volup" => Some(Command::VolumeUp(1)),
+        "voldown" => Some(Command::VolumeDown(1)),
         "help" => Some(Command::Help),
         "reload" => Some(Command::ReloadConfig),
         "insert" => {

--- a/src/command.rs
+++ b/src/command.rs
@@ -344,8 +344,12 @@ pub fn parse(input: &str) -> Option<Command> {
                 _ => Command::Save,
             })
             .or(Some(Command::Save)),
-        "volup" => Some(Command::VolumeUp(args[0].to_string().parse::<u16>().unwrap())),
-        "voldown" => Some(Command::VolumeDown(args[0].to_string().parse::<u16>().unwrap())),
+        "volup" => Some(Command::VolumeUp(
+            args.get(0).and_then(|v| v.parse::<u16>().ok()).unwrap_or(1),
+        )),
+        "voldown" => Some(Command::VolumeDown(
+            args.get(0).and_then(|v| v.parse::<u16>().ok()).unwrap_or(1),
+        )),
         "help" => Some(Command::Help),
         "reload" => Some(Command::ReloadConfig),
         "insert" => {

--- a/src/command.rs
+++ b/src/command.rs
@@ -344,8 +344,8 @@ pub fn parse(input: &str) -> Option<Command> {
                 _ => Command::Save,
             })
             .or(Some(Command::Save)),
-        "volup" => Some(Command::VolumeUp(1)),
-        "voldown" => Some(Command::VolumeDown(1)),
+        "volup" => Some(Command::VolumeUp(args[0].to_string().parse::<u16>().unwrap())),
+        "voldown" => Some(Command::VolumeDown(args[0].to_string().parse::<u16>().unwrap())),
         "help" => Some(Command::Help),
         "reload" => Some(Command::ReloadConfig),
         "insert" => {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -148,13 +148,13 @@ impl CommandManager {
                 }
                 Ok(None)
             }
-            Command::VolumeUp => {
-                let volume = self.spotify.volume().saturating_add(VOLUME_PERCENT);
+            Command::VolumeUp(amount) => {
+                let volume = self.spotify.volume().saturating_add(VOLUME_PERCENT * amount);
                 self.spotify.set_volume(volume);
                 Ok(None)
             }
-            Command::VolumeDown => {
-                let volume = self.spotify.volume().saturating_sub(VOLUME_PERCENT);
+            Command::VolumeDown(amount) => {
+                let volume = self.spotify.volume().saturating_sub(VOLUME_PERCENT * amount);
                 debug!("vol {}", volume);
                 self.spotify.set_volume(volume);
                 Ok(None)
@@ -294,8 +294,11 @@ impl CommandManager {
             "Shift+b".into(),
             Command::Seek(SeekDirection::Relative(-10000)),
         );
-        kb.insert("+".into(), Command::VolumeUp);
-        kb.insert("-".into(), Command::VolumeDown);
+        kb.insert("+".into(), Command::VolumeUp(1));
+        kb.insert("]".into(), Command::VolumeUp(5));
+        kb.insert("-".into(), Command::VolumeDown(1));
+        kb.insert("[".into(), Command::VolumeDown(5));
+
         kb.insert("r".into(), Command::Repeat(None));
         kb.insert("z".into(), Command::Shuffle(None));
         kb.insert("x".into(), Command::Share(TargetMode::Current));

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -149,12 +149,18 @@ impl CommandManager {
                 Ok(None)
             }
             Command::VolumeUp(amount) => {
-                let volume = self.spotify.volume().saturating_add(VOLUME_PERCENT * amount);
+                let volume = self
+                    .spotify
+                    .volume()
+                    .saturating_add(VOLUME_PERCENT * amount);
                 self.spotify.set_volume(volume);
                 Ok(None)
             }
             Command::VolumeDown(amount) => {
-                let volume = self.spotify.volume().saturating_sub(VOLUME_PERCENT * amount);
+                let volume = self
+                    .spotify
+                    .volume()
+                    .saturating_sub(VOLUME_PERCENT * amount);
                 debug!("vol {}", volume);
                 self.spotify.set_volume(volume);
                 Ok(None)


### PR DESCRIPTION
I choosed `[` and `]` because are near to `-` and `+`.
I tried to use a keybinding with `-` and `+`, but `Ctrl` was used by the terminal and `Alt` wasn't recognized.