### PR TITLE
[Docs] Fix link to theming section in configuration table

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Possible configuration values are:
 | `gapless`                | Enable gapless playback                     | `true`, `false`                                   |   `false`   |
 | `shuffle`                | Set default shuffle state                   | `true`, `false`                                   |   `false`   |
 | `repeat`                 | Set default repeat mode                     | `off`, `track`, `playlist`                        |    `off`    |
-| `[theme]`                | Custom theme                                | See [custom theme](<(#theming)>)                  |             |
+| `[theme]`                | Custom theme                                | See [custom theme](#theming)                      |             |
 | `[keybindings]`          | Custom keybindings                          | See [custom keybindings](<(#custom-keybindings)>) |             |
 
 [^1]:

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ Possible configuration values are:
 | `shuffle`                | Set default shuffle state                   | `true`, `false`                                   |   `false`   |
 | `repeat`                 | Set default repeat mode                     | `off`, `track`, `playlist`                        |    `off`    |
 | `[theme]`                | Custom theme                                | See [custom theme](#theming)                      |             |
-| `[keybindings]`          | Custom keybindings                          | See [custom keybindings](<(#custom-keybindings)>) |             |
+| `[keybindings]`          | Custom keybindings                          | See [custom keybindings](#custom-keybindings)     |             |
 
 [^1]:
     By default the statusbar will show a play icon when a track is playing and


### PR DESCRIPTION
First of all thanks for this software, it's quickly become my main Spotify client!

This PR fixes up 2 broken markdown anchor links in the "Configuration" section