### PR TITLE
Switch Cursive backend defualt to termion for true color support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ optional = true
 [features]
 alsa_backend = ["librespot-playback/alsa-backend"]
 cover = ["ioctl-rs"] # Support displaying the album cover
-default = ["share_clipboard", "pulseaudio_backend", "mpris", "notify", "pancurses_backend"]
+default = ["share_clipboard", "pulseaudio_backend", "mpris", "notify", "termion_backend"]
 mpris = ["dbus", "dbus-tree"] # Allow ncspot to be controlled via MPRIS API
 notify = ["notify-rust"] # Show what's playing via a notification
 pancurses_backend = ["cursive/pancurses-backend", "pancurses/win32"]


### PR DESCRIPTION
Cursive supports true color support (rather than just the 256 terminal colors), but not with all backends. ncspot's default does not appear to be one that supports true color.

ncspot already has a feature flag for termion, which does support true color, so I suggest making that Cursive backend the default.