### PR TITLE
Fix queueview shuffle order.

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -120,7 +120,13 @@ impl CommandManager {
                         self.queue.get_current_index()
                     );
                     s.queuestate.queue = queue.clone();
-                    s.queuestate.random_order = self.queue.get_random_order();
+                    s.queuestate.random_order = self
+                        .queue
+                        .get_random_order()
+                        .read()
+                        .unwrap()
+                        .as_ref()
+                        .cloned();
                     s.queuestate.current_track = self.queue.get_current_index();
                     s.queuestate.track_progress = self.spotify.get_current_progress();
                 });

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -43,7 +43,7 @@ pub struct Queue {
     /// the raw data only.
     pub queue: Arc<RwLock<Vec<Playable>>>,
     /// The playback order of the queue, as indices into `self.queue`.
-    random_order: RwLock<Option<Vec<usize>>>,
+    random_order: Arc<RwLock<Option<Vec<usize>>>>,
     current_track: RwLock<Option<usize>>,
     spotify: Spotify,
     cfg: Arc<Config>,
@@ -62,7 +62,7 @@ impl Queue {
             queue: Arc::new(RwLock::new(queue_state.queue)),
             spotify: spotify.clone(),
             current_track: RwLock::new(queue_state.current_track),
-            random_order: RwLock::new(queue_state.random_order),
+            random_order: Arc::new(RwLock::new(queue_state.random_order)),
             cfg,
             #[cfg(feature = "notify")]
             notification_id: Arc::new(AtomicU32::new(0)),
@@ -446,8 +446,8 @@ impl Queue {
     }
 
     /// Get the current order that is used to shuffle.
-    pub fn get_random_order(&self) -> Option<Vec<usize>> {
-        self.random_order.read().unwrap().clone()
+    pub fn get_random_order(&self) -> Arc<RwLock<Option<Vec<usize>>>> {
+        self.random_order.clone()
     }
 
     /// (Re)generate the random shuffle order.

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -23,7 +23,8 @@ pub struct QueueView {
 
 impl QueueView {
     pub fn new(queue: Arc<Queue>, library: Arc<Library>) -> QueueView {
-        let list = ListView::new(queue.queue.clone(), queue.clone(), library.clone());
+        let list = ListView::new(queue.queue.clone(), queue.clone(), library.clone())
+            .with_order(queue.get_random_order());
 
         QueueView {
             list,


### PR DESCRIPTION
This bugfix changes the way the `ListView` renders the content. It adds a way to add an explicit order of items to `ListView` in the same way as `Queue` has, and uses that for rendering. I just want to ask to quickly check this one to make sure it doesn't break other things (I don't think adding the order and using it only for rendering should have side effects, but I'm not 100% sure about it).

closes #465 