### PR TITLE
Add back PanicInfo to backtrace.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -93,12 +93,11 @@ fn credentials_prompt(error_message: Option<String>) -> Result<Credentials, Stri
     authentication::create_credentials()
 }
 
-#[inline]
 fn register_backtrace_panic_handler() {
     // During most of the program, Cursive is responsible for drawing to the
     // tty. Since stdout probably doesn't work as expected during a panic, the
     // backtrace is written to a file at $USER_CACHE_DIR/ncspot/backtrace.log.
-    std::panic::set_hook(Box::new(|_panic_info| {
+    std::panic::set_hook(Box::new(|panic_info| {
         // A panic hook will prevent the default panic handler from being
         // called. An unwrap in this part would cause a hard crash of ncspot.
         // Don't unwrap/expect/panic in here!
@@ -107,6 +106,7 @@ fn register_backtrace_panic_handler() {
             path.push("backtrace.log");
             if let Ok(mut file) = File::create(path) {
                 writeln!(file, "{}", backtrace::Backtrace::force_capture()).unwrap_or_default();
+                writeln!(file, "{}", panic_info).unwrap_or_default();
             }
         }
     }));


### PR DESCRIPTION
Just a small PR because I forgot to add the PanicInfo to the backtrace when I wrote that panic handler. It makes the backtrace easier to read at a glance.

### Example (last line):
```
[...]
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/std/src/rt.rs:165:17
  30: main
  31: <unknown>
  32: __libc_start_main
  33: _start
             at /build/glibc/src/glibc/csu/../sysdeps/x86_64/start.S:115

panicked at 'explicit panic', src/main.rs:123:5
```