### PR TITLE
ui: listview: fix log::info errors

### DIFF
--- a/src/ui/listview.rs
+++ b/src/ui/listview.rs
@@ -85,7 +85,7 @@ impl<I: ListItem> ListView<I> {
 
     pub fn content_height_with_paginator(&self) -> usize {
         let content_len = self.content.read().unwrap().len();
-        log::info!("content len: {content_len}");
+        log::info!("content len: {}", content_len);
 
         // add 1 more row for paginator if we can paginate
         if self.can_paginate() {
@@ -97,7 +97,7 @@ impl<I: ListItem> ListView<I> {
 
     fn can_paginate(&self) -> bool {
         let loaded = self.get_pagination().loaded_content();
-        log::info!("can paginate: {loaded}");
+        log::info!("can paginate: {}", loaded);
         self.get_pagination().max_content().unwrap_or(0) > self.get_pagination().loaded_content()
     }
 


### PR DESCRIPTION
This commit fixes the errors below, introduced in "Move from
`ScrollBase` to `scroll` module" [1]. As noted by the rust docs [2],
named arguments should be used in the format

```rust
log::info!("content len: {content_len}", content_len=content_len);
```

As this provides no advantage over unnamed args, use them for
conciseness with the rest of the project.

```raw
error: there is no argument named `content_len`
  --> src/ui/listview.rs:88:34
   |
88 |         log::info!("content len: {content_len}");
   |                                  ^^^^^^^^^^^^^

error: there is no argument named `loaded`
   --> src/ui/listview.rs:100:35
    |
100 |         log::info!("can paginate: {loaded}");
    |                                   ^^^^^^^^

error: could not compile `ncspot` due to 2 previous errors
```

[1] - Move from `ScrollBase` to `scroll` module (adf8da2f)
[2] - https://doc.rust-lang.org/std/fmt/#named-parameters

Signed-off-by: Isabella Basso <isabbasso@riseup.net>
