### PR TITLE
Improved `seek` command to allow more units

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,7 +611,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "libc",
  "log",
- "num",
+ "num 0.3.1",
  "owning_ref",
  "syn",
  "unicode-segmentation",
@@ -1470,7 +1470,7 @@ dependencies = [
  "hyper-proxy",
  "librespot-protocol",
  "log",
- "num-bigint",
+ "num-bigint 0.4.3",
  "num-integer",
  "num-traits",
  "once_cell",
@@ -1738,6 +1738,7 @@ dependencies = [
  "log",
  "notify-rust",
  "pancurses 0.17.0",
+ "parse_duration",
  "platform-dirs",
  "rand",
  "regex",
@@ -1921,14 +1922,39 @@ dependencies = [
 
 [[package]]
 name = "num"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
+dependencies = [
+ "num-bigint 0.2.6",
+ "num-complex 0.2.4",
+ "num-integer",
+ "num-iter",
+ "num-rational 0.2.4",
+ "num-traits",
+]
+
+[[package]]
+name = "num"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7a8e9be5e039e2ff869df49155f1c06bd01ade2117ec783e56ab0932b67a8f"
 dependencies = [
- "num-complex",
+ "num-complex 0.3.1",
  "num-integer",
  "num-iter",
- "num-rational",
+ "num-rational 0.3.2",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -1942,6 +1968,16 @@ dependencies = [
  "num-integer",
  "num-traits",
  "rand",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+dependencies = [
+ "autocfg",
+ "num-traits",
 ]
 
 [[package]]
@@ -1981,6 +2017,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
+dependencies = [
+ "autocfg",
+ "num-bigint 0.2.6",
  "num-integer",
  "num-traits",
 ]
@@ -2257,6 +2305,17 @@ dependencies = [
  "redox_syscall 0.2.10",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "parse_duration"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7037e5e93e0172a5a96874380bf73bc6ecef022e26fa25f2be26864d6b3ba95d"
+dependencies = [
+ "lazy_static 1.4.0",
+ "num 0.2.1",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ ioctl-rs = { version = "0.2", optional = true }
 serde_cbor = "0.11.2"
 pancurses = { version = "0.17.0", features = ["win32"], optional = true }
 libc = "0.2.111"
+parse_duration = "2.1.1"
 
 [dependencies.rspotify]
 version = "0.11.3"

--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ The following commands are supported:
 | `logout` | Remove any cached credentials from disk and quit `ncspot`. |
 | `toggle` | Toggle playback. |
 | `stop` | Stop playback. |
+| `seek [+\|-]<time>` | Seek to the specified position, or seek relative to current position by prepending `+`/`-`. Supports mixing time units (e.g. `seek 1m42s`). Default unit is `millisecond`. |
 | `previous` | Play previous track. |
 | `next` | Play next track. |
 | `clear` | Clear playlist. |

--- a/src/command.rs
+++ b/src/command.rs
@@ -395,7 +395,9 @@ pub fn parse(input: &str) -> Option<Vec<Command>> {
                     .and_then(|millis| {
                         match first_char {
                             // handle i32::MAX < millis < u32::MAX gracefully
-                            Some('+') => i32::try_from(millis).ok().map(|signed| SeekDirection::Relative(signed)),
+                            Some('+') => i32::try_from(millis)
+                                .ok()
+                                .map(|signed| SeekDirection::Relative(signed)),
                             Some('-') => i32::try_from(millis)
                                 .ok()
                                 .map(|signed| SeekDirection::Relative(-signed)),

--- a/src/command.rs
+++ b/src/command.rs
@@ -377,29 +377,33 @@ pub fn parse(input: &str) -> Option<Vec<Command>> {
 
                 Some(Command::Repeat(mode))
             }
-            "seek" => args.get(0).and_then(|arg| match arg.chars().next() {
-                Some(x) if x == '-' || x == '+' => arg
-                    .chars()
-                    .skip(1)
-                    .collect::<String>()
-                    .parse::<i32>()
+            "seek" => {
+                let arg = args.join(" ");
+                let first_char = arg.chars().next();
+                let unsigned_amount_raw = match first_char {
+                    Some('+' | '-') => arg.chars().skip(1).collect(),
+                    _ => arg.to_string(),
+                };
+                unsigned_amount_raw
+                    .parse::<u32>() // accept raw milliseconds for backward compatibility
                     .ok()
-                    .map(|amount| {
-                        Command::Seek(SeekDirection::Relative(
-                            amount
-                                * match x {
-                                    '-' => -1,
-                                    _ => 1,
-                                },
-                        ))
-                    }),
-                _ => arg
-                    .chars()
-                    .collect::<String>()
-                    .parse()
-                    .ok()
-                    .map(|amount| Command::Seek(SeekDirection::Absolute(amount))),
-            }),
+                    .or_else(|| {
+                        parse_duration::parse(&unsigned_amount_raw) // accept fancy duration
+                            .ok()
+                            .and_then(|dur| dur.as_millis().try_into().ok())
+                    })
+                    .and_then(|millis| {
+                        match first_char {
+                            // handle i32::MAX < millis < u32::MAX gracefully
+                            Some('+') => i32::try_from(millis).ok().map(|signed| SeekDirection::Relative(signed)),
+                            Some('-') => i32::try_from(millis)
+                                .ok()
+                                .map(|signed| SeekDirection::Relative(-signed)),
+                            _ => Some(SeekDirection::Absolute(millis)),
+                        }
+                        .map(|direction| Command::Seek(direction))
+                    })
+            }
             "focus" => args
                 .get(0)
                 .map(|target| Command::Focus((*target).to_string())),


### PR DESCRIPTION
I changed the `seek` command to use [parse_duration](https://docs.rs/parse_duration/latest/parse_duration/), so now it accepts not only milliseconds as input but also more convenient units (mix and match capability included). I think this is a good quality-of-life improvement.

![new_seek](https://user-images.githubusercontent.com/28627918/147419665-67d8de01-80c4-41ee-a507-69d38842970b.gif)
