### PR TITLE
CI: add clippy and update toolchain install action.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,12 +49,9 @@ jobs:
             features: '--no-default-features --features rodio_backend,pancurses_backend,share_clipboard,notify'
     steps:
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
           target: ${{ matrix.target }}
-          profile: minimal
       - name: Install macOS dependencies
         if: matrix.os == 'macos-latest'
         run: brew install portaudio pkg-config
@@ -69,19 +66,17 @@ jobs:
         run: |
           apt update
           apt install -y ${{ matrix.dependencies }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout src
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Running cargo build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --locked --release --target ${{ matrix.target }} ${{ matrix.features }}
+        run: cargo build --release --target ${{ matrix.target }} ${{ matrix.features }}
       - name: Extract git tag
         shell: bash
         run: echo "##[set-output name=tag;]$(echo ${GITHUB_REF#refs/tags/})"
@@ -91,11 +86,11 @@ jobs:
         run: |
           cd target/${{ matrix.target }}/release
           case ${{ matrix.target }} in
-          *-pc-windows-*) 
+          *-pc-windows-*)
             7z -y a ncspot-${{ steps.extract_tag.outputs.tag }}-${{ matrix.build_target }}.zip ncspot.exe
             sha256sum ncspot-${{ steps.extract_tag.outputs.tag }}-${{ matrix.build_target }}.zip > ncspot-${{ steps.extract_tag.outputs.tag }}-${{ matrix.build_target }}.sha256
             ;;
-          *) 
+          *)
             tar czvf ncspot-${{ steps.extract_tag.outputs.tag }}-${{ matrix.build_target }}.tar.gz ncspot
             shasum -a 256 ncspot-${{ steps.extract_tag.outputs.tag }}-${{ matrix.build_target }}.tar.gz > ncspot-${{ steps.extract_tag.outputs.tag }}-${{ matrix.build_target }}.sha256
             ;;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,8 @@ on:
     branches: [ main ]
 
 jobs:
-  check-macos:
+  # Build the Rust code.
+  build:
     name: Checking ${{ matrix.build_target }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -30,13 +31,21 @@ jobs:
             target: x86_64-pc-windows-msvc
             features: '--no-default-features --features rodio_backend,pancurses_backend,share_clipboard,notify'
     steps:
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        name: Cache build data
         with:
-          toolchain: stable
-          override: true
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/bin
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
           target: ${{ matrix.target }}
-          profile: minimal
+          components: clippy, rustfmt
       - name: Install macOS dependencies
         if: matrix.os == 'macos-latest'
         run: brew install portaudio pkg-config
@@ -45,23 +54,48 @@ jobs:
         run: |
           sudo apt update
           sudo apt install libpulse-dev libdbus-1-dev libncursesw5-dev libxcb-shape0-dev libxcb-xfixes0-dev
-      - uses: actions/checkout@v2
-        name: Checkout src
-      - uses: actions/cache@v2
+      - name: Running cargo build
+        run: cargo build --locked --target ${{ matrix.target }} ${{ matrix.features }}
+
+  # Check Rust code formatting.
+  fmt:
+    name: Running `cargo fmt`
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          target: x86_64-unknown-linux-gnu
+          components: clippy, rustfmt
+      - name: cargo fmt
+        run: cargo fmt --all -- --check
+
+  # Run `cargo clippy` on all the targets in all workspace members with all
+  # features enabled, and return an error if there are any clippy suggestions.
+  clippy:
+    name: Running `cargo clippy`
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        name: Cache build data
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Running cargo check
-        uses: actions-rs/cargo@v1
+            ~/.cargo/bin
+            target
+          key: ${{ runner.os }}-clippy-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
-          command: check
-          args: --locked --release --target ${{ matrix.target }} ${{ matrix.features }}
+          target: x86_64-unknown-linux-gnu
+          components: clippy, rustfmt
+      - name: Install Linux dependencies
+        run: |
+          sudo apt update
+          sudo apt install portaudio19-dev libasound2-dev libpulse-dev libdbus-1-dev libncursesw5-dev libxcb-shape0-dev libxcb-xfixes0-dev
+      - name: cargo clippy
+        run: cargo clippy --locked --no-deps --workspace --all-targets --all-features --verbose -- -D warnings
 
-  fmt:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: cargo fmt
-        run: cargo fmt --all -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,10 +83,11 @@ jobs:
         name: Cache build data
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/bin
-            target
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
           key: ${{ runner.os }}-clippy-${{ hashFiles('**/Cargo.lock') }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           sudo apt update
           sudo apt install libpulse-dev libdbus-1-dev libncursesw5-dev libxcb-shape0-dev libxcb-xfixes0-dev
       - name: Running cargo build
-        run: cargo build --locked --target ${{ matrix.target }} ${{ matrix.features }}
+        run: cargo check --locked --target ${{ matrix.target }} ${{ matrix.features }}
 
   # Check Rust code formatting.
   fmt:
@@ -100,4 +100,3 @@ jobs:
           sudo apt install portaudio19-dev libasound2-dev libpulse-dev libdbus-1-dev libncursesw5-dev libxcb-shape0-dev libxcb-xfixes0-dev
       - name: cargo clippy
         run: cargo clippy --locked --no-deps --workspace --all-targets --all-features --verbose -- -D warnings
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,11 @@ jobs:
         name: Cache build data
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/bin
-            target
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/src/ui/cover.rs
+++ b/src/ui/cover.rs
@@ -151,7 +151,7 @@ impl CoverView {
         if ueberzug.is_none() {
             *ueberzug = Some(
                 std::process::Command::new("ueberzug")
-                    .args(&["layer", "--silent"])
+                    .args(["layer", "--silent"])
                     .stdin(Stdio::piped())
                     .stdout(Stdio::piped())
                     .spawn()?,


### PR DESCRIPTION
- Update all the actions to the latest version since some of them were using deprecated stuff.
- Use a different Rust toolchain installation action because the previous one is no longer maintained and generated deprecated warnings. The new one is by dtolnay (the author of the syn, anyhow and cargo-expand) so it will probably be maintained for a while :slightly_smiling_face: 
- Fix the last clippy warning that occurred by enabling all features.
- Cache the build artifacts as long as the dependencies don't change.
- Build the project instead of just checking it (I'm not sure but I think just checking can miss errors under some circumstances. Some projects check, others build.). Building doesn't add much extra time when caching the `target` directory anyways.

I hope this is ok. This is only my second GitHub CI config I've worked on so if anything isn't right, I'll happily change it :slightly_smiling_face:

The first run without any caches took around 10m for me, subsequent runs take around 3m40s as long as the `Cargo.lock` file doesn't change (which invalidates the dependency artifact caches).

Also it might be necessary to manually delete the latest caches (the ones that were used in the last while) as I don't think they will be updated with the target directory otherwise...

closes #1051 