### PR TITLE
Only show playlists where the user is allowed to add tracks when trying to add tracks

### DIFF
--- a/src/library.rs
+++ b/src/library.rs
@@ -33,7 +33,7 @@ pub struct Library {
     pub playlists: Arc<RwLock<Vec<Playlist>>>,
     pub shows: Arc<RwLock<Vec<Show>>>,
     pub is_done: Arc<RwLock<bool>>,
-    user_id: Option<String>,
+    pub user_id: Option<String>,
     ev: EventManager,
     spotify: Arc<Spotify>,
     pub cfg: Arc<Config>,

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -19,6 +19,7 @@ pub struct Playlist {
     pub snapshot_id: String,
     pub num_tracks: usize,
     pub tracks: Option<Vec<Track>>,
+    pub collaborative: bool
 }
 
 impl Playlist {
@@ -126,6 +127,7 @@ impl From<&SimplifiedPlaylist> for Playlist {
             snapshot_id: list.snapshot_id.clone(),
             num_tracks,
             tracks: None,
+            collaborative: list.collaborative,
         }
     }
 }
@@ -139,6 +141,7 @@ impl From<&FullPlaylist> for Playlist {
             snapshot_id: list.snapshot_id.clone(),
             num_tracks: list.tracks.total as usize,
             tracks: None,
+            collaborative: list.collaborative
         }
     }
 }

--- a/src/ui/contextmenu.rs
+++ b/src/ui/contextmenu.rs
@@ -38,10 +38,10 @@ impl ContextMenu {
         track: Track,
     ) -> Modal<Dialog> {
         let mut list_select: SelectView<Playlist> = SelectView::new().autojump();
-        let current_user_id = spotify.current_user().unwrap().id;
+        let current_user_id = library.user_id.as_ref().unwrap();
 
         for list in library.items().iter() {
-            if current_user_id == list.owner_id || list.collaborative {
+            if current_user_id == &list.owner_id || list.collaborative {
                 list_select.add_item(list.name.clone(), list.clone());
             }
         }

--- a/src/ui/contextmenu.rs
+++ b/src/ui/contextmenu.rs
@@ -38,9 +38,12 @@ impl ContextMenu {
         track: Track,
     ) -> Modal<Dialog> {
         let mut list_select: SelectView<Playlist> = SelectView::new().autojump();
+        let current_user_id = spotify.current_user().unwrap().id;
 
         for list in library.items().iter() {
-            list_select.add_item(list.name.clone(), list.clone());
+            if current_user_id == list.owner_id || list.collaborative {
+                list_select.add_item(list.name.clone(), list.clone());
+            }
         }
 
         list_select.set_on_submit(move |s, selected| {


### PR DESCRIPTION
Currently all playlists are showed when trying to add a track, this fixes so only playlists where the user is allowed to add tracks are shown.