### PR TITLE
Make behavior of Shift modifier consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ depending on your desktop environment settings. Have a look at the
 * `r` to toggle repeat mode
 * `z` to toggle shuffle playback
 * `q` quits ncspot
-* `x` copies a sharable URL of the song to the system clipboard
-* `Shift-x` copies a sharable URL of the currently selected item to the system clipboard
+* `x` copies a sharable URL of the currently selected item to the system clipboard
+* `Shift-x` copies a sharable URL of the currently playing track to the system clipboard
 
 Use `/` to open a Vim-like search bar, you can use `n` and `N` to go for the next/previous
 search occurrence, respectivly.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -375,8 +375,8 @@ impl CommandManager {
 
         kb.insert("r".into(), Command::Repeat(None));
         kb.insert("z".into(), Command::Shuffle(None));
-        kb.insert("x".into(), Command::Share(TargetMode::Current));
-        kb.insert("Shift+x".into(), Command::Share(TargetMode::Selected));
+        kb.insert("x".into(), Command::Share(TargetMode::Selected));
+        kb.insert("Shift+x".into(), Command::Share(TargetMode::Current));
 
         kb.insert("F1".into(), Command::Focus("queue".into()));
         kb.insert("F2".into(), Command::Focus("search".into()));


### PR DESCRIPTION
Previously, Shift+o opened the menu for the currently playing item
while Shift+x copied a link to the currently selected item. Now Shift
operates on the currently playing item in both cases.

Fixes #516.