### PR TITLE
Use Rodio backend for macOS builds

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,7 +42,7 @@ jobs:
           - build_target: macos-x86_64
             os: macos-latest
             target: x86_64-apple-darwin
-            features: '--no-default-features --features portaudio_backend,pancurses_backend'
+            features: '--no-default-features --features rodio_backend,pancurses_backend'
           - build_target: windows-x86_64
             os: windows-latest
             target: x86_64-pc-windows-msvc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
             os: macos-latest
             artifact_suffix: macos-x86_64
             target: x86_64-apple-darwin
-            features: '--no-default-features --features portaudio_backend,cursive/pancurses-backend'
+            features: '--no-default-features --features rodio_backend,cursive/pancurses-backend'
           - build_target: windows
             os: windows-latest
             artifact_suffix: windows-x86_64


### PR DESCRIPTION
Gets rid of the dynamically linked PortAudio dependency