### PR TITLE
Add simple debian-packaging with cargo-deb

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,3 +63,17 @@ termion_backend = ["cursive/termion-backend"]
 mpris = ["dbus", "dbus-tree"]
 notify = ["notify-rust"]
 default = ["share_clipboard", "pulseaudio_backend", "mpris", "notify", "cursive/pancurses-backend"]
+
+[package.metadata.deb]
+depends = "$auto, pulseaudio"
+section = "sound"
+priority = "optional"
+extended-description = """\
+ncurses Spotify client written in Rust using librespot. \
+It is heavily inspired by ncurses MPD clients, such as ncmpc."""
+license-file = ["LICENSE"]
+assets = [
+    ["target/release/ncspot", "usr/bin/", "755"],
+    ["README.md", "usr/share/doc/ncspot/README.md", "644"],
+]
+

--- a/README.md
+++ b/README.md
@@ -52,6 +52,23 @@ For Fedora, these dependencies are required:
 dnf install pulseaudio-libs-devel libxcb-devel openssl-devel ncurses-devel dbus-devel
 ```
 
+#### Building a Debian Package
+
+You can use `cargo-deb` create in order to build a Debian package from source. Install it by:
+
+```
+cargo install cargo-deb
+```
+
+Then you can build a Dabian package with:
+
+```
+cargo deb
+```
+
+You can find it under `target/debian`.
+
+
 ## Usage
 
 * Install the latest ncspot release using `cargo install ncspot`


### PR DESCRIPTION
This adds simple debian-packaging with cargo-deb.

I have seen this on https://github.com/Spotifyd/spotifyd, but I like ncspot much more, so I added it to the Cargo.toml and updated the Readme.md how to build a debian-package.