### PR TITLE
Fix: Crash on liked artist but no liked music

### DIFF
--- a/src/queue.rs
+++ b/src/queue.rs
@@ -273,9 +273,11 @@ impl Queue {
     }
 
     pub fn play(&self, mut index: usize, reshuffle: bool, shuffle_index: bool) {
-        if shuffle_index && self.get_shuffle() {
+        let queue_length = self.queue.read().unwrap().len();
+        // The length of the queue must be bigger than 0 or gen_range panics!
+        if queue_length > 0 && shuffle_index && self.get_shuffle() {
             let mut rng = rand::thread_rng();
-            index = rng.gen_range(0..self.queue.read().unwrap().len());
+            index = rng.gen_range(0..queue_length);
         }
 
         if let Some(track) = &self.queue.read().unwrap().get(index) {

--- a/src/ui/cover.rs
+++ b/src/ui/cover.rs
@@ -204,7 +204,7 @@ impl View for CoverView {
             }
         });
 
-        let cover_url = self.queue.get_current().map(|t| t.cover_url()).flatten();
+        let cover_url = self.queue.get_current().and_then(|t| t.cover_url());
 
         if let Some(url) = cover_url {
             self.draw_cover(url, printer.offset, printer.size);

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -143,6 +143,7 @@ impl Layout {
         self.get_focussed_stack_mut().map(|stack| stack.pop());
     }
 
+    #[allow(clippy::borrowed_box)]
     fn get_current_screen(&self) -> Option<&Box<dyn ViewExt>> {
         self.focus
             .as_ref()
@@ -168,6 +169,7 @@ impl Layout {
             .unwrap_or(false)
     }
 
+    #[allow(clippy::borrowed_box)]
     fn get_top_view(&self) -> Option<&Box<dyn ViewExt>> {
         let focussed_stack = self.get_focussed_stack();
         if focussed_stack.map(|s| s.len()).unwrap_or_default() > 0 {


### PR DESCRIPTION
Like mentioned in the corresponding issue by ayushjaipuriyar, ncspot would crash when the queue was empty, shuffled, and played. This commit fixes that, together with some minor clippy fixes.

fixes #943 