### PR TITLE
commands: Adding "disconnect" command to force socket shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ Note: \<FOO\> - mandatory arg; [BAR] - optional arg
 | `exec` \<CMD\>                                                   | Execute a command in the system shell.<br/>\* Command output is printed to the terminal, so redirection (`2> /dev/null`) may be necessary.                                                                                                                      |
 | `noop`                                                           | Do nothing. Useful for disabling default keybindings. See [custom keybindings](#custom-keybindings).                                                                                                                                                            |
 | `reload`                                                         | Reload the configuration from disk. See [Configuration](#configuration).                                                                                                                                                                                        |
+| `reconnect`                                                      | Reconnect to Spotify (useful when session has expired or connection was lost                                                                                                                                                                                    |
 
 ## Remote control (IPC)
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -157,7 +157,7 @@ pub enum Command {
     ShowRecommendations(TargetMode),
     Redraw,
     Execute(String),
-    Disconnect,
+    Reconnect,
 }
 
 impl fmt::Display for Command {
@@ -217,7 +217,7 @@ impl fmt::Display for Command {
             | Command::ReloadConfig
             | Command::Noop
             | Command::Logout
-            | Command::Disconnect
+            | Command::Reconnect
             | Command::Redraw => vec![],
         };
         repr_tokens.append(&mut extras_args);
@@ -268,7 +268,7 @@ impl Command {
             Command::ShowRecommendations(_) => "similar",
             Command::Redraw => "redraw",
             Command::Execute(_) => "exec",
-            Command::Disconnect => "disconnect",
+            Command::Reconnect => "reconnect",
         }
     }
 }
@@ -724,7 +724,7 @@ pub fn parse(input: &str) -> Result<Vec<Command>, CommandParseError> {
                 }
                 "redraw" => Command::Redraw,
                 "exec" => Command::Execute(args.join(" ")),
-                "disconnect" => Command::Disconnect,
+                "reconnect" => Command::Reconnect,
                 _ => {
                     return Err(NoSuchCommand {
                         cmd: command.into(),

--- a/src/command.rs
+++ b/src/command.rs
@@ -157,6 +157,7 @@ pub enum Command {
     ShowRecommendations(TargetMode),
     Redraw,
     Execute(String),
+    Disconnect,
 }
 
 impl fmt::Display for Command {
@@ -216,6 +217,7 @@ impl fmt::Display for Command {
             | Command::ReloadConfig
             | Command::Noop
             | Command::Logout
+            | Command::Disconnect
             | Command::Redraw => vec![],
         };
         repr_tokens.append(&mut extras_args);
@@ -266,6 +268,7 @@ impl Command {
             Command::ShowRecommendations(_) => "similar",
             Command::Redraw => "redraw",
             Command::Execute(_) => "exec",
+            Command::Disconnect => "disconnect",
         }
     }
 }
@@ -721,6 +724,7 @@ pub fn parse(input: &str) -> Result<Vec<Command>, CommandParseError> {
                 }
                 "redraw" => Command::Redraw,
                 "exec" => Command::Execute(args.join(" ")),
+                "disconnect" => Command::Disconnect,
                 _ => {
                     return Err(NoSuchCommand {
                         cmd: command.into(),

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -269,6 +269,11 @@ impl CommandManager {
                 log::info!("Exit code: {}", result);
                 Ok(None)
             }
+            Command::Disconnect => {
+                self.spotify.shutdown();
+                Ok(None)
+            }
+
 
             Command::Queue
             | Command::PlayNext

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -269,11 +269,10 @@ impl CommandManager {
                 log::info!("Exit code: {}", result);
                 Ok(None)
             }
-            Command::Disconnect => {
+            Command::Reconnect => {
                 self.spotify.shutdown();
                 Ok(None)
             }
-
 
             Command::Queue
             | Command::PlayNext


### PR DESCRIPTION
Hi, this pull request add a "disconnect" command, usefull when your connection change and you want to force closing the socket for reconnect