### PR TITLE
Add Windows instructions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,6 +1898,7 @@ dependencies = [
  "librespot-protocol",
  "log",
  "notify-rust",
+ "pancurses",
  "platform-dirs",
  "rand 0.8.3",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ strum_macros = "0.21.1"
 regex = "1"
 ioctl-rs = { version = "0.2", optional = true }
 serde_cbor = "0.11.1"
+pancurses = { version = "0.16.1", features = ["win32"] }
 
 [dependencies.cursive]
 version = "0.16.3"

--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ cargo deb
 You can find it under `target/debian`.
 
 
+### On Windows
+
+Make sure you're using MSVC toolchain
+
+```
+cargo install ncspot --no-default-features --features rodio_backend,cursive/pancurses-backend
+```
+
 ## Usage
 
 * Install the latest ncspot release using `cargo install ncspot`
@@ -173,7 +181,7 @@ To close the commandprompt at any time, press `esc`.
 
 ## Configuration
 
-Configuration is saved to `~/.config/ncspot/config.toml`. To reload the
+Configuration is saved to `~/.config/ncspot/config.toml` (or `%AppData%\ncspot\config.toml` on Windows). To reload the
 configuration during runtime use the `reload` statement in the command prompt
 `:reload`.
 
@@ -255,7 +263,7 @@ To allow scaling the album art up beyond its resolution (640x640 for Spotify cov
 cover_max_scale = 2
 ```
 
-### Authentication 
+### Authentication
 
 `ncspot` prompts for a Spotify username and password on first launch, uses this to generate an OAuth token, and stores it to disk.
 


### PR DESCRIPTION
This follows from https://github.com/hrkfdn/ncspot/issues/23#issuecomment-603955270

Closes #254 

The CD can be setup for Windows releases too, see here https://github.com/42wim/ncspot/blob/master/.github/workflows/cd.yml

Once a release has been made, I'll make a PR in the scoop repos so that ncspot can be installed directly via scoop (like brew).