### PR TITLE
Allow creation of default userstate.toml file

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -65,6 +65,7 @@ pub struct QueueState {
     pub current_track: Option<usize>,
     pub random_order: Option<Vec<usize>>,
     pub track_progress: std::time::Duration,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub queue: Vec<Playable>,
 }
 


### PR DESCRIPTION
Serializing an empty `Vec<Playable>` causes serde to panic as described
in #485 This commit tells serde not to serialize `queue` if it is an
empty `Vec`.