### PR TITLE
Add `userRating` entity to mpris metadata

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -186,14 +186,15 @@ async fn main() -> Result<(), String> {
 
     let queue = Arc::new(queue::Queue::new(spotify.clone(), cfg.clone()));
 
+    let library = Arc::new(Library::new(&event_manager, spotify.clone(), cfg.clone()));
+
     #[cfg(feature = "mpris")]
     let mpris_manager = Arc::new(mpris::MprisManager::new(
         event_manager.clone(),
         spotify.clone(),
         queue.clone(),
+        library.clone(),
     ));
-
-    let library = Arc::new(Library::new(&event_manager, spotify.clone(), cfg.clone()));
 
     let mut cmd_manager = CommandManager::new(
         spotify.clone(),


### PR DESCRIPTION
This PR enables MPRIS metadata output sent over D-Bus to output the saved/unsaved status of a track, with 0 and 1 corresponding to unsaved/not-liked and saved/liked in Spotify, respectively. This is in accordance with the [mpris-spec](https://www.freedesktop.org/wiki/Specifications/mpris-spec/metadata/). Addresses #623.