### PR TITLE
Allow primary selection for sharing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ default-features = false
 
 [features]
 share_clipboard = ["clipboard"]
+share_selection = ["clipboard"] # Use the primary selection for sharing - linux only
 alsa_backend = ["librespot-playback/alsa-backend"]
 pulseaudio_backend = ["librespot-playback/pulseaudio-backend"]
 rodio_backend = ["librespot-playback/rodio-backend"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,7 @@ mod library;
 mod playable;
 mod playlist;
 mod queue;
+mod sharing;
 mod show;
 mod spotify;
 mod theme;

--- a/src/sharing.rs
+++ b/src/sharing.rs
@@ -1,0 +1,35 @@
+#![cfg(feature = "share_clipboard")]
+
+#[cfg(not(feature = "share_selection"))]
+use clipboard::ClipboardContext;
+use clipboard::ClipboardProvider;
+#[cfg(feature = "share_selection")]
+use clipboard::x11_clipboard::{X11ClipboardContext, Primary};
+
+#[cfg(not(feature = "share_selection"))]
+pub fn read_share() -> Option<String> {
+    ClipboardProvider::new()
+        .and_then(|mut ctx: ClipboardContext| ctx.get_contents())
+        .ok()
+}
+
+#[cfg(feature = "share_selection")]
+pub fn read_share() -> Option<String> {
+    ClipboardProvider::new()
+        .and_then(|mut ctx: X11ClipboardContext<Primary>| ctx.get_contents())
+        .ok()
+}
+
+#[cfg(not(feature = "share_selection"))]
+pub fn write_share(url: String) -> Option<()> {
+    ClipboardProvider::new()
+        .and_then(|mut ctx: ClipboardContext| ctx.set_contents(url))
+        .ok()
+}
+
+#[cfg(feature = "share_selection")]
+pub fn write_share(url: String) -> Option<()> {
+    ClipboardProvider::new()
+        .and_then(|mut ctx: X11ClipboardContext<Primary>| ctx.set_contents(url))
+        .ok()
+}

--- a/src/ui/contextmenu.rs
+++ b/src/ui/contextmenu.rs
@@ -7,6 +7,8 @@ use cursive::Cursive;
 use crate::commands::CommandResult;
 use crate::library::Library;
 use crate::queue::Queue;
+#[cfg(feature = "share_clipboard")]
+use crate::sharing::write_share;
 use crate::track::Track;
 use crate::traits::{ListItem, ViewExt};
 use crate::playable::Playable;
@@ -17,8 +19,6 @@ use crate::{
     playlist::Playlist,
     spotify::Spotify,
 };
-#[cfg(feature = "share_clipboard")]
-use clipboard::{ClipboardContext, ClipboardProvider};
 use cursive::traits::{Finder, Nameable};
 
 pub struct ContextMenu {
@@ -137,9 +137,7 @@ impl ContextMenu {
                 }
                 ContextMenuAction::ShareUrl(url) => {
                     #[cfg(feature = "share_clipboard")]
-                    ClipboardProvider::new()
-                        .and_then(|mut ctx: ClipboardContext| ctx.set_contents(url.to_string()))
-                        .ok();
+                    write_share(url.to_string());
                 }
                 ContextMenuAction::AddToPlaylist(track) => {
                     let dialog =


### PR DESCRIPTION
Adds a feature flag to use the primary selection instead of the clipboard. Only works on Linux.