### PR TITLE
config / authentication: permit to call external program for getting …

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ You **must** have an existing premium Spotify subscription to use `ncspot`.
     - [Notification Formatting](#notification-formatting)
   - [Cover Drawing](#cover-drawing)
   - [Authentication](#authentication)
+    - [Using a password manager](#using-a-password-manager)
 
 ## Resource Footprint Comparison
 
@@ -608,3 +609,18 @@ The credentials are stored in `~/.cache/ncspot/librespot/credentials.json`
 
 The `logout` command can be used to remove cached credentials. See
 [Vim-Like Commands](#vim-like-commands).
+
+### Using a password manager
+
+If you would like ncspot to retrieve your login data from command results,
+i.e. because you use a password manager like `pass`, you can add the following
+configuration:
+
+```toml
+[credentials]
+username_cmd = "echo username"
+password_cmd = "pass spotify.com/username"
+```
+
+Do note that this is only required for the initial login or when your credential
+token has expired.

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -1,3 +1,5 @@
+use std::process::Command;
+
 use cursive::traits::Resizable;
 use cursive::view::Nameable;
 use cursive::views::*;
@@ -58,6 +60,30 @@ pub fn create_credentials() -> Result<RespotCredentials, String> {
         .user_data()
         .cloned()
         .unwrap_or_else(|| Err("Didn't obtain any credentials".to_string()))
+}
+
+pub fn credentials_eval(username: String, passeval: String) -> Result<RespotCredentials, String> {
+    println!("using username {}", username);
+    println!("getting password using passeval {}", passeval);
+
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(passeval)
+        .output()
+        .expect("Failed to execute command");
+    let mut auth_data = output.stdout;
+
+    if let Some(&last_byte) = auth_data.last() {
+        if last_byte == 10 {
+            auth_data.pop();
+        }
+    }
+
+    Ok(RespotCredentials {
+        username,
+        auth_type: AuthenticationType::AUTHENTICATION_USER_PASS,
+        auth_data,
+    })
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,8 +93,13 @@ pub struct ConfigValues {
     pub statusbar_format: Option<String>,
     pub library_tabs: Option<Vec<LibraryTab>>,
     pub hide_display_names: Option<bool>,
-    pub creds_username: Option<String>,
-    pub creds_passeval: Option<String>,
+    pub credentials: Option<Credentials>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+pub struct Credentials {
+    pub username_cmd: Option<String>,
+    pub password_cmd: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,6 +93,8 @@ pub struct ConfigValues {
     pub statusbar_format: Option<String>,
     pub library_tabs: Option<Vec<LibraryTab>>,
     pub hide_display_names: Option<bool>,
+    pub creds_username: Option<String>,
+    pub creds_passeval: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,14 +192,12 @@ fn main() -> Result<(), String> {
                 c
             }
             None => {
-                let c = cfg.clone();
-                let config = c.values();
-                let creds_username = config.creds_username.clone();
-                let creds_passeval = config.creds_passeval.clone();
+                info!("Attempting to resolve credentials via username/password commands");
+                let creds = cfg.values().credentials.clone().unwrap_or_default();
 
-                match (creds_username, creds_passeval) {
-                    (Some(username), Some(passeval)) => {
-                        authentication::credentials_eval(username, passeval)?
+                match (creds.username_cmd, creds.password_cmd) {
+                    (Some(username_cmd), Some(password_cmd)) => {
+                        authentication::credentials_eval(&username_cmd, &password_cmd)?
                     }
                     _ => credentials_prompt(None)?,
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -191,7 +191,19 @@ fn main() -> Result<(), String> {
                 info!("Using cached credentials");
                 c
             }
-            None => credentials_prompt(None)?,
+            None => {
+                let c = cfg.clone();
+                let config = c.values();
+                let creds_username = config.creds_username.clone();
+                let creds_passeval = config.creds_passeval.clone();
+
+                match (creds_username, creds_passeval) {
+                    (Some(username), Some(passeval)) => {
+                        authentication::credentials_eval(username, passeval)?
+                    }
+                    _ => credentials_prompt(None)?,
+                }
+            }
         }
     };
 


### PR DESCRIPTION
Hi, with this pull request

You can add into your ncspot/config.toml like this:

```
creds_username = "mylogin"
creds_passeval = "pass my_pass_path_to_spot_password"
```

Or using any password manager who send your password.to stdout. If a newline is detected it will be automatically removed