### PR TITLE
Return to search when viewing search results

### DIFF
--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -318,6 +318,15 @@ impl ViewExt for Layout {
     fn on_command(&mut self, s: &mut Cursive, cmd: &Command) -> Result<CommandResult, String> {
         match cmd {
             Command::Focus(view) => {
+                // Clear search results and return to search bar
+                // If trying to focus search screen while already on it
+                let search_view_name = "search";
+                if view == search_view_name && self.focus == Some(search_view_name.into()) {
+                    if let Some(stack) = self.stack.get_mut(search_view_name) {
+                        stack.clear();
+                    }
+                }
+
                 if self.screens.keys().any(|k| k == view) {
                     self.set_screen(view.clone());
                     let screen = self.screens.get_mut(view).unwrap();


### PR DESCRIPTION
With the changes that came from separating the search and search results in commit 18dc6c6 searches now opens a new view with the search results.

If you navigate a bit through the search results and navigate to albums and artists it takes multiple keypresses to return to the search view.

My solution is if you're viewing the search results and press to focus the search view again, the search results are closed and you're returned to the search view.

Fixes #390 