### PR TITLE
Use ▶ icon in stopped state

### DIFF
--- a/src/ui/statusbar.rs
+++ b/src/ui/statusbar.rs
@@ -72,15 +72,13 @@ impl View for StatusBar {
 
         let state_icon = if self.use_nerdfont {
             match self.spotify.get_current_status() {
-                PlayerEvent::Paused(_) => "\u{f909} ",
+                PlayerEvent::Paused(_) | PlayerEvent::Stopped | PlayerEvent::FinishedTrack => "\u{f909} ",
                 PlayerEvent::Playing(_) => "\u{f8e3} ",
-                PlayerEvent::Stopped | PlayerEvent::FinishedTrack => "\u{f9da} ",
             }
         } else {
             match self.spotify.get_current_status() {
-                PlayerEvent::Paused(_) => "▶ ",
+                PlayerEvent::Paused(_) | PlayerEvent::Stopped | PlayerEvent::FinishedTrack => "▶ ",
                 PlayerEvent::Playing(_) => "▮▮",
-                PlayerEvent::Stopped | PlayerEvent::FinishedTrack => "◼ ",
             }
         }
         .to_string();


### PR DESCRIPTION
This is a small follow-up to #511 that changes the status bar icon for the 'stopped' state to ▶ (to make it consistent with the 'paused' state).