### PR TITLE
Fix some errors and warnings when enabling/disabling features

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -3,8 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::command::{
-    parse, Command, GotoMode, InsertSource, JumpMode, MoveAmount, MoveMode, SeekDirection,
-    ShiftMode, TargetMode,
+    parse, Command, GotoMode, JumpMode, MoveAmount, MoveMode, SeekDirection, ShiftMode, TargetMode,
 };
 use crate::config::Config;
 use crate::events::EventManager;
@@ -275,7 +274,6 @@ impl CommandManager {
             | Command::SaveQueue
             | Command::Delete
             | Command::Focus(_)
-            | Command::Share(_)
             | Command::Back
             | Command::Open(_)
             | Command::Goto(_)
@@ -285,6 +283,11 @@ impl CommandManager {
             | Command::Insert(_)
             | Command::ShowRecommendations(_)
             | Command::Sort(_, _) => Err(format!(
+                "The command \"{}\" is unsupported in this view",
+                cmd.basename()
+            )),
+            #[cfg(feature = "share_clipboard")]
+            Command::Share(_) => Err(format!(
                 "The command \"{}\" is unsupported in this view",
                 cmd.basename()
             )),
@@ -424,8 +427,12 @@ impl CommandManager {
 
         kb.insert("r".into(), vec![Command::Repeat(None)]);
         kb.insert("z".into(), vec![Command::Shuffle(None)]);
-        kb.insert("x".into(), vec![Command::Share(TargetMode::Selected)]);
-        kb.insert("Shift+x".into(), vec![Command::Share(TargetMode::Current)]);
+
+        #[cfg(feature = "share_clipboard")]
+        {
+            kb.insert("x".into(), vec![Command::Share(TargetMode::Selected)]);
+            kb.insert("Shift+x".into(), vec![Command::Share(TargetMode::Current)]);
+        }
 
         kb.insert("F1".into(), vec![Command::Focus("queue".into())]);
         kb.insert("F2".into(), vec![Command::Focus("search".into())]);
@@ -528,7 +535,7 @@ impl CommandManager {
         #[cfg(feature = "share_clipboard")]
         kb.insert(
             "Ctrl+v".into(),
-            vec![Command::Insert(InsertSource::Clipboard)],
+            vec![Command::Insert(crate::command::InsertSource::Clipboard)],
         );
 
         kb

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -14,9 +14,6 @@ use crate::model::playable::Playable;
 use crate::spotify::Spotify;
 use crate::{config::Config, spotify::PlayerEvent};
 
-#[cfg(feature = "cover")]
-use crate::ui;
-
 #[derive(Display, Clone, Copy, PartialEq, Debug, Serialize, Deserialize)]
 pub enum RepeatSetting {
     #[serde(rename = "off")]

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -1,4 +1,5 @@
 use std::cmp::Ordering;
+#[cfg(feature = "notify")]
 use std::sync::atomic::AtomicU32;
 use std::sync::{Arc, RwLock};
 
@@ -35,6 +36,7 @@ pub struct Queue {
     current_track: RwLock<Option<usize>>,
     spotify: Spotify,
     cfg: Arc<Config>,
+    #[cfg(feature = "notify")]
     notification_id: Arc<AtomicU32>,
 }
 
@@ -48,6 +50,7 @@ impl Queue {
             current_track: RwLock::new(queue_state.current_track),
             random_order: RwLock::new(queue_state.random_order),
             cfg,
+            #[cfg(feature = "notify")]
             notification_id: Arc::new(AtomicU32::new(0)),
         };
 

--- a/src/sharing.rs
+++ b/src/sharing.rs
@@ -14,7 +14,7 @@ use {
 
 #[cfg(feature = "share_selection")]
 use clipboard::{x11_clipboard, x11_clipboard::X11ClipboardContext};
-#[cfg(feature = "share_selection")]
+#[cfg(all(feature = "share_selection", feature = "wayland_clipboard"))]
 use wl_clipboard_rs::utils::{is_primary_selection_supported, PrimarySelectionCheckError};
 
 #[cfg(not(feature = "share_selection"))]
@@ -80,8 +80,8 @@ pub fn read_share() -> Option<String> {
         #[cfg(feature = "wayland_clipboard")]
         {
             //use wayland clipboard
-            match is_primary_selection_supported() {
-                Ok(supported) => {
+            string = match is_primary_selection_supported() {
+                Ok(_supported) => {
                     let result = get_contents(
                         paste::ClipboardType::Primary,
                         Seat::Unspecified,
@@ -124,11 +124,7 @@ pub fn read_share() -> Option<String> {
                 }
             }
         }
-        if let Some(s) = string {
-            Some(s)
-        } else {
-            None
-        }
+        string
     } else {
         //use x11 clipboard
         ClipboardProvider::new()

--- a/src/ui/contextmenu.rs
+++ b/src/ui/contextmenu.rs
@@ -43,6 +43,7 @@ enum ContextMenuAction {
     PlayTrack(Box<Track>),
     ShowItem(Box<dyn ListItem>),
     SelectArtist(Vec<Artist>),
+    #[cfg(feature = "share_clipboard")]
     ShareUrl(String),
     AddToPlaylist(Box<Track>),
     ShowRecommendations(Box<Track>),
@@ -183,13 +184,14 @@ impl ContextMenu {
         if let Some(a) = item.album(queue.clone()) {
             content.add_item("Show album", ContextMenuAction::ShowItem(Box::new(a)));
         }
-        if let Some(url) = item.share_url() {
-            #[cfg(feature = "share_clipboard")]
-            content.add_item("Share", ContextMenuAction::ShareUrl(url));
-        }
-        if let Some(url) = item.album(queue.clone()).and_then(|a| a.share_url()) {
-            #[cfg(feature = "share_clipboard")]
-            content.add_item("Share album", ContextMenuAction::ShareUrl(url));
+        #[cfg(feature = "share_clipboard")]
+        {
+            if let Some(url) = item.share_url() {
+                content.add_item("Share", ContextMenuAction::ShareUrl(url));
+            }
+            if let Some(url) = item.album(queue.clone()).and_then(|a| a.share_url()) {
+                content.add_item("Share album", ContextMenuAction::ShareUrl(url));
+            }
         }
         if let Some(t) = item.track() {
             content.insert_item(
@@ -232,8 +234,8 @@ impl ContextMenu {
                             s.call_on_name("main", move |v: &mut Layout| v.push_view(view));
                         }
                     }
+                    #[cfg(feature = "share_clipboard")]
                     ContextMenuAction::ShareUrl(url) => {
-                        #[cfg(feature = "share_clipboard")]
                         write_share(url.to_string());
                     }
                     ContextMenuAction::AddToPlaylist(track) => {

--- a/src/ui/cover.rs
+++ b/src/ui/cover.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::{Child, Stdio};

--- a/src/ui/cover.rs
+++ b/src/ui/cover.rs
@@ -239,6 +239,7 @@ impl ViewExt for CoverView {
                     track.unsave(self.library.clone());
                 }
             }
+            #[cfg(feature = "share_clipboard")]
             Command::Share(_mode) => {
                 let url = self
                     .queue
@@ -246,7 +247,6 @@ impl ViewExt for CoverView {
                     .and_then(|t| t.as_listitem().share_url());
 
                 if let Some(url) = url {
-                    #[cfg(feature = "share_clipboard")]
                     crate::sharing::write_share(url);
                 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 /// Returns a human readable String of a Duration
 ///
 /// Example: `3h 12m 53s`


### PR DESCRIPTION
Most were just unused imports and lint warnings, but `sharing.rs` was erroring with `wayland_clipboard` feature enabled.