### PR TITLE
Add rounding to volume percentage display

### DIFF
--- a/src/ui/statusbar.rs
+++ b/src/ui/statusbar.rs
@@ -125,7 +125,7 @@ impl View for StatusBar {
 
         let volume = format!(
             " [{}%]",
-            (self.spotify.volume() as f64 / 65535_f64 * 100.0) as u16
+            (self.spotify.volume() as f64 / 65535_f64 * 100.0).round() as u16
         );
 
         printer.with_color(style_bar_bg, |printer| {


### PR DESCRIPTION
Shown percentage is sometimes lower than actual because float number is cast to u16 without rounding, so for example 4.99_f64 becomes 4_u16. It's seen for example when pressing "volup 5" when volume is at 0%. When you do that the bar displays 4%.
![image](https://user-images.githubusercontent.com/34860241/115110425-aac89d00-9f7b-11eb-920e-d77dee9c61a7.png)
