### PR TITLE
Fix nerdfont pause/stop glyphs

### DIFF
--- a/src/ui/statusbar.rs
+++ b/src/ui/statusbar.rs
@@ -46,8 +46,8 @@ impl StatusBar {
             .unwrap_or(false);
 
         const NF_PLAY: &str = "\u{f909} ";
-        const NF_PAUSE: &str = "\u{f909} ";
-        const NF_STOP: &str = "\u{f909} ";
+        const NF_PAUSE: &str = "\u{f8e3} ";
+        const NF_STOP: &str = "\u{f9da} ";
         let indicators = match (nerdfont, flipped) {
             (false, false) => ("▶ ", "▮▮", "◼ "),
             (false, true) => ("▮▮", "▶ ", "▶ "),


### PR DESCRIPTION
b42315d accidentally changed both of these to the glyph for play, this reverts them back to the correct glyphs.