### PR TITLE
Change to correct trackid

### DIFF
--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -43,7 +43,12 @@ fn get_metadata(playable: Option<Playable>) -> Metadata {
 
     hm.insert(
         "mpris:trackid".to_string(),
-        Variant(Box::new(playable.map(|t| t.uri()).unwrap_or_default())),
+        Variant(Box::new(Path::from(format!(
+            "/org/ncspot/{}",
+            playable
+                .map(|t| t.uri().replace(':', "/"))
+                .unwrap_or("0".to_string())
+        )))),
     );
     hm.insert(
         "mpris:length".to_string(),


### PR DESCRIPTION
Seems that one of commit from #252 was lost so trying to do something with MPRIS via `playerctl` crashes because there's wrong `mpris:trackid` in the code.