### PR TITLE
main.rs: println before setting up cursive backend.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -168,6 +168,7 @@ async fn main() -> Result<(), String> {
         credentials = credentials_prompt(Some(error_msg))?;
     }
 
+    println!("Connecting to Spotify..");
     let backend = cursive::backends::try_default().map_err(|e| e.to_string())?;
     let buffered_backend = Box::new(cursive_buffered_backend::BufferedBackend::new(backend));
 
@@ -179,7 +180,6 @@ async fn main() -> Result<(), String> {
 
     let event_manager = EventManager::new(cursive.cb_sink().clone());
 
-    println!("Connecting to Spotify..");
     let spotify = spotify::Spotify::new(event_manager.clone(), credentials, cfg.clone());
 
     let library = Arc::new(Library::new(&event_manager, spotify.clone(), cfg.clone()));


### PR DESCRIPTION
It appears that calling `println!` after setting the cursive backend is causing the cursor on the new line to shift to the end position of the `Connecting to Spotify..` message. After exiting `ncspot`, the user prompt appears in this offset position. Calling `println!` before the backend instead keeps the cursor at the start of the new line.