### PR TITLE
Add new cargo build profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ version = "0.11.2"
 # Build time is very slow, but binaries are smaller.
 [profile.release]
 lto = true
-strip = true
 codegen-units = 1
 
 # Used when creating optimized builds for testing.
@@ -23,7 +22,7 @@ codegen-units = 1
 [profile.optimized]
 inherits = "release"
 lto = false
-strip = false
+codegen-units = 16
 
 [badges]
 maintenance = {status = "actively-developed"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ version = "0.11.2"
 [profile.release]
 lto = true
 strip = true
+codegen-units = 1
 
 # Used when creating optimized builds for testing.
 # Build time is much faster than release, but performance should be about the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,20 @@ readme = "README.md"
 repository = "https://github.com/hrkfdn/ncspot"
 version = "0.11.2"
 
+# Used only when releasing final builds of ncspot.
+# Build time is very slow, but binaries are smaller.
+[profile.release]
+lto = true
+strip = true
+
+# Used when creating optimized builds for testing.
+# Build time is much faster than release, but performance should be about the
+# same.
+[profile.optimized]
+inherits = "release"
+lto = false
+strip = false
+
 [badges]
 maintenance = {status = "actively-developed"}
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,29 @@ For debugging, you can pass a debug log filename and pipe `stderr` to a file:
 RUST_BACKTRACE=full cargo run -- -d debug.log 2> stderr.log
 ```
 
+#### Cargo profiles
+
+- release:
+Used for final releases. Creates the most optimized binaries.
+
+```
+cargo build --release
+```
+
+- optimized:
+Used for optimized test builds, when optimizing for size isn't neccesary.
+
+```
+cargo build --profile optimized
+```
+
+- dev:
+Used for development and debugging.
+
+```
+cargo build
+```
+
 #### Building a Debian Package
 
 You can also use `cargo-deb` to build a Debian package


### PR DESCRIPTION
I did some tests and with lto and stripping applied (which isn't done for the current release bulids on the Github release page of ncspot), the size of the compiled binary drops from 30M to 13M. Normally package managers strip the binary, but this could be a nice addition for people who download ncspot from the release builds. Since the compilation time almost doubles, I added an optimized profile which is just the previous release profile.

It might make sense to switch these options around, and have something like a "actual-release" profile instead, but then all of the package managers would have to switch to that. I think this is a little more seamless, although now you'd make "normal" release builds with a slightly longer command...