### PR TITLE
feat: Ability to set a custom config filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ Configuration is saved to `~/.config/ncspot/config.toml` (or `%AppData%\ncspot\c
 configuration during runtime use the `reload` statement in the command prompt
 `:reload`.
 
+If a different config filename should be used, within the same directory, it can be set by the environment variable `NCSPOT_CONFIG_FILE` e.g `NCSPOT_CONFIG_FILE=alternative.toml`
+
 Possible configuration values are:
 
 * `use_nerdfont`: Turn nerdfont glyphs on/off <true/false>

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
-use std::{fs, process, env};
+use std::{env, fs, process};
 
 use cursive::theme::Theme;
 use log::{debug, error};
@@ -166,7 +166,7 @@ impl Config {
 }
 
 fn load() -> Result<ConfigValues, String> {
-        let config_filename = match env::var(ALT_CONFIG_FILENAME) {
+    let config_filename = match env::var(ALT_CONFIG_FILENAME) {
         Ok(val) => val,
         Err(_e) => "config.toml".to_string(),
     };

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
-use std::{fs, process};
+use std::{fs, process, env};
 
 use cursive::theme::Theme;
 use log::{debug, error};
@@ -13,6 +13,7 @@ use crate::queue;
 use crate::serialization::{Serializer, CBOR, TOML};
 
 pub const CLIENT_ID: &str = "d420a117a32841c2b3474932e49fb54b";
+pub const ALT_CONFIG_FILENAME: &str = "NCSPOT_CONFIG_FILE";
 
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
 pub struct ConfigValues {
@@ -165,7 +166,12 @@ impl Config {
 }
 
 fn load() -> Result<ConfigValues, String> {
-    let path = config_path("config.toml");
+        let config_filename = match env::var(ALT_CONFIG_FILENAME) {
+        Ok(val) => val,
+        Err(_e) => "config.toml".to_string(),
+    };
+
+    let path = config_path(&config_filename);
     TOML.load_or_generate_default(path, || Ok(ConfigValues::default()), false)
 }
 


### PR DESCRIPTION
Through `NCSPOT_CONFIG_FILE` env var a custom
configuration filename e.g "dark.toml" can
be specified

I use this with two different files "light.toml" and "dark.toml" to use different colors when my terminal colors are for daylight or nighttime