### PR TITLE
Add manpage generation using xtask.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [alias]
-xtask = "run --package xtask --"
+xtask = "run --quiet --package xtask --"

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 tags
 
 /.vscode/
+
+# Ignore generated manpages
+*.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,6 +320,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_mangen"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48283ce8d5cd9513633949a674a0442bcb507ab61ed6533863437052ddbb494b"
+dependencies = [
+ "clap",
+ "roff",
+]
+
+[[package]]
 name = "clipboard"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2602,6 +2612,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "roff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b833d8d034ea094b1ea68aa6d5c740e0d04bad9d16568d08ba6f76823a114316"
+
+[[package]]
 name = "rspotify"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3855,6 +3871,14 @@ name = "xml-rs"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
+
+[[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "clap_mangen",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3878,6 +3878,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "clap_mangen",
+ "ncspot",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,12 @@ version = "0.12.0"
 [badges]
 maintenance = {status = "actively-developed"}
 
+[workspace]
+members = [
+    ".",
+    "xtask"
+]
+
 [dependencies]
 chrono = "0.4"
 clap = "4.0.0"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ You **must** have an existing premium Spotify subscription to use `ncspot`.
     - [Debugging](#debugging)
     - [Compiling](#compiling)
       - [Building a Debian Package](#building-a-debian-package)
+      - [Packaging Information](#packaging-information)
     - [Audio Backends](#audio-backends)
     - [Other Features](#other-features)
   - [Key Bindings](#key-bindings)
@@ -169,6 +170,14 @@ cargo deb
 
 You can find the package under `target/debian`.
 
+#### Packaging Information
+The following files are provided and should be bundled together with ncspot:
+- LICENSE
+- images/logo.svg (optional)
+- misc/ncspot.desktop (for Linux systems)
+- misc/ncspot.1 (for Linux systems)
+
+Some of these files have to be generated. Execute `cargo xtask --help` for more information.
 ### Audio Backends
 
 By default `ncspot` is built using the PulseAudio backend. To make it use the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ pub const AUTHOR: &str = "Henrik Friedrichsen <henrik@affekt.org> and contributo
 
 /// Return the [Command](clap::Command) that models the program's command line arguments. The
 /// command can be used to parse the actual arguments passed to the program, or to automatically
-/// generate a manpage using clap's mangen package.
+/// generate a man page using clap's mangen package.
 pub fn program_arguments() -> clap::Command {
     let backends = {
         let backends: Vec<&str> = audio_backend::BACKENDS.iter().map(|b| b.0).collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,41 @@
+use librespot_playback::audio_backend;
+
+pub const AUTHOR: &str = "Henrik Friedrichsen <henrik@affekt.org> and contributors";
+
+/// Return the [Command](clap::Command) that models the program's command line arguments. The
+/// command can be used to parse the actual arguments passed to the program, or to automatically
+/// generate a manpage using clap's mangen package.
+pub fn program_arguments() -> clap::Command {
+    let backends = {
+        let backends: Vec<&str> = audio_backend::BACKENDS.iter().map(|b| b.0).collect();
+        format!("Audio backends: {}", backends.join(", "))
+    };
+
+    clap::Command::new("ncspot")
+        .version(env!("CARGO_PKG_VERSION"))
+        .author(AUTHOR)
+        .about("cross-platform ncurses Spotify client")
+        .after_help(backends)
+        .arg(
+            clap::Arg::new("debug")
+                .short('d')
+                .long("debug")
+                .value_name("FILE")
+                .help("Enable debug logging to the specified file"),
+        )
+        .arg(
+            clap::Arg::new("basepath")
+                .short('b')
+                .long("basepath")
+                .value_name("PATH")
+                .help("custom basepath to config/cache files"),
+        )
+        .arg(
+            clap::Arg::new("config")
+                .short('c')
+                .long("config")
+                .value_name("FILE")
+                .help("Filename of config file in basepath")
+                .default_value("config.toml"),
+        )
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,14 +12,13 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use clap::{Arg, Command as ClapCommand};
 use cursive::event::EventTrigger;
 use cursive::traits::Nameable;
 use librespot_core::authentication::Credentials;
 use librespot_core::cache::Cache;
-use librespot_playback::audio_backend;
 use log::{error, info, trace};
 
+use ncspot::program_arguments;
 #[cfg(unix)]
 use signal_hook::{consts::SIGHUP, consts::SIGTERM, iterator::Signals};
 
@@ -130,38 +129,7 @@ lazy_static!(
 fn main() -> Result<(), String> {
     register_backtrace_panic_handler();
 
-    let backends = {
-        let backends: Vec<&str> = audio_backend::BACKENDS.iter().map(|b| b.0).collect();
-        format!("Audio backends: {}", backends.join(", "))
-    };
-    let matches = ClapCommand::new("ncspot")
-        .version(env!("CARGO_PKG_VERSION"))
-        .author("Henrik Friedrichsen <henrik@affekt.org> and contributors")
-        .about("cross-platform ncurses Spotify client")
-        .after_help(backends)
-        .arg(
-            Arg::new("debug")
-                .short('d')
-                .long("debug")
-                .value_name("FILE")
-                .help("Enable debug logging to the specified file"),
-        )
-        .arg(
-            Arg::new("basepath")
-                .short('b')
-                .long("basepath")
-                .value_name("PATH")
-                .help("custom basepath to config/cache files"),
-        )
-        .arg(
-            Arg::new("config")
-                .short('c')
-                .long("config")
-                .value_name("FILE")
-                .help("Filename of config file in basepath")
-                .default_value("config.toml"),
-        )
-        .get_matches();
+    let matches = program_arguments().get_matches();
 
     if let Some(filename) = matches.get_one::<String>("debug") {
         setup_logging(filename).expect("can't setup logging");

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+clap_mangen = "0.2.8"
+clap = "4.1.6"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,10 +1,13 @@
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
 [package]
 name = "xtask"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 clap_mangen = "0.2.8"
 clap = "4.1.6"
+
+[dependencies.ncspot]
+path = ".."

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,66 @@
+use clap::Arg;
+use std::env;
+
+type DynError = Box<dyn std::error::Error>;
+
+fn main() {
+    if let Err(e) = try_main() {
+        eprintln!("{}", e);
+        std::process::exit(-1);
+    }
+}
+
+fn try_main() -> Result<(), DynError> {
+    let task = env::args().nth(1);
+    match task.as_deref() {
+        Some("generate-manpage") => generate_manpage()?,
+        _ => print_help(),
+    }
+    Ok(())
+}
+
+fn print_help() {
+    eprintln!(
+        "Tasks:
+generate-manpage            Generate the man pages.
+"
+    )
+}
+
+fn generate_manpage() -> Result<(), DynError> {
+    let out_dir = std::path::PathBuf::new();
+    let cmd = clap::Command::new("ncspot")
+        .version(env!("CARGO_PKG_VERSION"))
+        .author("Henrik Friedrichsen <henrik@affekt.org> and contributors")
+        .about("cross-platform ncurses Spotify client")
+        .arg(
+            Arg::new("debug")
+                .short('d')
+                .long("debug")
+                .value_name("FILE")
+                .help("Enable debug logging to the specified file"),
+        )
+        .arg(
+            Arg::new("basepath")
+                .short('b')
+                .long("basepath")
+                .value_name("PATH")
+                .help("custom basepath to config/cache files"),
+        )
+        .arg(
+            Arg::new("config")
+                .short('c')
+                .long("config")
+                .value_name("FILE")
+                .help("Filename of config file in basepath")
+                .default_value("config.toml"),
+        );
+
+    let man = clap_mangen::Man::new(cmd);
+    let mut buffer: Vec<u8> = Default::default();
+    man.render(&mut buffer)?;
+
+    std::fs::write(out_dir.join("ncspot.1"), buffer)?;
+
+    Ok(())
+}


### PR DESCRIPTION
This commit introduces semi-automatic manpage generation using the xtask workflow. This automates generation of manpages using the provided clap Command struct. I only wanted to suggest it for now, so I'm making it a draft.