### PR TITLE
fix(backtrace): Fix backtrace logging and stdout

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,9 +30,14 @@ If applicable, add screenshots to help explain your problem.
  - Installed from: [e.g. AUR, brew, cargo]
 
 **Backtrace/Debug log**
-Instructions on how to capture debug logs: https://github.com/hrkfdn/ncspot#usage
+Please attach a debug log and backtrace if ncspot has crashed.
 
-To debug crashes a backtrace is very helpful. Make sure you run a debug build of ncspot, e.g. by running the command mentioned in the link above.
+Instructions on how to capture debug logs: https://github.com/hrkfdn/ncspot#debugging
+
+For backtraces, make sure you run a debug build of ncspot, e.g. by running the
+command mentioned in the [compilation
+instructions](https://github.com/hrkfdn/ncspot#compiling).  You can find the
+latest backtrace at `~/.cache/ncspot/backtrace.log`.
 
 **Additional context**
 Add any other context about the problem here.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ You **must** have an existing premium Spotify subscription to use `ncspot`.
     - [On Linux](#on-linux)
   - [Build](#build)
     - [Prerequisites](#prerequisites)
+    - [Debugging](#debugging)
     - [Compiling](#compiling)
       - [Building a Debian Package](#building-a-debian-package)
     - [Audio Backends](#audio-backends)
@@ -126,6 +127,16 @@ On Linux, you also need:
     sudo pacman -S dbus libpulse libxcb ncurses openssl
     ```
 
+### Debugging
+
+For debugging, you can pass a debug log filename:
+
+```sh
+RUST_BACKTRACE=full cargo run -- -d debug.log
+```
+
+If ncspot has crashed you can find the latest backtrace at `~/.cache/ncspot/backtrace.log`.
+
 ### Compiling
 
 Compile and install the latest release with `cargo-install`:
@@ -143,12 +154,6 @@ cargo build --release
 
 **You may need to manually set the audio backend on non-Linux OSes.** See
 [Audio Backends](#audio-backends).
-
-For debugging, you can pass a debug log filename and pipe `stderr` to a file:
-
-```sh
-RUST_BACKTRACE=full cargo run -- -d debug.log 2> stderr.log
-```
 
 #### Building a Debian Package
 

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -18,13 +18,13 @@ pub trait Serializer {
         // Nothing exists so just write the default and return it
         if !path.exists() {
             let value = default()?;
-            return self.write(&path, value);
+            return self.write(path, value);
         }
 
-        let result = self.load(&path);
+        let result = self.load(path);
         if default_on_parse_failure && result.is_err() {
             let value = default()?;
-            return self.write(&path, value);
+            return self.write(path, value);
         }
         result.map_err(|e| format!("Unable to parse {}: {}", path.to_string_lossy(), e))
     }

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -204,7 +204,7 @@ impl View for Layout {
         let result = self.get_result();
 
         let cmdline_visible = self.cmdline.get_content().len() > 0;
-        let mut cmdline_height = if cmdline_visible { 1 } else { 0 };
+        let mut cmdline_height = usize::from(cmdline_visible);
         if result.as_ref().map(Option::is_some).unwrap_or(true) {
             cmdline_height += 1;
         }
@@ -318,7 +318,7 @@ impl View for Layout {
             let result = self.get_result();
 
             let cmdline_visible = self.cmdline.get_content().len() > 0;
-            let mut cmdline_height = if cmdline_visible { 1 } else { 0 };
+            let mut cmdline_height = usize::from(cmdline_visible);
             if result.as_ref().map(Option::is_some).unwrap_or(true) {
                 cmdline_height += 1;
             }


### PR DESCRIPTION
- Add manual implementation for panic that logs backtrace to a file.
- Remove all manual output to stdout.
- Fix new clippy warnings from Rust 1.65.