### PR TITLE
Fix multiple tracks in queue being shown as playing

### DIFF
--- a/src/ui/listview.rs
+++ b/src/ui/listview.rs
@@ -269,10 +269,11 @@ impl<I: ListItem> View for ListView<I> {
                 });
             } else {
                 let item = &content[i];
-                let currently_playing = self.queue.get_current_index() == Some(i);
+                let currently_playing = item.is_playing(self.queue.clone())
+                    && self.queue.get_current_index() == Some(i);
 
                 let style = if self.selected == i {
-                    let fg = if item.is_playing(self.queue.clone()) && currently_playing {
+                    let fg = if currently_playing {
                         *printer.theme.palette.custom("playing_selected").unwrap()
                     } else {
                         PaletteColor::Tertiary.resolve(&printer.theme.palette)
@@ -281,7 +282,7 @@ impl<I: ListItem> View for ListView<I> {
                         ColorType::Color(fg),
                         ColorType::Palette(PaletteColor::Highlight),
                     )
-                } else if item.is_playing(self.queue.clone()) && currently_playing {
+                } else if currently_playing {
                     ColorStyle::new(
                         ColorType::Color(*printer.theme.palette.custom("playing").unwrap()),
                         ColorType::Color(*printer.theme.palette.custom("playing_bg").unwrap()),

--- a/src/ui/listview.rs
+++ b/src/ui/listview.rs
@@ -269,9 +269,10 @@ impl<I: ListItem> View for ListView<I> {
                 });
             } else {
                 let item = &content[i];
+                let currently_playing = self.queue.get_current_index() == Some(i);
 
                 let style = if self.selected == i {
-                    let fg = if item.is_playing(self.queue.clone()) {
+                    let fg = if item.is_playing(self.queue.clone()) && currently_playing {
                         *printer.theme.palette.custom("playing_selected").unwrap()
                     } else {
                         PaletteColor::Tertiary.resolve(&printer.theme.palette)
@@ -280,7 +281,7 @@ impl<I: ListItem> View for ListView<I> {
                         ColorType::Color(fg),
                         ColorType::Palette(PaletteColor::Highlight),
                     )
-                } else if item.is_playing(self.queue.clone()) {
+                } else if item.is_playing(self.queue.clone()) && currently_playing {
                     ColorStyle::new(
                         ColorType::Color(*printer.theme.palette.custom("playing").unwrap()),
                         ColorType::Color(*printer.theme.palette.custom("playing_bg").unwrap()),


### PR DESCRIPTION
Before this fix, when adding duplicates to the queue, all duplicates would be shown as playing:
![Example of multiple tracks being marked as playing](https://user-images.githubusercontent.com/3757388/104819721-ac28e300-582f-11eb-9eaf-7755b5162868.png)

After, only the currently playing track is shown as playing.
![image](https://user-images.githubusercontent.com/3757388/104819731-c95db180-582f-11eb-874f-82ca3f1b4484.png)
