### PR TITLE
let everyone have covers in their notifications

### DIFF
--- a/src/queue.rs
+++ b/src/queue.rs
@@ -338,11 +338,7 @@ impl Queue {
 
                     let summary_txt = Playable::format(track, &title, self.library.clone());
                     let body_txt = Playable::format(track, &body, self.library.clone());
-                    let cover_url = if cfg!(feature = "cover") {
-                        track.cover_url()
-                    } else {
-                        None
-                    };
+                    let cover_url = track.cover_url();
                     move || send_notification(&summary_txt, &body_txt, cover_url, notification_id)
                 });
             }


### PR DESCRIPTION
I don't know why this check exists, because at least to my understanding the cover feature is only for drawing the covers in the terminal. 

I tested this and it displayed the covers in my notifications without needing the "cover" feature, at least i think the cover feature isn't automatically enabled when i compile it with `cargo build`. 

And i personally don't see a reason why covers shouldn't be displayed for everyone. I don't want to use the "cover" feature but having the cover in my notifications is a thing i want.