### PR TITLE
Fix not handling changed event

### DIFF
--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -202,7 +202,9 @@ impl futures::Future for Worker {
             if let Ok(v01_Async::Ready(Some(event))) = self.player_events.poll() {
                 debug!("librespot player event: {:?}", event);
                 match event {
-                    LibrespotPlayerEvent::Started { .. } | LibrespotPlayerEvent::Loading { .. } => {
+                    LibrespotPlayerEvent::Started { .. }
+                    | LibrespotPlayerEvent::Loading { .. }
+                    | LibrespotPlayerEvent::Changed { .. } => {
                         progress = true;
                     }
                     LibrespotPlayerEvent::Playing { .. } => {


### PR DESCRIPTION
When trying to play an album with an unavailable track, for example https://open.spotify.com/album/3nG37CdJEbz1c7KrOOQn4Z, it would skip to the next available track but the status would be shown as stopped, the progress bar would be frozen but audio was still playing in the background, and the play/pause button would do nothing.

Handling the changed event which is described as "Same as started but in the case that the player already had a track loaded.", the same way as Started/Loading correctly updates the status bar with the right info.