### PR TITLE
Switch from MM:SS to HH:MM:SS duration representation if needed.

### DIFF
--- a/src/model/episode.rs
+++ b/src/model/episode.rs
@@ -2,6 +2,7 @@ use crate::library::Library;
 use crate::model::playable::Playable;
 use crate::queue::Queue;
 use crate::traits::{ListItem, ViewExt};
+use crate::utils::ms_to_hms;
 use chrono::{DateTime, Utc};
 use rspotify::model::show::{FullEpisode, SimplifiedEpisode};
 use rspotify::model::Id;
@@ -23,9 +24,7 @@ pub struct Episode {
 
 impl Episode {
     pub fn duration_str(&self) -> String {
-        let minutes = self.duration / 60_000;
-        let seconds = (self.duration / 1000) % 60;
-        format!("{minutes:02}:{seconds:02}")
+        ms_to_hms(self.duration)
     }
 }
 

--- a/src/model/playable.rs
+++ b/src/model/playable.rs
@@ -8,6 +8,7 @@ use crate::model::episode::Episode;
 use crate::model::track::Track;
 use crate::queue::Queue;
 use crate::traits::{ListItem, ViewExt};
+use crate::utils::ms_to_hms;
 use std::fmt;
 use std::sync::Arc;
 
@@ -118,10 +119,7 @@ impl Playable {
     }
 
     pub fn duration_str(&self) -> String {
-        let duration = self.duration();
-        let minutes = duration / 60_000;
-        let seconds = (duration / 1000) % 60;
-        format!("{minutes:02}:{seconds:02}")
+        ms_to_hms(self.duration())
     }
 
     pub fn as_listitem(&self) -> Box<dyn ListItem> {

--- a/src/model/track.rs
+++ b/src/model/track.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::sync::{Arc, RwLock};
 
 use crate::config;
+use crate::utils::ms_to_hms;
 use chrono::{DateTime, Utc};
 use rspotify::model::album::FullAlbum;
 use rspotify::model::track::{FullTrack, SavedTrack, SimplifiedTrack};
@@ -72,9 +73,7 @@ impl Track {
     }
 
     pub fn duration_str(&self) -> String {
-        let minutes = self.duration / 60_000;
-        let seconds = (self.duration / 1000) % 60;
-        format!("{minutes:02}:{seconds:02}")
+        ms_to_hms(self.duration)
     }
 }
 

--- a/src/ui/statusbar.rs
+++ b/src/ui/statusbar.rs
@@ -12,6 +12,7 @@ use crate::library::Library;
 use crate::model::playable::Playable;
 use crate::queue::{Queue, RepeatSetting};
 use crate::spotify::{PlayerEvent, Spotify};
+use crate::utils::ms_to_hms;
 
 pub struct StatusBar {
     queue: Arc<Queue>,
@@ -165,11 +166,7 @@ impl View for StatusBar {
         let elapsed = self.spotify.get_current_progress();
         let elapsed_ms = elapsed.as_millis() as u32;
 
-        let formatted_elapsed = format!(
-            "{:02}:{:02}",
-            elapsed.as_secs() / 60,
-            elapsed.as_secs() % 60
-        );
+        let formatted_elapsed = ms_to_hms(elapsed.as_millis().try_into().unwrap_or(0));
 
         let playback_duration_status = match self.queue.get_current() {
             Some(ref t) => format!("{} / {}", formatted_elapsed, t.duration_str()),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -35,8 +35,6 @@ pub fn ms_to_hms(duration: u32) -> String {
 
     if hours > 0 {
         formated_time.push_str(&format!("{hours}:"));
-    }
-    if hours > 0 {
         formated_time.push_str(&format!("{minutes:02}:"));
     } else {
         formated_time.push_str(&format!("{minutes}:"));

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -24,6 +24,28 @@ pub fn format_duration(d: &std::time::Duration) -> String {
     s.trim_end().to_string()
 }
 
+/// Returns a human readable String of milliseconds in the HH:MM:SS format.
+pub fn ms_to_hms(duration: u32) -> String {
+    let mut formated_time = String::new();
+
+    let total_seconds = duration / 1000;
+    let seconds = total_seconds % 60;
+    let minutes = (total_seconds / 60) % 60;
+    let hours = total_seconds / 3600;
+
+    if hours > 0 {
+        formated_time.push_str(&format!("{hours}:"));
+    }
+    if hours > 0 {
+        formated_time.push_str(&format!("{minutes:02}:"));
+    } else {
+        formated_time.push_str(&format!("{minutes}:"));
+    }
+    formated_time.push_str(&format!("{seconds:02}"));
+
+    formated_time
+}
+
 pub fn cache_path_for_url(url: String) -> std::path::PathBuf {
     let mut path = crate::config::cache_path("covers");
     path.push(url.split('/').last().unwrap());

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -34,8 +34,7 @@ pub fn ms_to_hms(duration: u32) -> String {
     let hours = total_seconds / 3600;
 
     if hours > 0 {
-        formated_time.push_str(&format!("{hours}:"));
-        formated_time.push_str(&format!("{minutes:02}:"));
+        formated_time.push_str(&format!("{hours}:{minutes:02}:"));
     } else {
         formated_time.push_str(&format!("{minutes}:"));
     }


### PR DESCRIPTION
This PR applies the same logic to durations as the native Spotify client:
0:00
0:01
0:23
0:20
1:00
10:02
1:00:00
1:01:01
...

It applies it to all the places where currently the old method was used (statusbar left and right, track durations, episode durations).

closes #1048 