### PR TITLE
Restart queue if pressing play when stopped

### DIFF
--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -400,9 +400,9 @@ fn run_dbus_server(
         });
 
     let method_playpause = {
-        let spotify = spotify.clone();
+        let queue = queue.clone();
         f.method("PlayPause", (), move |m| {
-            spotify.toggleplayback();
+            queue.toggleplayback();
             Ok(vec![m.msg.method_return()])
         })
     };

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -268,10 +268,11 @@ impl Queue {
             PlayerEvent::Playing | PlayerEvent::Paused => {
                 self.spotify.toggleplayback();
             }
-            PlayerEvent::FinishedTrack | PlayerEvent::Stopped => match self.next_index() {
+            PlayerEvent::Stopped => match self.next_index() {
                 Some(_) => self.next(false),
                 None => self.play(0, false, false),
             },
+            _ => ()
         }
     }
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -272,7 +272,7 @@ impl Queue {
                 Some(_) => self.next(false),
                 None => self.play(0, false, false),
             },
-            _ => ()
+            _ => (),
         }
     }
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -7,9 +7,9 @@ use notify_rust::Notification;
 use rand::prelude::*;
 use strum_macros::Display;
 
-use crate::config::Config;
 use crate::playable::Playable;
 use crate::spotify::Spotify;
+use crate::{config::Config, spotify::PlayerEvent};
 
 #[derive(Display, Clone, Copy, PartialEq, Debug, Serialize, Deserialize)]
 pub enum RepeatSetting {
@@ -264,7 +264,15 @@ impl Queue {
     }
 
     pub fn toggleplayback(&self) {
-        self.spotify.toggleplayback();
+        match self.spotify.get_current_status() {
+            PlayerEvent::Playing | PlayerEvent::Paused => {
+                self.spotify.toggleplayback();
+            }
+            PlayerEvent::FinishedTrack | PlayerEvent::Stopped => match self.next_index() {
+                Some(_) => self.next(false),
+                None => self.play(0, false, false),
+            },
+        }
     }
 
     pub fn stop(&self) {

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -890,11 +890,7 @@ impl Spotify {
     }
 
     pub fn toggleplayback(&self) {
-        let status = self
-            .status
-            .read()
-            .expect("could not acquire read lock on player state");
-        match *status {
+        match self.get_current_status() {
             PlayerEvent::Playing => self.pause(),
             PlayerEvent::Paused => self.play(),
             _ => (),


### PR DESCRIPTION
Currently when all tracks in the queue have been played, and the playback has stopped, the play/pause button does nothing.

This PR copies the behaviour from the desktop client, with the queue restarting from the top and starting to play again if play/pause is pressed.

It also fixes a bug where if adding a track after playback had stopped, play/pause did nothing but next track would advance and play the new track in the queue. Now when pressing play/pause it plays the next track in the queue as expected.