### PR TITLE
Refactor needs_download and rename library.items to better convey usage

### DIFF
--- a/src/library.rs
+++ b/src/library.rs
@@ -60,10 +60,8 @@ impl Library {
         library
     }
 
-    pub fn items(&self) -> RwLockReadGuard<Vec<Playlist>> {
-        self.playlists
-            .read()
-            .expect("could not readlock listview content")
+    pub fn playlists(&self) -> RwLockReadGuard<Vec<Playlist>> {
+        self.playlists.read().expect("can't readlock playlists")
     }
 
     fn load_cache<T: DeserializeOwned>(&self, cache_path: PathBuf, store: Arc<RwLock<Vec<T>>>) {
@@ -99,9 +97,7 @@ impl Library {
     }
 
     fn needs_download(&self, remote: &SimplifiedPlaylist) -> bool {
-        self.playlists
-            .read()
-            .expect("can't readlock playlists")
+        self.playlists()
             .iter()
             .find(|local| local.id == remote.id)
             .and_then(|local| Some(local.snapshot_id != remote.snapshot_id))

--- a/src/library.rs
+++ b/src/library.rs
@@ -99,17 +99,13 @@ impl Library {
     }
 
     fn needs_download(&self, remote: &SimplifiedPlaylist) -> bool {
-        for local in self
-            .playlists
+        self.playlists
             .read()
             .expect("can't readlock playlists")
             .iter()
-        {
-            if local.id == remote.id {
-                return local.snapshot_id != remote.snapshot_id;
-            }
-        }
-        true
+            .find(|local| local.id == remote.id)
+            .and_then(|local| Some(local.snapshot_id != remote.snapshot_id))
+            .unwrap_or(true)
     }
 
     fn append_or_update(&self, updated: &Playlist) -> usize {

--- a/src/ui/contextmenu.rs
+++ b/src/ui/contextmenu.rs
@@ -51,7 +51,7 @@ impl ContextMenu {
         let mut list_select: SelectView<Playlist> = SelectView::new();
         let current_user_id = library.user_id.as_ref().unwrap();
 
-        for list in library.items().iter() {
+        for list in library.playlists().iter() {
             if current_user_id == &list.owner_id || list.collaborative {
                 list_select.add_item(list.name.clone(), list.clone());
             }

--- a/src/ui/playlists.rs
+++ b/src/ui/playlists.rs
@@ -27,8 +27,8 @@ impl PlaylistsView {
     }
 
     pub fn delete_dialog(&mut self) -> Option<Modal<Dialog>> {
-        let store = self.library.items();
-        let current = store.get(self.list.get_selected_index());
+        let playlists = self.library.playlists();
+        let current = playlists.get(self.list.get_selected_index());
 
         if let Some(playlist) = current {
             let library = self.library.clone();

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -67,7 +67,7 @@ impl QueueView {
         let mut list_select: SelectView<Option<String>> = SelectView::new().autojump();
         list_select.add_item("[Create new]", None);
 
-        for list in library.items().iter() {
+        for list in library.playlists().iter() {
             list_select.add_item(list.name.clone(), Some(list.id.clone()));
         }
 


### PR DESCRIPTION
Use .find() instead of for each loop to find playlist.

Just thought it made it clearer than before.

Saw that library had a function called .items() which only returned the playlists so I reused it in needs_download and renamed it to .playlists() since that is what it returns.