### PR TITLE
Fixes a pagination bug that caused items to not load when scrolling with the mouse

### DIFF
--- a/src/ui/pagination.rs
+++ b/src/ui/pagination.rs
@@ -85,6 +85,13 @@ impl<I: ListItem + Clone> ApiResult<I> {
 
 pub type Paginator<I> = Box<dyn Fn(Arc<RwLock<Vec<I>>>) + Send + Sync>;
 
+/// Manages the loading of ListItems, to increase performance and decrease
+/// memory usage.
+///
+/// `loaded_content`: The amount of currently loaded items
+/// `max_content`: The maximum amount of items
+/// `callback`: TODO: document
+/// `busy`: TODO: document
 pub struct Pagination<I: ListItem> {
     loaded_content: Arc<RwLock<usize>>,
     max_content: Arc<RwLock<Option<usize>>>,


### PR DESCRIPTION
This PR fixes the pagination but that prevented loading. I also added some documentation to some of the less obvious methods. There is still a bug present that causes the pagination message to appear at the bottom of the Browse tab, even when there isn't any more items. Help would be wanted with fixing that. I could also open another separate bug report for that if that's easier :slightly_smiling_face: .

fixes #938 