### PR TITLE
Add desktop entry & notification icon hint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,5 +88,6 @@ It is heavily inspired by ncurses MPD clients, such as ncmpc."""
 license-file = ["LICENSE"]
 assets = [
     ["target/release/ncspot", "usr/bin/", "755"],
+    ["misc/ncspot.desktop", "usr/share/applications/", "644"],
     ["README.md", "usr/share/doc/ncspot/README.md", "644"],
 ]

--- a/misc/ncspot.desktop
+++ b/misc/ncspot.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=ncspot
+Comment=Cross-platform ncurses Spotify client written in Rust
+TryExec=ncspot
+Exec=ncspot
+Icon=ncspot
+Terminal=true
+Categories=AudioVideo;Audio;Player;ConsoleOnly
+Keywords=spotify;music;player

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -433,49 +433,45 @@ impl Queue {
 #[cfg(feature = "notify")]
 pub fn send_notification(
     track_name: &str,
-    _cover_url: Option<String>,
+    cover_url: Option<String>,
     notification_id: Arc<AtomicU32>,
 ) {
     let current_notification_id = notification_id.load(std::sync::atomic::Ordering::Relaxed);
-    let res = if let Some(u) = _cover_url {
-        // download album cover image
-        let path = crate::utils::cache_path_for_url(u.to_string());
 
+    let mut n = Notification::new();
+    n.appname("ncspot")
+        .id(current_notification_id)
+        .summary(track_name);
+
+    // album cover image
+    if let Some(u) = cover_url {
+        let path = crate::utils::cache_path_for_url(u.to_string());
         if !path.exists() {
             if let Err(e) = crate::utils::download(u, path.clone()) {
                 error!("Failed to download cover: {}", e);
             }
         }
+        n.icon(path.to_str().unwrap());
+    }
 
-        Notification::new()
-            .appname("ncspot")
-            .hint(Hint::DesktopEntry("ncspot".into()))
-            .id(current_notification_id)
-            .summary(track_name)
-            .icon(path.to_str().unwrap())
-            .show()
-    } else {
-        Notification::new()
-            .appname("ncspot")
-            .hint(Hint::DesktopEntry("ncspot".into()))
-            .id(current_notification_id)
-            .summary(track_name)
-            .show()
-    };
+    // XDG desktop entry hint
+    #[cfg(all(unix, not(target_os = "macos")))]
+    n.hint(Hint::DesktopEntry("ncspot".into()));
 
-    if let Ok(n) = res {
-        // only available for XDG
-        #[cfg(all(unix, not(target_os = "macos")))]
-        {
-            let new_notification_id = n.id();
-            log::debug!(
-                "new notification id: {}, previously: {}",
-                new_notification_id,
-                current_notification_id
-            );
-            notification_id.store(new_notification_id, std::sync::atomic::Ordering::Relaxed);
+    match n.show() {
+        Ok(_handle) => {
+            // only available for XDG
+            #[cfg(all(unix, not(target_os = "macos")))]
+            {
+                let new_notification_id = _handle.id();
+                log::debug!(
+                    "new notification id: {}, previously: {}",
+                    new_notification_id,
+                    current_notification_id
+                );
+                notification_id.store(new_notification_id, std::sync::atomic::Ordering::Relaxed);
+            }
         }
-    } else if let Err(e) = res {
-        error!("Failed to send notification cover: {}", e);
+        Err(e) => error!("Failed to send notification cover: {}", e),
     }
 }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, RwLock};
 
 use log::{debug, error, info};
 #[cfg(feature = "notify")]
-use notify_rust::{Hint, Notification};
+use notify_rust::{Hint, Notification, Urgency};
 
 use rand::prelude::*;
 use strum_macros::Display;
@@ -454,9 +454,11 @@ pub fn send_notification(
         n.icon(path.to_str().unwrap());
     }
 
-    // XDG desktop entry hint
+    // XDG desktop entry hints
     #[cfg(all(unix, not(target_os = "macos")))]
-    n.hint(Hint::DesktopEntry("ncspot".into()));
+    n.urgency(Urgency::Low)
+        .hint(Hint::Transient(true))
+        .hint(Hint::DesktopEntry("ncspot".into()));
 
     match n.show() {
         Ok(_handle) => {

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, RwLock};
 
 use log::{debug, error, info};
 #[cfg(feature = "notify")]
-use notify_rust::Notification;
+use notify_rust::{Hint, Notification};
 
 use rand::prelude::*;
 use strum_macros::Display;
@@ -449,6 +449,7 @@ pub fn send_notification(
 
         Notification::new()
             .appname("ncspot")
+            .hint(Hint::DesktopEntry("ncspot".into()))
             .id(current_notification_id)
             .summary(track_name)
             .icon(path.to_str().unwrap())
@@ -456,6 +457,7 @@ pub fn send_notification(
     } else {
         Notification::new()
             .appname("ncspot")
+            .hint(Hint::DesktopEntry("ncspot".into()))
             .id(current_notification_id)
             .summary(track_name)
             .show()


### PR DESCRIPTION
- Added a `.desktop` file so that the user can launch `ncspot` straight from the launcher of their desktop environment
- Added the desktop entry hint to notification so ncspot's logo can be displayed inline with the notification

On KDE Plasma:
- Before
![before](https://user-images.githubusercontent.com/28627918/171912281-959aa142-7d86-478a-b78b-8c42326476f5.png)
- After
![after](https://user-images.githubusercontent.com/28627918/171912288-df6ff376-4928-4f07-9a0a-96a2a20881c9.png)
