### PR TITLE
theme config support for cursive's HighlightInactive

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -106,6 +106,7 @@ pub struct ConfigTheme {
     pub playing_bg: Option<String>,
     pub highlight: Option<String>,
     pub highlight_bg: Option<String>,
+    pub highlight_inactive_bg: Option<String>,
     pub error: Option<String>,
     pub error_bg: Option<String>,
     pub statusbar_progress: Option<String>,

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -33,6 +33,7 @@ pub fn load(theme_cfg: &Option<ConfigTheme>) -> Theme {
     palette[TitlePrimary] = load_color!(theme_cfg, title, Dark(Red));
     palette[HighlightText] = load_color!(theme_cfg, highlight, Dark(White));
     palette[Highlight] = load_color!(theme_cfg, highlight_bg, Dark(Red));
+    palette[HighlightInactive] = load_color!(theme_cfg, highlight_inactive_bg, Dark(Blue));
     palette.set_color("playing", load_color!(theme_cfg, playing, Dark(Blue)));
     palette.set_color(
         "playing_selected",


### PR DESCRIPTION
Hi, thanks for this awesome software.

With the color theme I'm using, opening the context menu for a track and tabbing to the "Close" button, it was hard to read the focused (but now inactive) selected item in the list. cursive defaults to using dark blue for the HighlightInactive PaletteStyle for such items in a SelectView, and it seems useful to allow users to override this.

I added a theme option "highlight_inactive_bg" which overrides the default HighlightInactive color from cursive.