### PR TITLE
Fix not setting correct country/market

### DIFF
--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -306,7 +306,7 @@ impl Spotify {
         spotify.country = spotify
             .current_user()
             .and_then(|u| u.country)
-            .and_then(|c| Country::from_str(&c.as_str()).ok());
+            .and_then(|c| c.parse().ok());
 
         spotify
     }


### PR DESCRIPTION
Previously the country was not set at all. This had the behaviour that when country was required it was defaulted to the US, and when not required it would get all entries ignoring your current market. This had some weird implications especially when looking at an artists albums
![image](https://user-images.githubusercontent.com/3757388/103951679-72751f80-513f-11eb-8438-c2a9e2b3507d.png)

After setting the correct country the list now looks like what I see in the desktop client:

![image](https://user-images.githubusercontent.com/3757388/103951777-989abf80-513f-11eb-8ab5-24cd978bb8b2.png)

