### PR TITLE
Disable autojump for add to playlist dialog.

### DIFF
--- a/src/ui/contextmenu.rs
+++ b/src/ui/contextmenu.rs
@@ -67,7 +67,6 @@ impl ContextMenu {
             }
         }
 
-        list_select.set_autojump(true);
         list_select.set_on_submit(move |s, selected| {
             let track = track.clone();
             let mut playlist = selected.clone();


### PR DESCRIPTION
Autojump seems to take precedence over regular keys, which isn't the wanted behavior, especially when there are playlists in the list that contain some of the most common Vim keybindings. For example when there is a playlist called 'jazz', pressing `j` will jump to that playlist instead of going down.

This commit disables autojump for now. If search inside the add to playlist dialog would be a wanted feature, it could be implemented using the default Vim search button `/` which would work the same way as searching in other lists works right now.

closes #881 