### PR TITLE
Only download cover image when flag enabled

### DIFF
--- a/src/queue.rs
+++ b/src/queue.rs
@@ -274,7 +274,11 @@ impl Queue {
                 let notification_id = self.notification_id.clone();
                 std::thread::spawn({
                     let track_name = track.to_string();
-                    let cover_url = if cfg!(feature = "cover") { track.cover_url() } else { None };
+                    let cover_url = if cfg!(feature = "cover") {
+                        track.cover_url()
+                    } else {
+                        None
+                    };
                     move || send_notification(&track_name, cover_url, notification_id)
                 });
             }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -274,7 +274,7 @@ impl Queue {
                 let notification_id = self.notification_id.clone();
                 std::thread::spawn({
                     let track_name = track.to_string();
-                    let cover_url = track.cover_url();
+                    let cover_url = if cfg!(feature = "cover") { track.cover_url() } else { None };
                     move || send_notification(&track_name, cover_url, notification_id)
                 });
             }


### PR DESCRIPTION
Previously, cover images were downloaded and cached even when the corresponding feature flag was disabled; this adds a check to make sure that the cover image is actually used before trying to get and store it.