### PR TITLE
Don't handle FinishedTrack as Stopped

### DIFF
--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -28,13 +28,13 @@ type Metadata = HashMap<String, Variant<Box<dyn RefArg>>>;
 
 struct MprisState(String, Option<Playable>);
 
-fn get_playbackstatus(spotify: Arc<Spotify>) -> String {
+fn get_playbackstatus(spotify: Arc<Spotify>) -> Option<String> {
     match spotify.get_current_status() {
-        PlayerEvent::Playing => "Playing",
-        PlayerEvent::Paused => "Paused",
-        _ => "Stopped",
+        PlayerEvent::Playing => Some("Playing".into()),
+        PlayerEvent::Paused => Some("Paused".into()),
+        PlayerEvent::Stopped => Some("Stopped".into()),
+        _ => None,
     }
-    .to_string()
 }
 
 fn get_metadata(playable: Option<Playable>) -> Metadata {
@@ -224,8 +224,9 @@ fn run_dbus_server(
         f.property::<String, _>("PlaybackStatus", ())
             .access(Access::Read)
             .on_get(move |iter, _| {
-                let status = get_playbackstatus(spotify.clone());
-                iter.append(status);
+                if let Some(status) = get_playbackstatus(spotify.clone()) {
+                    iter.append(status);
+                }
                 Ok(())
             })
     };
@@ -699,8 +700,9 @@ impl MprisManager {
     }
 
     pub fn update(&self) {
-        let status = get_playbackstatus(self.spotify.clone());
-        let track = self.queue.get_current();
-        self.tx.send(MprisState(status, track)).unwrap();
+        if let Some(status) = get_playbackstatus(self.spotify.clone()) {
+            let track = self.queue.get_current();
+            self.tx.send(MprisState(status, track)).unwrap();
+        }
     }
 }


### PR DESCRIPTION
Currently FinishedTrack and Stopped both returned "Stopped" leading mpris to report stopped after every track and then playing again when the new track starts.

Not sure if I am allowed to not return a value when we don't have a valid PlaybackState value. The [docs](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:PlaybackStatussays ) for the PlaybackState states "When this property changes, the org.freedesktop.DBus.Properties.PropertiesChanged signal is emitted with the new value." 

but I'm not very knowledgeable with DBus. 

I've not encountered any weird behaviour using the same debugging technique described in #395.

Fixes #395 