### PR TITLE
More detailed error message in case of command parse error

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -309,8 +309,8 @@ pub fn parse(input: &str) -> Result<Vec<Command>, CommandParseError> {
             // https://docs.rs/regex/latest/regex/#example-avoid-compiling-the-same-regex-in-a-loop
             static ref CONTINUOUS_SPACE_MATCHER: Regex = Regex::new(r" +").unwrap();
         }
-        let commands_sanitised = CONTINUOUS_SPACE_MATCHER.replace_all(&command_input, " ");
-        let components: Vec<_> = commands_sanitised.trim().split(' ').collect();
+        let command_sanitised = CONTINUOUS_SPACE_MATCHER.replace_all(&command_input, " ");
+        let components: Vec<_> = command_sanitised.trim().split(' ').collect();
 
         let command = handle_aliases(components[0]);
         let args = components[1..].to_vec();

--- a/src/command.rs
+++ b/src/command.rs
@@ -305,12 +305,7 @@ pub fn parse(input: &str) -> Result<Vec<Command>, CommandParseError> {
 
     let mut commands = vec![];
     for command_input in command_inputs {
-        lazy_static! {
-            // https://docs.rs/regex/latest/regex/#example-avoid-compiling-the-same-regex-in-a-loop
-            static ref CONTINUOUS_SPACE_MATCHER: Regex = Regex::new(r" +").unwrap();
-        }
-        let command_sanitised = CONTINUOUS_SPACE_MATCHER.replace_all(&command_input, " ");
-        let components: Vec<_> = command_sanitised.trim().split(' ').collect();
+        let components: Vec<_> = command_input.split_whitespace().collect();
 
         let command = handle_aliases(components[0]);
         let args = components[1..].to_vec();

--- a/src/command.rs
+++ b/src/command.rs
@@ -2,7 +2,6 @@ use crate::queue::RepeatSetting;
 use std::collections::HashMap;
 use std::fmt;
 
-use regex::Regex;
 use strum_macros::Display;
 
 #[derive(Clone, Serialize, Deserialize, Debug)]

--- a/src/command.rs
+++ b/src/command.rs
@@ -2,6 +2,7 @@ use crate::queue::RepeatSetting;
 use std::collections::HashMap;
 use std::fmt;
 
+use regex::Regex;
 use strum_macros::Display;
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -243,7 +244,40 @@ fn handle_aliases(input: &str) -> &str {
     }
 }
 
-pub fn parse(input: &str) -> Option<Vec<Command>> {
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub enum CommandParseError {
+    NoSuchCommand { cmd: String },
+    NotEnoughArgs { cmd: String, hint: Option<String> },
+    BadEnumArg { arg: String, accept: Vec<String> },
+    ArgParseError { arg: String, err: String },
+}
+
+impl fmt::Display for CommandParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use CommandParseError::*;
+        let formatted = match self {
+            NoSuchCommand { cmd } => format!("No such command \"{}\"", cmd),
+            NotEnoughArgs { cmd, hint } => {
+                if let Some(hint_str) = hint {
+                    format!("\"{}\" requires additional arguments: {}", cmd, hint_str)
+                } else {
+                    format!("\"{}\" requires additional arguments", cmd)
+                }
+            }
+            BadEnumArg { arg, accept } => {
+                format!(
+                    "Illegal argument \"{}\": supported values are {}",
+                    arg,
+                    accept.join("|")
+                )
+            }
+            ArgParseError { arg, err } => format!("Error with argument \"{}\": {}", arg, err),
+        };
+        write!(f, "{}", formatted)
+    }
+}
+
+pub fn parse(input: &str) -> Result<Vec<Command>, CommandParseError> {
     let mut command_inputs = vec!["".to_string()];
     let mut command_idx = 0;
     enum ParseState {
@@ -271,226 +305,351 @@ pub fn parse(input: &str) -> Option<Vec<Command>> {
 
     let mut commands = vec![];
     for command_input in command_inputs {
-        let components: Vec<_> = command_input.trim().split(' ').collect();
+        lazy_static! {
+            // https://docs.rs/regex/latest/regex/#example-avoid-compiling-the-same-regex-in-a-loop
+            static ref CONTINUOUS_SPACE_MATCHER: Regex = Regex::new(r" +").unwrap();
+        }
+        let commands_sanitised = CONTINUOUS_SPACE_MATCHER.replace_all(&command_input, " ");
+        let components: Vec<_> = commands_sanitised.trim().split(' ').collect();
 
         let command = handle_aliases(components[0]);
         let args = components[1..].to_vec();
 
+        use CommandParseError::*;
         let command = match command {
-            "quit" => Some(Command::Quit),
-            "playpause" => Some(Command::TogglePlay),
-            "stop" => Some(Command::Stop),
-            "previous" => Some(Command::Previous),
-            "next" => Some(Command::Next),
-            "clear" => Some(Command::Clear),
-            "playnext" => Some(Command::PlayNext),
-            "queue" => Some(Command::Queue),
-            "play" => Some(Command::Play),
-            "update" => Some(Command::UpdateLibrary),
-            "delete" => Some(Command::Delete),
-            "back" => Some(Command::Back),
-            "open" => args
-                .get(0)
-                .and_then(|target| match *target {
-                    "selected" => Some(TargetMode::Selected),
-                    "current" => Some(TargetMode::Current),
-                    _ => None,
-                })
-                .map(Command::Open),
-            "jump" => Some(Command::Jump(JumpMode::Query(args.join(" ")))),
-            "jumpnext" => Some(Command::Jump(JumpMode::Next)),
-            "jumpprevious" => Some(Command::Jump(JumpMode::Previous)),
-            "search" => Some(Command::Search(args.join(" "))),
+            "quit" => Command::Quit,
+            "playpause" => Command::TogglePlay,
+            "stop" => Command::Stop,
+            "previous" => Command::Previous,
+            "next" => Command::Next,
+            "clear" => Command::Clear,
+            "playnext" => Command::PlayNext,
+            "queue" => Command::Queue,
+            "play" => Command::Play,
+            "update" => Command::UpdateLibrary,
+            "delete" => Command::Delete,
+            "back" => Command::Back,
+            "open" => {
+                let &target_mode_raw = args.get(0).ok_or(NotEnoughArgs {
+                    cmd: command.into(),
+                    hint: Some("selected|current".into()),
+                })?;
+                let target_mode = match target_mode_raw {
+                    "selected" => Ok(TargetMode::Selected),
+                    "current" => Ok(TargetMode::Current),
+                    _ => Err(BadEnumArg {
+                        arg: target_mode_raw.into(),
+                        accept: vec!["selected".into(), "current".into()],
+                    }),
+                }?;
+                Command::Open(target_mode)
+            }
+            "jump" => Command::Jump(JumpMode::Query(args.join(" "))),
+            "jumpnext" => Command::Jump(JumpMode::Next),
+            "jumpprevious" => Command::Jump(JumpMode::Previous),
+            "search" => Command::Search(args.join(" ")),
             "shift" => {
-                let amount = args.get(1).and_then(|amount| amount.parse().ok());
-
-                args.get(0)
-                    .and_then(|direction| match *direction {
-                        "up" => Some(ShiftMode::Up),
-                        "down" => Some(ShiftMode::Down),
-                        _ => None,
-                    })
-                    .map(|mode| Command::Shift(mode, amount))
+                let &shift_dir_raw = args.get(0).ok_or(NotEnoughArgs {
+                    cmd: command.into(),
+                    hint: Some("up|down".into()),
+                })?;
+                let shift_dir = match shift_dir_raw {
+                    "up" => Ok(ShiftMode::Up),
+                    "down" => Ok(ShiftMode::Down),
+                    _ => Err(BadEnumArg {
+                        arg: shift_dir_raw.into(),
+                        accept: vec!["up".into(), "down".into()],
+                    }),
+                }?;
+                let amount = match args.get(1) {
+                    Some(&amount_raw) => {
+                        let amount = amount_raw.parse::<i32>().map_err(|err| ArgParseError {
+                            arg: amount_raw.into(),
+                            err: err.to_string(),
+                        })?;
+                        Some(amount)
+                    }
+                    None => None,
+                };
+                Command::Shift(shift_dir, amount)
             }
             "move" => {
-                let cmd: Option<Command> = {
-                    args.get(0).and_then(|extreme| match *extreme {
-                        "top" => Some(Command::Move(MoveMode::Up, MoveAmount::Extreme)),
-                        "bottom" => Some(Command::Move(MoveMode::Down, MoveAmount::Extreme)),
-                        "leftmost" => Some(Command::Move(MoveMode::Left, MoveAmount::Extreme)),
-                        "rightmost" => Some(Command::Move(MoveMode::Right, MoveAmount::Extreme)),
-                        "playing" => Some(Command::Move(MoveMode::Playing, MoveAmount::default())),
-                        _ => None,
-                    })
+                let &move_mode_raw = args.get(0).ok_or(NotEnoughArgs {
+                    cmd: command.into(),
+                    hint: Some("a direction".into()),
+                })?;
+                let move_mode = {
+                    use MoveMode::*;
+                    match move_mode_raw {
+                        "playing" => Ok(Playing),
+                        "top" | "up" => Ok(Up),
+                        "bottom" | "down" => Ok(Down),
+                        "leftmost" | "left" => Ok(Left),
+                        "rightmost" | "right" => Ok(Right),
+                        _ => Err(BadEnumArg {
+                            arg: move_mode_raw.into(),
+                            accept: vec![
+                                "playing".into(),
+                                "top".into(),
+                                "bottom".into(),
+                                "leftmost".into(),
+                                "rightmost".into(),
+                                "up".into(),
+                                "down".into(),
+                                "left".into(),
+                                "right".into(),
+                            ],
+                        }),
+                    }?
                 };
-
-                cmd.or({
-                    let amount = args
-                        .get(1)
-                        .and_then(|amount| amount.parse().ok())
-                        .map(MoveAmount::Integer)
-                        .unwrap_or_default();
-
-                    args.get(0)
-                        .and_then(|direction| match *direction {
-                            "up" => Some(MoveMode::Up),
-                            "down" => Some(MoveMode::Down),
-                            "left" => Some(MoveMode::Left),
-                            "right" => Some(MoveMode::Right),
-                            _ => None,
-                        })
-                        .map(|mode| Command::Move(mode, amount))
-                })
+                let move_amount = match move_mode_raw {
+                    "playing" => Ok(MoveAmount::default()),
+                    "top" | "bottom" | "leftmost" | "rightmost" => Ok(MoveAmount::Extreme),
+                    "up" | "down" | "left" | "right" => {
+                        let amount = match args.get(1) {
+                            Some(&amount_raw) => amount_raw
+                                .parse::<i32>()
+                                .map(MoveAmount::Integer)
+                                .map_err(|err| ArgParseError {
+                                    arg: amount_raw.into(),
+                                    err: err.to_string(),
+                                })?,
+                            None => MoveAmount::default(),
+                        };
+                        Ok(amount)
+                    }
+                    _ => unreachable!(), // already guarded when determining MoveMode
+                }?;
+                Command::Move(move_mode, move_amount)
             }
-            "goto" => args
-                .get(0)
-                .and_then(|mode| match *mode {
-                    "album" => Some(GotoMode::Album),
-                    "artist" => Some(GotoMode::Artist),
-                    _ => None,
-                })
-                .map(Command::Goto),
-            "share" => args
-                .get(0)
-                .and_then(|target| match *target {
-                    "selected" => Some(TargetMode::Selected),
-                    "current" => Some(TargetMode::Current),
-                    _ => None,
-                })
-                .map(Command::Share),
+            "goto" => {
+                let &goto_mode_raw = args.get(0).ok_or(NotEnoughArgs {
+                    cmd: command.into(),
+                    hint: Some("album|artist".into()),
+                })?;
+                let goto_mode = match goto_mode_raw {
+                    "album" => Ok(GotoMode::Album),
+                    "artist" => Ok(GotoMode::Artist),
+                    _ => Err(BadEnumArg {
+                        arg: goto_mode_raw.into(),
+                        accept: vec!["album".into(), "artist".into()],
+                    }),
+                }?;
+                Command::Goto(goto_mode)
+            }
+            "share" => {
+                let &target_mode_raw = args.get(0).ok_or(NotEnoughArgs {
+                    cmd: command.into(),
+                    hint: Some("selected|current".into()),
+                })?;
+                let target_mode = match target_mode_raw {
+                    "selected" => Ok(TargetMode::Selected),
+                    "current" => Ok(TargetMode::Current),
+                    _ => Err(BadEnumArg {
+                        arg: target_mode_raw.into(),
+                        accept: vec!["selected".into(), "current".into()],
+                    }),
+                }?;
+                Command::Share(target_mode)
+            }
             "shuffle" => {
-                let shuffle = args.get(0).and_then(|mode| match *mode {
-                    "on" => Some(true),
-                    "off" => Some(false),
-                    _ => None,
-                });
-
-                Some(Command::Shuffle(shuffle))
+                let switch = match args.get(0).cloned() {
+                    Some("on") => Ok(Some(true)),
+                    Some("off") => Ok(Some(false)),
+                    Some(arg) => Err(BadEnumArg {
+                        arg: arg.into(),
+                        accept: vec!["**omit**".into(), "on".into(), "off".into()],
+                    }),
+                    None => Ok(None),
+                }?;
+                Command::Shuffle(switch)
             }
             "repeat" => {
-                let mode = args.get(0).and_then(|mode| match *mode {
-                    "list" | "playlist" | "queue" => Some(RepeatSetting::RepeatPlaylist),
-                    "track" | "once" | "single" => Some(RepeatSetting::RepeatTrack),
-                    "none" | "off" => Some(RepeatSetting::None),
-                    _ => None,
-                });
-
-                Some(Command::Repeat(mode))
+                let mode = match args.get(0).cloned() {
+                    Some("list" | "playlist" | "queue") => Ok(Some(RepeatSetting::RepeatPlaylist)),
+                    Some("track" | "once" | "single") => Ok(Some(RepeatSetting::RepeatTrack)),
+                    Some("none" | "off") => Ok(Some(RepeatSetting::None)),
+                    Some(arg) => Err(BadEnumArg {
+                        arg: arg.into(),
+                        accept: vec![
+                            "**omit**".into(),
+                            "list".into(),
+                            "playlist".into(),
+                            "queue".into(),
+                            "track".into(),
+                            "once".into(),
+                            "single".into(),
+                            "none".into(),
+                            "off".into(),
+                        ],
+                    }),
+                    None => Ok(None),
+                }?;
+                Command::Repeat(mode)
             }
             "seek" => {
                 let arg = args.join(" ");
                 let first_char = arg.chars().next();
                 let duration_raw = match first_char {
-                    Some('+' | '-') => arg.chars().skip(1).collect(),
-                    _ => arg.to_string(),
+                    Some('+' | '-') => {
+                        arg.chars().skip(1).collect::<String>().trim().into()
+                        // `trim` is necessary here, otherwise `+1000` -> 1 second, but `+ 1000` -> 1000 seconds
+                        // this behaviour is inconsistent and could cause confusion
+                    }
+                    _ => arg,
                 };
-                duration_raw
-                    .parse::<u32>() // accept raw milliseconds for backward compatibility
-                    .ok()
-                    .or_else(|| {
-                        parse_duration::parse(&duration_raw) // accept fancy duration
-                            .ok()
-                            .and_then(|dur| dur.as_millis().try_into().ok())
-                    })
-                    .and_then(|unsigned_millis| {
-                        match first_char {
-                            // handle i32::MAX < unsigned_millis < u32::MAX gracefully
-                            Some('+') => {
-                                i32::try_from(unsigned_millis)
-                                    .ok()
-                                    .map(|unsigned_millis_i32| {
-                                        SeekDirection::Relative(unsigned_millis_i32)
-                                    })
-                            }
-                            Some('-') => {
-                                i32::try_from(unsigned_millis)
-                                    .ok()
-                                    .map(|unsigned_millis_i32| {
-                                        SeekDirection::Relative(-unsigned_millis_i32)
-                                    })
-                            }
-                            _ => Some(SeekDirection::Absolute(unsigned_millis)),
-                        }
-                        .map(|direction| Command::Seek(direction))
-                    })
-            }
-            "focus" => args
-                .get(0)
-                .map(|target| Command::Focus((*target).to_string())),
-            "save" => args
-                .get(0)
-                .map(|target| match *target {
-                    "queue" => Command::SaveQueue,
-                    _ => Command::Save,
-                })
-                .or(Some(Command::Save)),
-            "volup" => Some(Command::VolumeUp(
-                args.get(0).and_then(|v| v.parse::<u16>().ok()).unwrap_or(1),
-            )),
-            "voldown" => Some(Command::VolumeDown(
-                args.get(0).and_then(|v| v.parse::<u16>().ok()).unwrap_or(1),
-            )),
-            "help" => Some(Command::Help),
-            "reload" => Some(Command::ReloadConfig),
-            "insert" => {
-                if args.is_empty() {
-                    Some(Command::Insert(None))
-                } else {
-                    args.get(0)
-                        .map(|url| Command::Insert(Some((*url).to_string())))
+                let unsigned_millis = match duration_raw.parse() {
+                    // accept raw milliseconds
+                    Ok(millis) => millis,
+                    Err(_) => parse_duration::parse(&duration_raw) // accept fancy duration
+                        .map_err(|err| ArgParseError {
+                            arg: duration_raw.clone(),
+                            err: err.to_string(),
+                        })
+                        .and_then(|dur| {
+                            dur.as_millis().try_into().map_err(|_| ArgParseError {
+                                arg: duration_raw.clone(),
+                                err: "Duration value too large".into(),
+                            })
+                        })?,
+                };
+                let seek_direction = match first_char {
+                    // handle i32::MAX < unsigned_millis < u32::MAX gracefully
+                    Some('+') => {
+                        i32::try_from(unsigned_millis).map(|millis| SeekDirection::Relative(millis))
+                    }
+                    Some('-') => i32::try_from(unsigned_millis)
+                        .map(|millis| SeekDirection::Relative(-millis)),
+                    _ => Ok(SeekDirection::Absolute(unsigned_millis)),
                 }
+                .map_err(|_| ArgParseError {
+                    arg: duration_raw,
+                    err: "Duration value too large".into(),
+                })?;
+                Command::Seek(seek_direction)
+            }
+            "focus" => {
+                let &target = args.get(0).ok_or(NotEnoughArgs {
+                    cmd: command.into(),
+                    hint: Some("queue|search|library".into()),
+                })?;
+                // TODO: this really should be strongly typed
+                Command::Focus(target.into())
+            }
+            "save" => match args.get(0).cloned() {
+                Some("queue") => Ok(Command::SaveQueue),
+                Some(arg) => Err(BadEnumArg {
+                    arg: arg.into(),
+                    accept: vec!["**omit**".into(), "queue".into()],
+                }),
+                None => Ok(Command::Save),
+            }?,
+            "volup" => {
+                let amount = match args.get(0) {
+                    Some(&amount_raw) => {
+                        amount_raw.parse::<u16>().map_err(|err| ArgParseError {
+                            arg: amount_raw.into(),
+                            err: err.to_string(),
+                        })?
+                    }
+                    None => 1,
+                };
+                Command::VolumeUp(amount)
+            }
+            "voldown" => {
+                let amount = match args.get(0) {
+                    Some(&amount_raw) => {
+                        amount_raw.parse::<u16>().map_err(|err| ArgParseError {
+                            arg: amount_raw.into(),
+                            err: err.to_string(),
+                        })?
+                    }
+                    None => 1,
+                };
+                Command::VolumeDown(amount)
+            }
+            "help" => Command::Help,
+            "reload" => Command::ReloadConfig,
+            "insert" => {
+                // IDEA: this should fail fast too
+                Command::Insert(args.get(0).map(|&url| url.into()))
             }
             "newplaylist" => {
                 if !args.is_empty() {
-                    Some(Command::NewPlaylist(args.join(" ")))
+                    Ok(Command::NewPlaylist(args.join(" ")))
                 } else {
-                    None
-                }
+                    Err(NotEnoughArgs {
+                        cmd: command.into(),
+                        hint: Some("a name".into()),
+                    })
+                }?
             }
             "sort" => {
-                if !args.is_empty() {
-                    let sort_key = args.get(0).and_then(|key| match *key {
-                        "title" => Some(SortKey::Title),
-                        "duration" => Some(SortKey::Duration),
-                        "album" => Some(SortKey::Album),
-                        "added" => Some(SortKey::Added),
-                        "artist" => Some(SortKey::Artist),
-                        _ => None,
-                    })?;
-
-                    let sort_direction = args
-                        .get(1)
-                        .map(|direction| match *direction {
-                            "a" => SortDirection::Ascending,
-                            "asc" => SortDirection::Ascending,
-                            "ascending" => SortDirection::Ascending,
-                            "d" => SortDirection::Descending,
-                            "desc" => SortDirection::Descending,
-                            "descending" => SortDirection::Descending,
-                            _ => SortDirection::Ascending,
-                        })
-                        .unwrap_or(SortDirection::Ascending);
-
-                    Some(Command::Sort(sort_key, sort_direction))
-                } else {
-                    None
-                }
+                let &key_raw = args.get(0).ok_or(NotEnoughArgs {
+                    cmd: command.into(),
+                    hint: Some("a sort key".into()),
+                })?;
+                let key = match key_raw {
+                    "title" => Ok(SortKey::Title),
+                    "duration" => Ok(SortKey::Duration),
+                    "album" => Ok(SortKey::Album),
+                    "added" => Ok(SortKey::Added),
+                    "artist" => Ok(SortKey::Artist),
+                    _ => Err(BadEnumArg {
+                        arg: key_raw.into(),
+                        accept: vec![
+                            "title".into(),
+                            "duration".into(),
+                            "album".into(),
+                            "added".into(),
+                            "artist".into(),
+                        ],
+                    }),
+                }?;
+                let direction = match args.get(1) {
+                    Some(&direction_raw) => match direction_raw {
+                        "a" | "asc" | "ascending" => Ok(SortDirection::Ascending),
+                        "d" | "desc" | "descending" => Ok(SortDirection::Descending),
+                        _ => Err(BadEnumArg {
+                            arg: direction_raw.into(),
+                            accept: vec![
+                                "a".into(),
+                                "asc".into(),
+                                "ascending".into(),
+                                "d".into(),
+                                "desc".into(),
+                                "descending".into(),
+                            ],
+                        }),
+                    },
+                    None => Ok(SortDirection::Ascending),
+                }?;
+                Command::Sort(key, direction)
             }
-            "logout" => Some(Command::Logout),
-            "similar" => args
-                .get(0)
-                .and_then(|target| match *target {
-                    "selected" => Some(TargetMode::Selected),
-                    "current" => Some(TargetMode::Current),
-                    _ => None,
-                })
-                .map(Command::ShowRecommendations),
-            "noop" => Some(Command::Noop),
-            "redraw" => Some(Command::Redraw),
-            "exec" => Some(Command::Execute(args.join(" "))),
-            _ => None,
+            "logout" => Command::Logout,
+            "similar" => {
+                let &target_mode_raw = args.get(0).ok_or(NotEnoughArgs {
+                    cmd: command.into(),
+                    hint: Some("selected|current".into()),
+                })?;
+                let target_mode = match target_mode_raw {
+                    "selected" => Ok(TargetMode::Selected),
+                    "current" => Ok(TargetMode::Current),
+                    _ => Err(BadEnumArg {
+                        arg: target_mode_raw.into(),
+                        accept: vec!["selected".into(), "current".into()],
+                    }),
+                }?;
+                Command::ShowRecommendations(target_mode)
+            }
+            "noop" => Command::Noop,
+            "redraw" => Command::Redraw,
+            "exec" => Command::Execute(args.join(" ")),
+            _ => Err(NoSuchCommand {
+                cmd: command.into(),
+            })?, // I'm surprised this compiles lol
         };
-        commands.push(command?);
+        commands.push(command);
     }
-    Some(commands)
+    Ok(commands)
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -247,7 +247,7 @@ fn handle_aliases(input: &str) -> &str {
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub enum CommandParseError {
     NoSuchCommand { cmd: String },
-    NotEnoughArgs { cmd: String, hint: Option<String> },
+    InsufficientArgs { cmd: String, hint: Option<String> },
     BadEnumArg { arg: String, accept: Vec<String> },
     ArgParseError { arg: String, err: String },
 }
@@ -257,7 +257,7 @@ impl fmt::Display for CommandParseError {
         use CommandParseError::*;
         let formatted = match self {
             NoSuchCommand { cmd } => format!("No such command \"{}\"", cmd),
-            NotEnoughArgs { cmd, hint } => {
+            InsufficientArgs { cmd, hint } => {
                 if let Some(hint_str) = hint {
                     format!("\"{}\" requires additional arguments: {}", cmd, hint_str)
                 } else {
@@ -330,7 +330,7 @@ pub fn parse(input: &str) -> Result<Vec<Command>, CommandParseError> {
             "delete" => Command::Delete,
             "back" => Command::Back,
             "open" => {
-                let &target_mode_raw = args.get(0).ok_or(NotEnoughArgs {
+                let &target_mode_raw = args.get(0).ok_or(InsufficientArgs {
                     cmd: command.into(),
                     hint: Some("selected|current".into()),
                 })?;
@@ -349,7 +349,7 @@ pub fn parse(input: &str) -> Result<Vec<Command>, CommandParseError> {
             "jumpprevious" => Command::Jump(JumpMode::Previous),
             "search" => Command::Search(args.join(" ")),
             "shift" => {
-                let &shift_dir_raw = args.get(0).ok_or(NotEnoughArgs {
+                let &shift_dir_raw = args.get(0).ok_or(InsufficientArgs {
                     cmd: command.into(),
                     hint: Some("up|down".into()),
                 })?;
@@ -374,7 +374,7 @@ pub fn parse(input: &str) -> Result<Vec<Command>, CommandParseError> {
                 Command::Shift(shift_dir, amount)
             }
             "move" => {
-                let &move_mode_raw = args.get(0).ok_or(NotEnoughArgs {
+                let &move_mode_raw = args.get(0).ok_or(InsufficientArgs {
                     cmd: command.into(),
                     hint: Some("a direction".into()),
                 })?;
@@ -423,7 +423,7 @@ pub fn parse(input: &str) -> Result<Vec<Command>, CommandParseError> {
                 Command::Move(move_mode, move_amount)
             }
             "goto" => {
-                let &goto_mode_raw = args.get(0).ok_or(NotEnoughArgs {
+                let &goto_mode_raw = args.get(0).ok_or(InsufficientArgs {
                     cmd: command.into(),
                     hint: Some("album|artist".into()),
                 })?;
@@ -438,7 +438,7 @@ pub fn parse(input: &str) -> Result<Vec<Command>, CommandParseError> {
                 Command::Goto(goto_mode)
             }
             "share" => {
-                let &target_mode_raw = args.get(0).ok_or(NotEnoughArgs {
+                let &target_mode_raw = args.get(0).ok_or(InsufficientArgs {
                     cmd: command.into(),
                     hint: Some("selected|current".into()),
                 })?;
@@ -529,7 +529,7 @@ pub fn parse(input: &str) -> Result<Vec<Command>, CommandParseError> {
                 Command::Seek(seek_direction)
             }
             "focus" => {
-                let &target = args.get(0).ok_or(NotEnoughArgs {
+                let &target = args.get(0).ok_or(InsufficientArgs {
                     cmd: command.into(),
                     hint: Some("queue|search|library".into()),
                 })?;
@@ -578,14 +578,14 @@ pub fn parse(input: &str) -> Result<Vec<Command>, CommandParseError> {
                 if !args.is_empty() {
                     Ok(Command::NewPlaylist(args.join(" ")))
                 } else {
-                    Err(NotEnoughArgs {
+                    Err(InsufficientArgs {
                         cmd: command.into(),
                         hint: Some("a name".into()),
                     })
                 }?
             }
             "sort" => {
-                let &key_raw = args.get(0).ok_or(NotEnoughArgs {
+                let &key_raw = args.get(0).ok_or(InsufficientArgs {
                     cmd: command.into(),
                     hint: Some("a sort key".into()),
                 })?;
@@ -628,7 +628,7 @@ pub fn parse(input: &str) -> Result<Vec<Command>, CommandParseError> {
             }
             "logout" => Command::Logout,
             "similar" => {
-                let &target_mode_raw = args.get(0).ok_or(NotEnoughArgs {
+                let &target_mode_raw = args.get(0).ok_or(InsufficientArgs {
                     cmd: command.into(),
                     hint: Some("selected|current".into()),
                 })?;

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -71,11 +71,17 @@ impl CommandManager {
         let custom_bindings: Option<HashMap<String, String>> = config.keybindings.clone();
 
         for (key, commands) in custom_bindings.unwrap_or_default() {
-            if let Some(commands) = parse(&commands) {
-                info!("Custom keybinding: {} -> {:?}", key, commands);
-                kb.insert(key, commands);
-            } else {
-                error!("Invalid command(s) for key {}: {}", key, commands);
+            match parse(&commands) {
+                Ok(cmds) => {
+                    info!("Custom keybinding: {} -> {:?}", key, cmds);
+                    kb.insert(key, cmds);
+                }
+                Err(err) => {
+                    error!(
+                        "Invalid command(s) for key {}-\"{}\": {}",
+                        key, commands, err
+                    );
+                }
             }
         }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::command::{
-    parse, Command, GotoMode, JumpMode, MoveAmount, MoveMode, SeekDirection, ShiftMode, TargetMode,
+    parse, Command, GotoMode, InsertSource, JumpMode, MoveAmount, MoveMode, SeekDirection,
+    ShiftMode, TargetMode,
 };
 use crate::config::Config;
 use crate::events::EventManager;
@@ -514,7 +515,12 @@ impl CommandManager {
             "Shift+Down".into(),
             vec![Command::Shift(ShiftMode::Down, None)],
         );
-        kb.insert("Ctrl+v".into(), vec![Command::Insert(None)]);
+
+        #[cfg(feature = "share_clipboard")]
+        kb.insert(
+            "Ctrl+v".into(),
+            vec![Command::Insert(InsertSource::Clipboard)],
+        );
 
         kb
     }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -267,20 +267,27 @@ impl CommandManager {
                 log::info!("Exit code: {}", result);
                 Ok(None)
             }
-            Command::Jump(_)
-            | Command::Move(_, _)
-            | Command::Shift(_, _)
-            | Command::Play
+
+            Command::Queue
             | Command::PlayNext
-            | Command::Queue
+            | Command::Play
             | Command::Save
+            | Command::SaveQueue
             | Command::Delete
+            | Command::Focus(_)
+            | Command::Share(_)
             | Command::Back
             | Command::Open(_)
-            | Command::ShowRecommendations(_)
+            | Command::Goto(_)
+            | Command::Move(_, _)
+            | Command::Shift(_, _)
+            | Command::Jump(_)
             | Command::Insert(_)
-            | Command::Goto(_) => Ok(None),
-            _ => Err("Unknown Command".into()),
+            | Command::ShowRecommendations(_)
+            | Command::Sort(_, _) => Err(format!(
+                "The command \"{}\" is unsupported in this view",
+                cmd.basename()
+            )),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -302,10 +302,7 @@ async fn main() -> Result<(), String> {
                     }
                     Err(err) => {
                         let mut main = s.find_name::<ui::layout::Layout>("main").unwrap();
-                        let err_msg = format!(
-                            "Failed to parse command(s) \"{}\": {}",
-                            cmd_without_prefix, err
-                        );
+                        let err_msg = format!("Failed to parse command(s): {}", err);
                         main.set_result(Err(err_msg));
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -302,8 +302,7 @@ async fn main() -> Result<(), String> {
                     }
                     Err(err) => {
                         let mut main = s.find_name::<ui::layout::Layout>("main").unwrap();
-                        let err_msg = format!("Failed to parse command(s): {}", err);
-                        main.set_result(Err(err_msg));
+                        main.set_result(Err(err.to_string()));
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -292,17 +292,22 @@ async fn main() -> Result<(), String> {
                     data.cmd.handle(s, command);
                 }
             } else {
-                let parsed = command::parse(cmd_without_prefix);
-                if let Some(commands) = parsed {
-                    if let Some(data) = s.user_data::<UserData>().cloned() {
-                        for cmd in commands {
-                            data.cmd.handle(s, cmd);
+                match command::parse(cmd_without_prefix) {
+                    Ok(commands) => {
+                        if let Some(data) = s.user_data::<UserData>().cloned() {
+                            for cmd in commands {
+                                data.cmd.handle(s, cmd);
+                            }
                         }
                     }
-                } else {
-                    let mut main = s.find_name::<ui::layout::Layout>("main").unwrap();
-                    let err_msg = format!("Failed to parse command(s): \"{}\"", cmd_without_prefix);
-                    main.set_result(Err(err_msg));
+                    Err(err) => {
+                        let mut main = s.find_name::<ui::layout::Layout>("main").unwrap();
+                        let err_msg = format!(
+                            "Failed to parse command(s) \"{}\": {}",
+                            cmd_without_prefix, err
+                        );
+                        main.set_result(Err(err_msg));
+                    }
                 }
             }
             ev.trigger();

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -358,7 +358,7 @@ impl Spotify {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Copy, Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub enum UriType {
     Album,
     Artist,

--- a/src/spotify_url.rs
+++ b/src/spotify_url.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::spotify::UriType;
 
 use url::{Host, Url};
@@ -6,6 +8,20 @@ use url::{Host, Url};
 pub struct SpotifyUrl {
     pub id: String,
     pub uri_type: UriType,
+}
+
+impl fmt::Display for SpotifyUrl {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let type_seg = match self.uri_type {
+            UriType::Album => "album",
+            UriType::Artist => "artist",
+            UriType::Episode => "episode",
+            UriType::Playlist => "playlist",
+            UriType::Show => "show",
+            UriType::Track => "track",
+        };
+        write!(f, "https://open.spotify.com/{}/{}", type_seg, self.id)
+    }
 }
 
 impl SpotifyUrl {

--- a/src/spotify_url.rs
+++ b/src/spotify_url.rs
@@ -2,6 +2,7 @@ use crate::spotify::UriType;
 
 use url::{Host, Url};
 
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct SpotifyUrl {
     pub id: String,
     pub uri_type: UriType,
@@ -22,8 +23,8 @@ impl SpotifyUrl {
     /// assert_eq!(result.id, "4uLU6hMCjMI75M1A2tKUQC");
     /// assert_eq!(result.uri_type, URIType::Track);
     /// ```
-    pub fn from_url(s: &str) -> Option<SpotifyUrl> {
-        let url = Url::parse(s).ok()?;
+    pub fn from_url<S: AsRef<str>>(s: S) -> Option<SpotifyUrl> {
+        let url = Url::parse(s.as_ref()).ok()?;
         if url.host() != Some(Host::Domain("open.spotify.com")) {
             return None;
         }

--- a/src/ui/listview.rs
+++ b/src/ui/listview.rs
@@ -10,7 +10,7 @@ use cursive::view::ScrollBase;
 use cursive::{Cursive, Printer, Rect, Vec2};
 use unicode_width::UnicodeWidthStr;
 
-use crate::command::{Command, GotoMode, JumpMode, MoveAmount, MoveMode, TargetMode};
+use crate::command::{Command, GotoMode, InsertSource, JumpMode, MoveAmount, MoveMode, TargetMode};
 use crate::commands::CommandResult;
 use crate::library::Library;
 use crate::model::album::Album;
@@ -520,19 +520,14 @@ impl<I: ListItem + Clone> ViewExt for ListView<I> {
                     }
                 }
             }
-            Command::Insert(url) => {
-                let url = match url.as_ref().map(String::as_str) {
+            Command::Insert(source) => {
+                let url = match source {
+                    InsertSource::Input(url) => Some(url.clone()),
                     #[cfg(feature = "share_clipboard")]
-                    Some("") | None => read_share().unwrap(),
-                    Some(url) => url.to_owned(),
-                    // do nothing if clipboard feature is disabled and there is no url provided
-                    #[allow(unreachable_patterns)]
-                    _ => return Ok(CommandResult::Consumed(None)),
+                    InsertSource::Clipboard => SpotifyUrl::from_url(read_share().unwrap()),
                 };
 
                 let spotify = self.queue.get_spotify();
-
-                let url = SpotifyUrl::from_url(&url);
 
                 if let Some(url) = url {
                     let target: Option<Box<dyn ListItem>> = match url.uri_type {

--- a/src/ui/listview.rs
+++ b/src/ui/listview.rs
@@ -524,7 +524,7 @@ impl<I: ListItem + Clone> ViewExt for ListView<I> {
                 let url = match source {
                     InsertSource::Input(url) => Some(url.clone()),
                     #[cfg(feature = "share_clipboard")]
-                    InsertSource::Clipboard => SpotifyUrl::from_url(read_share().unwrap()),
+                    InsertSource::Clipboard => read_share().and_then(SpotifyUrl::from_url),
                 };
 
                 let spotify = self.queue.get_spotify();


### PR DESCRIPTION
## Change Summary
- A failed command parse now returns more detailed error info, closes #597
- Added API:
  - `pub enum command::CommandParseError`
- Changed API:
  - `pub fn command::parse(&str) -> Option<Vec<Command>>` -> `pub fn command::parse(&str) -> Result<Vec<Command>, CommandParseError>`
- Breaking changes:
  - Some commands previously allow bad args silently and perform some default action. These cases will now fail fast.
    - Examples:
      - `shuffle onn` (misspelled `on`) no longer toggles shuffle.
      - `volup -10` (negative not allowed) no longer increases volume by 1%.
      - `sort title desending` (misspelled `descending`) no longer sorts in ascending.
    - Commands affected: `shuffle`, `repeat`, `save`, `volup`, `voldown`, `sort`
  - Continuous spaces in commands are now interpreted as one
    - Examples:
      - `sort title  descending` (two spaces between `args[0]` and `args[1]`, doesn't show up on rendered markdown) no longer sorts in ascending.
    - Potentially adverse consequences:
      - `newplaylist` can no longer create a playlist containing multiple continuous spaces.

## Feature Preview
![feature-preview](https://user-images.githubusercontent.com/28627918/147584394-751b2623-3a50-4371-903b-ded0da374bc3.gif)