### PR TITLE
patch enumset dependency to work around build failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,8 +940,7 @@ dependencies = [
 [[package]]
 name = "enumset_derive"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74bef436ac71820c5cf768d7af9ba33121246b09a00e09a55d94ef8095a875ac"
+source = "git+https://github.com/ocboogie/enumset?branch=span-fix#4c01c583c27a725948fededbfb3461c572a669a4"
 dependencies = [
  "darling 0.10.2",
  "proc-macro2 1.0.24",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,3 +62,7 @@ termion_backend = ["cursive/termion-backend"]
 mpris = ["dbus", "dbus-tree"]
 notify = ["notify-rust"]
 default = ["share_clipboard", "pulseaudio_backend", "mpris", "notify", "cursive/pancurses-backend"]
+
+[patch.crates-io.enumset_derive]
+git = "https://github.com/ocboogie/enumset"
+branch = "span-fix"


### PR DESCRIPTION
While installing via Cargo, I received `cannot find export in syn` due to an issue with enumset. I found a workaround (link below) and thought I would share since I'm not sure when their permanent fix will be available. Tested locally and build now succeeds.

https://github.com/Lymia/enumset/pull/18#issuecomment-756358826