### PR TITLE
Make entry point synchronous and switch to global runtime instead.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -117,8 +117,15 @@ struct UserDataInner {
     pub cmd: CommandManager,
 }
 
-#[tokio::main]
-async fn main() -> Result<(), String> {
+lazy_static!(
+    /// The global Tokio runtime for running asynchronous tasks.
+    static ref ASYNC_RUNTIME: tokio::runtime::Runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+);
+
+fn main() -> Result<(), String> {
     register_backtrace_panic_handler();
 
     let backends = {


### PR DESCRIPTION
An example to illustrate what I mean in issue #993. This isn't meant to be merged (therefore a draft PR), but more as a way to show the proposed changes in the issue. Not a lot would have to change. From what I understand about async, this wouldn't have negative performance implications, but I might be wrong about this. I tested this and it works like before.