### PR TITLE
Improve album loading in artist view

### DIFF
--- a/src/artist.rs
+++ b/src/artist.rs
@@ -43,7 +43,7 @@ impl Artist {
         }
 
         if let Some(ref artist_id) = self.id {
-            let mut collected_albums: Vec<Album> = Vec::new();
+            let mut collected_ids: Vec<String> = Vec::new();
             let mut offset = 0;
             while let Some(sas) = spotify.artist_albums(artist_id, 50, offset) {
                 let items_len = sas.items.len() as u32;
@@ -54,9 +54,7 @@ impl Artist {
                         continue;
                     }
                     if let Some(album_id) = sa.id {
-                        if let Some(fa) = spotify.full_album(&album_id).as_ref() {
-                            collected_albums.push(fa.into());
-                        }
+                        collected_ids.push(album_id);
                     }
                 }
 
@@ -65,7 +63,12 @@ impl Artist {
                     None => break,
                 }
             }
-            self.albums = Some(collected_albums);
+
+            let albums = match spotify.albums(&collected_ids) {
+                Some(fas) => fas.iter().map(Album::from).collect(),
+                None => Vec::new(),
+            };
+            self.albums = Some(albums);
         }
     }
 

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -653,6 +653,16 @@ impl Spotify {
         self.api_with_retry(|api| api.album(album_id))
     }
 
+    pub fn albums(&self, album_ids: &[String]) -> Option<Vec<FullAlbum>> {
+        const MAX_SIZE: usize = 20;
+        let mut collected = Vec::new();
+        for ids in album_ids.chunks(MAX_SIZE) {
+            let fas = self.api_with_retry(|api| api.albums(ids.to_vec()))?;
+            collected.extend_from_slice(&fas.albums);
+        }
+        Some(collected)
+    }
+
     pub fn artist(&self, artist_id: &str) -> Option<FullArtist> {
         self.api_with_retry(|api| api.artist(artist_id))
     }


### PR DESCRIPTION
This PR improves album loading in artist view in the following 2 points:
1. Show all the albums (currently at most 50 albums are shown in artist view.)
2. Reduce API requests by batching