### PR TITLE
fix inconsistency in help message and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ depending on your desktop environment settings. Have a look at the
       * "Similar tracks"
 * `Shift-o` will open a context menu for the currently playing track
 * `a` will open the album view for the selected item
-* `A` will open the artist view for the selected item
+* `Shift-a` will open the artist view for the selected item
 * `m` will open a view with recommendations based on the selected item
-* `M` will open a view with recommendations based on the currently playing track
+* `Shift-m` will open a view with recommendations based on the currently playing track
 * `Ctrl-v` will open the context menu for a Spotify link in your clipboard
 * `Backspace` closes the current view
 * `Shift-p` toggles playback of a track (play/pause)

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -415,14 +415,14 @@ impl CommandManager {
         kb.insert("o".into(), vec![Command::Open(TargetMode::Selected)]);
         kb.insert("Shift+o".into(), vec![Command::Open(TargetMode::Current)]);
         kb.insert("a".into(), vec![Command::Goto(GotoMode::Album)]);
-        kb.insert("A".into(), vec![Command::Goto(GotoMode::Artist)]);
+        kb.insert("Shift+a".into(), vec![Command::Goto(GotoMode::Artist)]);
 
         kb.insert(
             "m".into(),
             vec![Command::ShowRecommendations(TargetMode::Selected)],
         );
         kb.insert(
-            "M".into(),
+            "Shift+m".into(),
             vec![Command::ShowRecommendations(TargetMode::Current)],
         );
 


### PR DESCRIPTION
Just a little fix in consistency. 
I don't know if there was a reason for `A` and `M` being the only ones without `Shift` prefixed. 