### PR TITLE
Add 'hide_display_names' config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,31 +325,32 @@ runtime use the `reload` command.
 
 Possible configuration values are:
 
-| Name                            | Description                                       | Possible values                                                 | Default     |
-|---------------------------------|---------------------------------------------------|-----------------------------------------------------------------|-------------|
-| `command_key`                   | Key to open command line                          | Single character                                                | `:`         |
-| `initial_screen`                | Screen to show after startup                      | `"library"`, `"search"`, `"queue"`, `"cover"`<sup>[1]</sup>     | `"library"` |
-| `use_nerdfont`                  | Turn nerdfont glyphs on/off                       | `true`, `false`                                                 | `false`     |
-| `flip_status_indicators`        | Reverse play/pause icon meaning<sup>[2]</sup>     | `true`, `false`                                                 | `false`     |
-| `backend`                       | Audio backend to use                              | String<sup>[3]</sup>                                            |             |
-| `backend_device`                | Audio device to configure the backend             | String                                                          |             |
-| `audio_cache`                   | Enable caching of audio files                     | `true`, `false`                                                 | `true`      |
-| `audio_cache_size`              | Maximum size of audio cache in MiB                | Number                                                          |             |
-| `volnorm`                       | Enable volume normalization                       | `true`, `false`                                                 | `false`     |
-| `volnorm_pregain`               | Normalization pregain to apply in dB (if enabled) | Number                                                          | `0.0`       |
-| `default_keybindings`           | Enable default keybindings                        | `true`, `false`                                                 | `false`     |
-| `notify`<sup>[4]</sup>          | Enable desktop notifications                      | `true`, `false`                                                 | `false`     |
-| `bitrate`                       | Audio bitrate to use for streaming                | `96`, `160`, `320`                                              | `320`       |
-| `album_column`                  | Show album column for tracks                      | `true`, `false`                                                 | `true`      |
-| `gapless`                       | Enable gapless playback                           | `true`, `false`                                                 | `true`      |
-| `shuffle`                       | Set default shuffle state                         | `true`, `false`                                                 | `false`     |
-| `repeat`                        | Set default repeat mode                           | `off`, `track`, `playlist`                                      | `off`       |
-| `playback_state`                | Set default playback state                        | `"Stopped"`, `"Paused"`, `"Playing"`, `"Default"`               | `"Paused"`  |
-| `library_tabs`                  | Tabs to show in library screen                    | Array of `tracks`, `albums`, `artists`, `playlists`, `podcasts` | All tabs    |
-| `cover_max_scale`<sup>[1]</sup> | Set maximum scaling ratio for cover art           | Number                                                          | `1.0`       |
-| `[track_format]`                | Set active fields shown in Library/Queue views    | See [track formatting](#track-formatting)                       |             |
-| `[theme]`                       | Custom theme                                      | See [custom theme](#theming)                                    |             |
-| `[keybindings]`                 | Custom keybindings                                | See [custom keybindings](#custom-keybindings)                   |             |
+| Name                            | Description                                                     | Possible values                                                 | Default     |
+|---------------------------------|-----------------------------------------------------------------|-----------------------------------------------------------------|-------------|
+| `command_key`                   | Key to open command line                                        | Single character                                                | `:`         |
+| `initial_screen`                | Screen to show after startup                                    | `"library"`, `"search"`, `"queue"`, `"cover"`<sup>[1]</sup>     | `"library"` |
+| `use_nerdfont`                  | Turn nerdfont glyphs on/off                                     | `true`, `false`                                                 | `false`     |
+| `flip_status_indicators`        | Reverse play/pause icon meaning<sup>[2]</sup>                   | `true`, `false`                                                 | `false`     |
+| `backend`                       | Audio backend to use                                            | String<sup>[3]</sup>                                            |             |
+| `backend_device`                | Audio device to configure the backend                           | String                                                          |             |
+| `audio_cache`                   | Enable caching of audio files                                   | `true`, `false`                                                 | `true`      |
+| `audio_cache_size`              | Maximum size of audio cache in MiB                              | Number                                                          |             |
+| `volnorm`                       | Enable volume normalization                                     | `true`, `false`                                                 | `false`     |
+| `volnorm_pregain`               | Normalization pregain to apply in dB (if enabled)               | Number                                                          | `0.0`       |
+| `default_keybindings`           | Enable default keybindings                                      | `true`, `false`                                                 | `false`     |
+| `notify`<sup>[4]</sup>          | Enable desktop notifications                                    | `true`, `false`                                                 | `false`     |
+| `bitrate`                       | Audio bitrate to use for streaming                              | `96`, `160`, `320`                                              | `320`       |
+| `album_column`                  | Show album column for tracks                                    | `true`, `false`                                                 | `true`      |
+| `gapless`                       | Enable gapless playback                                         | `true`, `false`                                                 | `true`      |
+| `shuffle`                       | Set default shuffle state                                       | `true`, `false`                                                 | `false`     |
+| `repeat`                        | Set default repeat mode                                         | `off`, `track`, `playlist`                                      | `off`       |
+| `playback_state`                | Set default playback state                                      | `"Stopped"`, `"Paused"`, `"Playing"`, `"Default"`               | `"Paused"`  |
+| `library_tabs`                  | Tabs to show in library screen                                  | Array of `tracks`, `albums`, `artists`, `playlists`, `podcasts` | All tabs    |
+| `cover_max_scale`<sup>[1]</sup> | Set maximum scaling ratio for cover art                         | Number                                                          | `1.0`       |
+| `hide_display_names`            | Hides spotify usernames in the library header and on playlists  | `true`, `false`                                                 | `false`     |
+| `[track_format]`                | Set active fields shown in Library/Queue views                  | See [track formatting](#track-formatting)                       |             |
+| `[theme]`                       | Custom theme                                                    | See [custom theme](#theming)                                    |             |
+| `[keybindings]`                 | Custom keybindings                                              | See [custom keybindings](#custom-keybindings)                   |             |
 
 1. If built with the `cover` feature.
 2. By default the statusbar will show a play icon when a track is playing and 

--- a/src/config.rs
+++ b/src/config.rs
@@ -74,6 +74,7 @@ pub struct ConfigValues {
     pub playback_state: Option<PlaybackState>,
     pub track_format: Option<TrackFormat>,
     pub library_tabs: Option<Vec<LibraryTab>>,
+    pub hide_display_names: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]

--- a/src/model/playlist.rs
+++ b/src/model/playlist.rs
@@ -191,10 +191,11 @@ impl ListItem for Playlist {
         }
     }
 
-    fn display_left(&self, _library: Arc<Library>) -> String {
-        match self.owner_name.as_ref() {
-            Some(owner) => format!("{} • {}", self.name, owner),
-            None => self.name.clone(),
+    fn display_left(&self, library: Arc<Library>) -> String {
+        let hide_owners = library.cfg.values().hide_display_names.unwrap_or(false);
+        match (self.owner_name.as_ref(), hide_owners) {
+            (Some(owner), false) => format!("{} • {}", self.name, owner),
+            _ => self.name.clone(),
         }
     }
 

--- a/src/ui/library.rs
+++ b/src/ui/library.rs
@@ -61,7 +61,19 @@ impl LibraryView {
 
         Self {
             tabs: tabview,
-            display_name: library.display_name.clone(),
+            display_name: {
+                let hide_username = library
+                    .cfg
+                    .values()
+                    .hide_display_names
+                    .clone()
+                    .unwrap_or(false);
+                if hide_username {
+                    None
+                } else {
+                    library.display_name.clone()
+                }
+            },
         }
     }
 }


### PR DESCRIPTION
Adds an option to the `config.toml` that allows a user to disable the display of usernames in the main library tab and against playlists.

This also updates the README.md file to account for this additional config option. 

This implementation follows a similar pattern to configuring custom [library_tabs](https://github.com/hrkfdn/ncspot/blob/main/src/ui/library.rs#L25), and custom [track_format](https://github.com/hrkfdn/ncspot/blob/main/src/model/track.rs#L186)

Fixes #853 