### PR TITLE
Enable mouse scrolling in TabViews

### DIFF
--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -247,8 +247,7 @@ impl View for Layout {
             }
 
             if position.y < self.last_size.y.saturating_sub(2 + cmdline_height) {
-                if let Some(ref id) = self.focus {
-                    let screen = self.views.get_mut(id).unwrap();
+                if let Some(screen) = self.get_current_screen_mut() {
                     screen.view.on_event(event);
                 }
             } else if position.y < self.last_size.y - cmdline_height {

--- a/src/ui/tabview.rs
+++ b/src/ui/tabview.rs
@@ -2,6 +2,7 @@ use std::cmp::{max, min};
 use std::collections::HashMap;
 
 use cursive::align::HAlign;
+use cursive::event::{Event, EventResult};
 use cursive::theme::{ColorStyle, ColorType, PaletteColor};
 use cursive::traits::View;
 use cursive::{Cursive, Printer, Vec2};
@@ -98,6 +99,14 @@ impl View for TabView {
     fn layout(&mut self, size: Vec2) {
         if let Some(tab) = self.tabs.get_mut(self.selected) {
             tab.view.layout(Vec2::new(size.x, size.y - 1));
+        }
+    }
+
+    fn on_event(&mut self, event: Event) -> EventResult {
+        if let Some(tab) = self.tabs.get_mut(self.selected) {
+            tab.view.on_event(event)
+        } else {
+            EventResult::Ignored
         }
     }
 }


### PR DESCRIPTION
Before this patch, we couldn't scroll ListViews contained by TabView with mouse.
This is because the default implementation of `cursive::traits::View::on_event` ignores any event.
This PR fixes the problem by forwarding events properly.