### PR TITLE
Remove notifications' dependency on 'cover'

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,7 +46,7 @@ jobs:
           - build_target: windows-x86_64
             os: windows-latest
             target: x86_64-pc-windows-msvc
-            features: '--no-default-features --features rodio_backend,pancurses_backend'
+            features: '--no-default-features --features rodio_backend,pancurses_backend,share_clipboard,notify'
     steps:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
             os: windows-latest
             artifact_suffix: windows-x86_64
             target: x86_64-pc-windows-msvc
-            features: '--no-default-features --features rodio_backend,cursive/pancurses-backend'
+            features: '--no-default-features --features rodio_backend,pancurses_backend,share_clipboard,notify'
     steps:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -414,10 +414,10 @@ pub fn send_notification(track_name: &str, _cover_url: Option<String>) {
     #[cfg(all(feature = "notify", feature = "cover"))]
     let res = if let Some(u) = _cover_url {
         // download album cover image
-        let path = ui::cover::cache_path_for_url(u.to_string());
+        let path = crate::utils::cache_path_for_url(u.to_string());
 
         if !path.exists() {
-            if let Err(e) = ui::cover::download(u.to_string(), path.clone()) {
+            if let Err(e) = crate::utils::download(u.to_string(), path.clone()) {
                 error!("Failed to download cover: {}", e);
             }
         }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -410,8 +410,8 @@ impl Queue {
     }
 }
 
+#[cfg(feature = "notify")]
 pub fn send_notification(track_name: &str, _cover_url: Option<String>) {
-    #[cfg(all(feature = "notify", feature = "cover"))]
     let res = if let Some(u) = _cover_url {
         // download album cover image
         let path = crate::utils::cache_path_for_url(u.to_string());
@@ -430,10 +430,6 @@ pub fn send_notification(track_name: &str, _cover_url: Option<String>) {
         Notification::new().summary(track_name).show()
     };
 
-    #[cfg(all(feature = "notify", not(feature = "cover")))]
-    let res = Notification::new().summary(track_name).show();
-
-    #[cfg(feature = "notify")]
     if let Err(e) = res {
         error!("Failed to send notification cover: {}", e);
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -36,4 +36,3 @@ pub fn download(url: String, path: std::path::PathBuf) -> Result<(), std::io::Er
     std::io::copy(&mut resp, &mut file)?;
     Ok(())
 }
-

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,3 +19,21 @@ pub fn format_duration(d: &std::time::Duration) -> String {
 
     s.trim_end().to_string()
 }
+
+pub fn cache_path_for_url(url: String) -> std::path::PathBuf {
+    let mut path = crate::config::cache_path("covers");
+    path.push(url.split('/').last().unwrap());
+    path
+}
+
+pub fn download(url: String, path: std::path::PathBuf) -> Result<(), std::io::Error> {
+    let mut resp = reqwest::blocking::get(&url)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+
+    std::fs::create_dir_all(path.parent().unwrap())?;
+    let mut file = std::fs::File::create(path)?;
+
+    std::io::copy(&mut resp, &mut file)?;
+    Ok(())
+}
+


### PR DESCRIPTION
This PR, in essence, just moves the functions `download` and `cache_path_for_url` from cover.rs to utils.rs. This is done so that the notification icon can be used on Windows. These functions were not doing doing anything Unix-specific, but since the `cover` feature is disabled on Windows, they couldn't be used before.

I have also enabled notifications and clipboard features for CI/CD on Windows. I have tested them in all scenarios, but please let me know if I missed anything. 