### PR TITLE
Cleanup: Remove PlayTrackMenu

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -13,7 +13,7 @@ use crate::queue::{Queue, RepeatSetting};
 use crate::spotify::{Spotify, VOLUME_PERCENT};
 use crate::traits::{IntoBoxedViewExt, ViewExt};
 use crate::ui::contextmenu::{
-    AddToPlaylistMenu, ContextMenu, PlayTrackMenu, SelectArtistActionMenu, SelectArtistMenu,
+    AddToPlaylistMenu, ContextMenu, SelectArtistActionMenu, SelectArtistMenu,
 };
 use crate::ui::help::HelpView;
 use crate::ui::layout::Layout;
@@ -308,8 +308,6 @@ impl CommandManager {
             s.find_name::<SelectArtistActionMenu>("selectartistaction")
         {
             select_artist_action.on_command(s, cmd)?
-        } else if let Some(mut play_track) = s.find_name::<PlayTrackMenu>("playtrackmenu") {
-            play_track.on_command(s, cmd)?
         } else {
             s.on_layout(|siv, mut l| l.on_command(siv, cmd))?
         };

--- a/src/ui/contextmenu.rs
+++ b/src/ui/contextmenu.rs
@@ -25,10 +25,6 @@ pub struct ContextMenu {
     dialog: Modal<Dialog>,
 }
 
-pub struct PlayTrackMenu {
-    dialog: Modal<Dialog>,
-}
-
 pub struct AddToPlaylistMenu {
     dialog: Modal<Dialog>,
 }
@@ -340,13 +336,6 @@ impl ContextMenu {
     }
 }
 
-impl ViewExt for PlayTrackMenu {
-    fn on_command(&mut self, s: &mut Cursive, cmd: &Command) -> Result<CommandResult, String> {
-        log::info!("playtrack command: {:?}", cmd);
-        handle_move_command::<bool>(&mut self.dialog, s, cmd, "playtrack_select")
-    }
-}
-
 impl ViewExt for AddToPlaylistMenu {
     fn on_command(&mut self, s: &mut Cursive, cmd: &Command) -> Result<CommandResult, String> {
         log::info!("playlist command: {:?}", cmd);
@@ -391,10 +380,6 @@ fn handle_move_command<T: 'static>(
             .unwrap_or(Ok(CommandResult::Consumed(None))),
         _ => Ok(CommandResult::Consumed(None)),
     }
-}
-
-impl ViewWrapper for PlayTrackMenu {
-    wrap_impl!(self.dialog: Modal<Dialog>);
 }
 
 impl ViewWrapper for AddToPlaylistMenu {


### PR DESCRIPTION
PlayTrackMenu was used before the refactor of the contextmenus. I forgot to clean up the struct before making the commit since rustc didn't complain. Just cleaning up my mistakes ;)