### PR TITLE
modified library.rs to sort after saving an album

### DIFF
--- a/src/library.rs
+++ b/src/library.rs
@@ -646,6 +646,11 @@ impl Library {
             let mut store = self.albums.write().unwrap();
             if !store.iter().any(|a| a.id == album.id) {
                 store.insert(0, album.clone());
+
+                // resort list of albums
+                store.sort_unstable_by_key(|a| {
+                    format!("{}{}{}", a.artists[0], a.year, a.title)
+                });
             }
         }
 


### PR DESCRIPTION
Hello.  I just started using ncspot and found that the list of albums in the library were not sorted after saving a new one (say from the list of albums in some search results).  Is this a design decision?  If so, please ignore this.  If not, here's a very quick and dirty fix.