### PR TITLE
Enable binding multiple commands to a key.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -288,13 +288,15 @@ async fn main() -> Result<(), String> {
                 }
             } else {
                 let parsed = command::parse(cmd_without_prefix);
-                if let Some(parsed) = parsed {
+                if let Some(commands) = parsed {
                     if let Some(data) = s.user_data::<UserData>().cloned() {
-                        data.cmd.handle(s, parsed)
+                        for cmd in commands {
+                            data.cmd.handle(s, cmd);
+                        }
                     }
                 } else {
                     let mut main = s.find_name::<ui::layout::Layout>("main").unwrap();
-                    let err_msg = format!("Unknown command: \"{}\"", cmd_without_prefix);
+                    let err_msg = format!("Failed to parse command(s): \"{}\"", cmd_without_prefix);
                     main.set_result(Err(err_msg));
                 }
             }

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -17,7 +17,7 @@ pub struct HelpView {
 }
 
 impl HelpView {
-    pub fn new(bindings: HashMap<String, Command>) -> HelpView {
+    pub fn new(bindings: HashMap<String, Vec<Command>>) -> HelpView {
         let mut text = StyledString::styled("Keybindings\n\n", Effect::Bold);
 
         let note = format!(
@@ -30,8 +30,16 @@ impl HelpView {
         keys.sort();
 
         for key in keys {
-            let command = &bindings[key];
-            let binding = format!("{} -> {}\n", key, command);
+            let commands = &bindings[key];
+            let binding = format!(
+                "{} -> {}\n",
+                key,
+                commands
+                    .iter()
+                    .map(|c| c.to_string())
+                    .collect::<Vec<_>>()
+                    .join("; ")
+            );
             text.append(binding);
         }
 


### PR DESCRIPTION
This enables useful combinations of commands like `Space -> queue; move
down 1` using ';' as command separator. ';' can be escaped using ';;'.