### PR TITLE
Refactor all .filter.map chains to .filter_map

### DIFF
--- a/src/album.rs
+++ b/src/album.rs
@@ -69,12 +69,7 @@ impl From<&SimplifiedAlbum> for Album {
             id: sa.id.clone(),
             title: sa.name.clone(),
             artists: sa.artists.iter().map(|sa| sa.name.clone()).collect(),
-            artist_ids: sa
-                .artists
-                .iter()
-                .filter(|a| a.id.is_some())
-                .map(|sa| sa.id.clone().unwrap())
-                .collect(),
+            artist_ids: sa.artists.iter().filter_map(|a| a.id.clone()).collect(),
             year: sa
                 .release_date
                 .clone()
@@ -105,12 +100,7 @@ impl From<&FullAlbum> for Album {
             id: Some(fa.id.clone()),
             title: fa.name.clone(),
             artists: fa.artists.iter().map(|sa| sa.name.clone()).collect(),
-            artist_ids: fa
-                .artists
-                .iter()
-                .filter(|a| a.id.is_some())
-                .map(|sa| sa.id.clone().unwrap())
-                .collect(),
+            artist_ids: fa.artists.iter().filter_map(|a| a.id.clone()).collect(),
             year: fa.release_date.split('-').next().unwrap().into(),
             cover_url: fa.images.get(0).map(|i| i.url.clone()),
             url: Some(fa.uri.clone()),
@@ -154,14 +144,10 @@ impl ListItem for Album {
                 .read()
                 .unwrap()
                 .iter()
-                .filter(|t| t.id().is_some())
-                .map(|t| t.id().unwrap())
+                .filter_map(|t| t.id())
                 .collect();
-            let ids: Vec<String> = tracks
-                .iter()
-                .filter(|t| t.id.is_some())
-                .map(|t| t.id.clone().unwrap())
-                .collect();
+
+            let ids: Vec<String> = tracks.iter().filter_map(|t| t.id.clone()).collect();
             !ids.is_empty() && playing == ids
         } else {
             false

--- a/src/artist.rs
+++ b/src/artist.rs
@@ -135,14 +135,9 @@ impl ListItem for Artist {
                 .read()
                 .unwrap()
                 .iter()
-                .filter(|t| t.id().is_some())
-                .map(|t| t.id().unwrap())
+                .filter_map(|t| t.id())
                 .collect();
-            let ids: Vec<String> = tracks
-                .iter()
-                .filter(|t| t.id.is_some())
-                .map(|t| t.id.clone().unwrap())
-                .collect();
+            let ids: Vec<String> = tracks.iter().filter_map(|t| t.id.clone()).collect();
             !ids.is_empty() && playing == ids
         } else {
             false

--- a/src/library.rs
+++ b/src/library.rs
@@ -551,13 +551,7 @@ impl Library {
         if api
             && self
                 .spotify
-                .current_user_saved_tracks_add(
-                    tracks
-                        .iter()
-                        .filter(|t| t.id.is_some())
-                        .map(|t| t.id.clone().unwrap())
-                        .collect(),
-                )
+                .current_user_saved_tracks_add(tracks.iter().filter_map(|t| t.id.clone()).collect())
                 .is_none()
         {
             return;
@@ -591,11 +585,7 @@ impl Library {
             && self
                 .spotify
                 .current_user_saved_tracks_delete(
-                    tracks
-                        .iter()
-                        .filter(|t| t.id.is_some())
-                        .map(|t| t.id.clone().unwrap())
-                        .collect(),
+                    tracks.iter().filter_map(|t| t.id.clone()).collect(),
                 )
                 .is_none()
         {

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -101,8 +101,7 @@ impl Playlist {
         let track_ids: Vec<String> = new_tracks
             .to_vec()
             .iter()
-            .filter(|t| t.id.is_some())
-            .map(|t| t.id.clone().unwrap())
+            .filter_map(|t| t.id.clone())
             .collect();
 
         let mut has_modified = false;
@@ -214,14 +213,9 @@ impl ListItem for Playlist {
                 .read()
                 .unwrap()
                 .iter()
-                .filter(|t| t.id().is_some())
-                .map(|t| t.id().unwrap())
+                .filter_map(|t| t.id())
                 .collect();
-            let ids: Vec<String> = tracks
-                .iter()
-                .filter(|t| t.id.is_some())
-                .map(|t| t.id.clone().unwrap())
-                .collect();
+            let ids: Vec<String> = tracks.iter().filter_map(|t| t.id.clone()).collect();
             !ids.is_empty() && playing == ids
         } else {
             false

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -594,11 +594,7 @@ impl Spotify {
 
     pub fn overwrite_playlist(&self, id: &str, tracks: &[Playable]) {
         // extract only track IDs
-        let mut tracks: Vec<String> = tracks
-            .iter()
-            .filter(|track| track.id().is_some())
-            .map(|track| track.id().unwrap())
-            .collect();
+        let mut tracks: Vec<String> = tracks.iter().filter_map(|track| track.id()).collect();
 
         // we can only send 100 tracks per request
         let mut remainder = if tracks.len() > 100 {

--- a/src/track.rs
+++ b/src/track.rs
@@ -37,18 +37,17 @@ impl Track {
         let artists = track
             .artists
             .iter()
-            .map(|ref artist| artist.name.clone())
+            .map(|artist| artist.name.clone())
             .collect::<Vec<String>>();
         let artist_ids = track
             .artists
             .iter()
-            .filter(|a| a.id.is_some())
-            .map(|ref artist| artist.id.clone().unwrap())
+            .filter_map(|a| a.id.clone())
             .collect::<Vec<String>>();
         let album_artists = album
             .artists
             .iter()
-            .map(|ref artist| artist.name.clone())
+            .map(|artist| artist.name.clone())
             .collect::<Vec<String>>();
 
         Self {
@@ -87,8 +86,7 @@ impl From<&SimplifiedTrack> for Track {
         let artist_ids = track
             .artists
             .iter()
-            .filter(|a| a.id.is_some())
-            .map(|ref artist| artist.id.clone().unwrap())
+            .filter_map(|a| a.id.clone())
             .collect::<Vec<String>>();
 
         Self {
@@ -121,8 +119,7 @@ impl From<&FullTrack> for Track {
         let artist_ids = track
             .artists
             .iter()
-            .filter(|a| a.id.is_some())
-            .map(|ref artist| artist.id.clone().unwrap())
+            .filter_map(|a| a.id.clone())
             .collect::<Vec<String>>();
         let album_artists = track
             .album


### PR DESCRIPTION
Combines all .filter.map chains with a single call to .filter_map instead.

`.filter` yields if closure returns `true`, `.filter_map` yields if closure returns `Some()`