### PR TITLE
Change unnecessary usage of Arc to borrow instead.

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -52,7 +52,7 @@ impl CommandManager {
         config: Arc<Config>,
         events: EventManager,
     ) -> CommandManager {
-        let bindings = RefCell::new(Self::get_bindings(config.clone()));
+        let bindings = RefCell::new(Self::get_bindings(&config));
         CommandManager {
             aliases: HashMap::new(),
             bindings,
@@ -64,7 +64,7 @@ impl CommandManager {
         }
     }
 
-    pub fn get_bindings(config: Arc<Config>) -> HashMap<String, Vec<Command>> {
+    pub fn get_bindings(config: &Config) -> HashMap<String, Vec<Command>> {
         let config = config.values();
         let mut kb = if config.default_keybindings.unwrap_or(true) {
             Self::default_keybindings()
@@ -227,8 +227,7 @@ impl CommandManager {
 
                 // update bindings
                 self.unregister_keybindings(s);
-                self.bindings
-                    .replace(Self::get_bindings(self.config.clone()));
+                self.bindings.replace(Self::get_bindings(&self.config));
                 self.register_keybindings(s);
                 Ok(None)
             }

--- a/src/model/album.rs
+++ b/src/model/album.rs
@@ -152,7 +152,7 @@ impl fmt::Debug for Album {
 }
 
 impl ListItem for Album {
-    fn is_playing(&self, queue: Arc<Queue>) -> bool {
+    fn is_playing(&self, queue: &Queue) -> bool {
         if let Some(tracks) = self.tracks.as_ref() {
             let playing: Vec<String> = queue
                 .queue
@@ -169,11 +169,11 @@ impl ListItem for Album {
         }
     }
 
-    fn display_left(&self, _library: Arc<Library>) -> String {
+    fn display_left(&self, _library: &Library) -> String {
         format!("{self}")
     }
 
-    fn display_right(&self, library: Arc<Library>) -> String {
+    fn display_right(&self, library: &Library) -> String {
         let saved = if library.is_saved_album(self) {
             if library.cfg.values().use_nerdfont.unwrap_or(false) {
                 "\u{f62b} "
@@ -186,7 +186,7 @@ impl ListItem for Album {
         format!("{}{}", saved, self.year)
     }
 
-    fn play(&mut self, queue: Arc<Queue>) {
+    fn play(&mut self, queue: &Queue) {
         self.load_all_tracks(queue.get_spotify());
 
         if let Some(tracks) = self.tracks.as_ref() {
@@ -199,7 +199,7 @@ impl ListItem for Album {
         }
     }
 
-    fn play_next(&mut self, queue: Arc<Queue>) {
+    fn play_next(&mut self, queue: &Queue) {
         self.load_all_tracks(queue.get_spotify());
 
         if let Some(tracks) = self.tracks.as_ref() {
@@ -209,7 +209,7 @@ impl ListItem for Album {
         }
     }
 
-    fn queue(&mut self, queue: Arc<Queue>) {
+    fn queue(&mut self, queue: &Queue) {
         self.load_all_tracks(queue.get_spotify());
 
         if let Some(tracks) = self.tracks.as_ref() {
@@ -219,7 +219,7 @@ impl ListItem for Album {
         }
     }
 
-    fn toggle_saved(&mut self, library: Arc<Library>) {
+    fn toggle_saved(&mut self, library: &Library) {
         if library.is_saved_album(self) {
             library.unsave_album(self);
         } else {
@@ -227,11 +227,11 @@ impl ListItem for Album {
         }
     }
 
-    fn save(&mut self, library: Arc<Library>) {
+    fn save(&mut self, library: &Library) {
         library.save_album(self);
     }
 
-    fn unsave(&mut self, library: Arc<Library>) {
+    fn unsave(&mut self, library: &Library) {
         library.unsave_album(self);
     }
 
@@ -303,7 +303,7 @@ impl ListItem for Album {
     }
 
     #[inline]
-    fn is_saved(&self, library: Arc<Library>) -> Option<bool> {
+    fn is_saved(&self, library: &Library) -> Option<bool> {
         Some(library.is_saved_album(self))
     }
 

--- a/src/model/artist.rs
+++ b/src/model/artist.rs
@@ -78,7 +78,7 @@ impl fmt::Debug for Artist {
 }
 
 impl ListItem for Artist {
-    fn is_playing(&self, queue: Arc<Queue>) -> bool {
+    fn is_playing(&self, queue: &Queue) -> bool {
         if let Some(tracks) = &self.tracks {
             let playing: Vec<String> = queue
                 .queue
@@ -94,11 +94,11 @@ impl ListItem for Artist {
         }
     }
 
-    fn display_left(&self, _library: Arc<Library>) -> String {
+    fn display_left(&self, _library: &Library) -> String {
         format!("{self}")
     }
 
-    fn display_right(&self, library: Arc<Library>) -> String {
+    fn display_right(&self, library: &Library) -> String {
         let followed = if library.is_followed_artist(self) {
             if library.cfg.values().use_nerdfont.unwrap_or(false) {
                 "\u{f62b} "
@@ -118,7 +118,7 @@ impl ListItem for Artist {
         format!("{followed}{tracks}")
     }
 
-    fn play(&mut self, queue: Arc<Queue>) {
+    fn play(&mut self, queue: &Queue) {
         self.load_top_tracks(queue.get_spotify());
 
         if let Some(tracks) = self.tracks.as_ref() {
@@ -131,7 +131,7 @@ impl ListItem for Artist {
         }
     }
 
-    fn play_next(&mut self, queue: Arc<Queue>) {
+    fn play_next(&mut self, queue: &Queue) {
         self.load_top_tracks(queue.get_spotify());
 
         if let Some(tracks) = self.tracks.as_ref() {
@@ -141,7 +141,7 @@ impl ListItem for Artist {
         }
     }
 
-    fn queue(&mut self, queue: Arc<Queue>) {
+    fn queue(&mut self, queue: &Queue) {
         self.load_top_tracks(queue.get_spotify());
 
         if let Some(tracks) = &self.tracks {
@@ -151,7 +151,7 @@ impl ListItem for Artist {
         }
     }
 
-    fn toggle_saved(&mut self, library: Arc<Library>) {
+    fn toggle_saved(&mut self, library: &Library) {
         if library.is_followed_artist(self) {
             library.unfollow_artist(self);
         } else {
@@ -159,11 +159,11 @@ impl ListItem for Artist {
         }
     }
 
-    fn save(&mut self, library: Arc<Library>) {
+    fn save(&mut self, library: &Library) {
         library.follow_artist(self);
     }
 
-    fn unsave(&mut self, library: Arc<Library>) {
+    fn unsave(&mut self, library: &Library) {
         library.unfollow_artist(self);
     }
 
@@ -203,7 +203,7 @@ impl ListItem for Artist {
     }
 
     #[inline]
-    fn is_saved(&self, library: Arc<Library>) -> Option<bool> {
+    fn is_saved(&self, library: &Library) -> Option<bool> {
         Some(library.is_followed_artist(self))
     }
 

--- a/src/model/category.rs
+++ b/src/model/category.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
 use crate::{
+    library::Library,
+    queue::Queue,
     traits::{IntoBoxedViewExt, ListItem},
     ui::listview::ListView,
 };
@@ -21,29 +23,29 @@ impl From<&rspotify::model::Category> for Category {
 }
 
 impl ListItem for Category {
-    fn is_playing(&self, _queue: Arc<crate::queue::Queue>) -> bool {
+    fn is_playing(&self, _queue: &Queue) -> bool {
         false
     }
 
-    fn display_left(&self, _library: Arc<crate::library::Library>) -> String {
+    fn display_left(&self, _library: &Library) -> String {
         self.name.clone()
     }
 
-    fn display_right(&self, _library: Arc<crate::library::Library>) -> String {
+    fn display_right(&self, _library: &Library) -> String {
         "".to_string()
     }
 
-    fn play(&mut self, _queue: Arc<crate::queue::Queue>) {}
+    fn play(&mut self, _queue: &Queue) {}
 
-    fn play_next(&mut self, _queue: Arc<crate::queue::Queue>) {}
+    fn play_next(&mut self, _queue: &Queue) {}
 
-    fn queue(&mut self, _queue: Arc<crate::queue::Queue>) {}
+    fn queue(&mut self, _queue: &Queue) {}
 
-    fn toggle_saved(&mut self, _library: Arc<crate::library::Library>) {}
+    fn toggle_saved(&mut self, _library: &Library) {}
 
-    fn save(&mut self, _library: Arc<crate::library::Library>) {}
+    fn save(&mut self, _library: &Library) {}
 
-    fn unsave(&mut self, _library: Arc<crate::library::Library>) {}
+    fn unsave(&mut self, _library: &Library) {}
 
     fn open(
         &self,

--- a/src/model/episode.rs
+++ b/src/model/episode.rs
@@ -67,39 +67,39 @@ impl fmt::Display for Episode {
 }
 
 impl ListItem for Episode {
-    fn is_playing(&self, queue: Arc<Queue>) -> bool {
+    fn is_playing(&self, queue: &Queue) -> bool {
         let current = queue.get_current();
         current
             .map(|t| t.id() == Some(self.id.clone()))
             .unwrap_or(false)
     }
 
-    fn display_left(&self, _library: Arc<Library>) -> String {
+    fn display_left(&self, _library: &Library) -> String {
         self.name.clone()
     }
 
-    fn display_right(&self, _library: Arc<Library>) -> String {
+    fn display_right(&self, _library: &Library) -> String {
         format!("{} [{}]", self.duration_str(), self.release_date)
     }
 
-    fn play(&mut self, queue: Arc<Queue>) {
+    fn play(&mut self, queue: &Queue) {
         let index = queue.append_next(&vec![Playable::Episode(self.clone())]);
         queue.play(index, true, false);
     }
 
-    fn play_next(&mut self, queue: Arc<Queue>) {
+    fn play_next(&mut self, queue: &Queue) {
         queue.insert_after_current(Playable::Episode(self.clone()));
     }
 
-    fn queue(&mut self, queue: Arc<Queue>) {
+    fn queue(&mut self, queue: &Queue) {
         queue.append(Playable::Episode(self.clone()));
     }
 
-    fn toggle_saved(&mut self, _library: Arc<Library>) {}
+    fn toggle_saved(&mut self, _library: &Library) {}
 
-    fn save(&mut self, _library: Arc<Library>) {}
+    fn save(&mut self, _library: &Library) {}
 
-    fn unsave(&mut self, _library: Arc<Library>) {}
+    fn unsave(&mut self, _library: &Library) {}
 
     fn open(&self, _queue: Arc<Queue>, _library: Arc<Library>) -> Option<Box<dyn ViewExt>> {
         None

--- a/src/model/playable.rs
+++ b/src/model/playable.rs
@@ -20,7 +20,7 @@ pub enum Playable {
 }
 
 impl Playable {
-    pub fn format(playable: &Playable, formatting: &str, library: Arc<Library>) -> String {
+    pub fn format(playable: &Playable, formatting: &str, library: &Library) -> String {
         formatting
             .replace(
                 "%artists",
@@ -162,43 +162,43 @@ impl fmt::Display for Playable {
 }
 
 impl ListItem for Playable {
-    fn is_playing(&self, queue: Arc<Queue>) -> bool {
+    fn is_playing(&self, queue: &Queue) -> bool {
         self.as_listitem().is_playing(queue)
     }
 
-    fn display_left(&self, library: Arc<Library>) -> String {
+    fn display_left(&self, library: &Library) -> String {
         self.as_listitem().display_left(library)
     }
 
-    fn display_center(&self, library: Arc<Library>) -> String {
+    fn display_center(&self, library: &Library) -> String {
         self.as_listitem().display_center(library)
     }
 
-    fn display_right(&self, library: Arc<Library>) -> String {
+    fn display_right(&self, library: &Library) -> String {
         self.as_listitem().display_right(library)
     }
 
-    fn play(&mut self, queue: Arc<Queue>) {
+    fn play(&mut self, queue: &Queue) {
         self.as_listitem().play(queue)
     }
 
-    fn play_next(&mut self, queue: Arc<Queue>) {
+    fn play_next(&mut self, queue: &Queue) {
         self.as_listitem().play_next(queue)
     }
 
-    fn queue(&mut self, queue: Arc<Queue>) {
+    fn queue(&mut self, queue: &Queue) {
         self.as_listitem().queue(queue)
     }
 
-    fn toggle_saved(&mut self, library: Arc<Library>) {
+    fn toggle_saved(&mut self, library: &Library) {
         self.as_listitem().toggle_saved(library)
     }
 
-    fn save(&mut self, library: Arc<Library>) {
+    fn save(&mut self, library: &Library) {
         self.as_listitem().save(library)
     }
 
-    fn unsave(&mut self, library: Arc<Library>) {
+    fn unsave(&mut self, library: &Library) {
         self.as_listitem().unsave(library)
     }
 
@@ -210,7 +210,7 @@ impl ListItem for Playable {
         self.as_listitem().share_url()
     }
 
-    fn album(&self, queue: Arc<Queue>) -> Option<Album> {
+    fn album(&self, queue: &Queue) -> Option<Album> {
         self.as_listitem().album(queue)
     }
 

--- a/src/model/playlist.rs
+++ b/src/model/playlist.rs
@@ -55,7 +55,7 @@ impl Playlist {
         })
     }
 
-    pub fn delete_track(&mut self, index: usize, spotify: Spotify, library: Arc<Library>) -> bool {
+    pub fn delete_track(&mut self, index: usize, spotify: Spotify, library: &Library) -> bool {
         let track = self.tracks.as_ref().unwrap()[index].clone();
         debug!("deleting track: {} {:?}", index, track);
         match spotify
@@ -74,12 +74,7 @@ impl Playlist {
         }
     }
 
-    pub fn append_tracks(
-        &mut self,
-        new_tracks: &[Playable],
-        spotify: Spotify,
-        library: Arc<Library>,
-    ) {
+    pub fn append_tracks(&mut self, new_tracks: &[Playable], spotify: &Spotify, library: &Library) {
         let mut has_modified = false;
 
         if spotify.api.append_tracks(&self.id, new_tracks, None) {
@@ -175,7 +170,7 @@ impl From<&FullPlaylist> for Playlist {
 }
 
 impl ListItem for Playlist {
-    fn is_playing(&self, queue: Arc<Queue>) -> bool {
+    fn is_playing(&self, queue: &Queue) -> bool {
         if let Some(tracks) = self.tracks.as_ref() {
             let playing: Vec<String> = queue
                 .queue
@@ -191,7 +186,7 @@ impl ListItem for Playlist {
         }
     }
 
-    fn display_left(&self, library: Arc<Library>) -> String {
+    fn display_left(&self, library: &Library) -> String {
         let hide_owners = library.cfg.values().hide_display_names.unwrap_or(false);
         match (self.owner_name.as_ref(), hide_owners) {
             (Some(owner), false) => format!("{} • {}", self.name, owner),
@@ -199,7 +194,7 @@ impl ListItem for Playlist {
         }
     }
 
-    fn display_right(&self, library: Arc<Library>) -> String {
+    fn display_right(&self, library: &Library) -> String {
         let saved = if library.is_saved_playlist(self) {
             if library.cfg.values().use_nerdfont.unwrap_or(false) {
                 "\u{f62b} "
@@ -219,7 +214,7 @@ impl ListItem for Playlist {
         format!("{saved}{num_tracks:>4} tracks")
     }
 
-    fn play(&mut self, queue: Arc<Queue>) {
+    fn play(&mut self, queue: &Queue) {
         self.load_tracks(queue.get_spotify());
 
         if let Some(tracks) = &self.tracks {
@@ -228,7 +223,7 @@ impl ListItem for Playlist {
         }
     }
 
-    fn play_next(&mut self, queue: Arc<Queue>) {
+    fn play_next(&mut self, queue: &Queue) {
         self.load_tracks(queue.get_spotify());
 
         if let Some(tracks) = self.tracks.as_ref() {
@@ -238,7 +233,7 @@ impl ListItem for Playlist {
         }
     }
 
-    fn queue(&mut self, queue: Arc<Queue>) {
+    fn queue(&mut self, queue: &Queue) {
         self.load_tracks(queue.get_spotify());
 
         if let Some(tracks) = self.tracks.as_ref() {
@@ -248,7 +243,7 @@ impl ListItem for Playlist {
         }
     }
 
-    fn toggle_saved(&mut self, library: Arc<Library>) {
+    fn toggle_saved(&mut self, library: &Library) {
         // Don't allow users to unsave their own playlists with one keypress
         if !library.is_followed_playlist(self) {
             return;
@@ -261,11 +256,11 @@ impl ListItem for Playlist {
         }
     }
 
-    fn save(&mut self, library: Arc<Library>) {
+    fn save(&mut self, library: &Library) {
         library.follow_playlist(self);
     }
 
-    fn unsave(&mut self, library: Arc<Library>) {
+    fn unsave(&mut self, library: &Library) {
         library.delete_playlist(&self.id);
     }
 
@@ -324,7 +319,7 @@ impl ListItem for Playlist {
         ))
     }
 
-    fn is_saved(&self, library: Arc<Library>) -> Option<bool> {
+    fn is_saved(&self, library: &Library) -> Option<bool> {
         // save status of personal playlists can't be toggled for safety
         if !library.is_followed_playlist(self) {
             return None;

--- a/src/model/show.rs
+++ b/src/model/show.rs
@@ -72,15 +72,15 @@ impl fmt::Display for Show {
 }
 
 impl ListItem for Show {
-    fn is_playing(&self, _queue: Arc<Queue>) -> bool {
+    fn is_playing(&self, _queue: &Queue) -> bool {
         false
     }
 
-    fn display_left(&self, _library: Arc<Library>) -> String {
+    fn display_left(&self, _library: &Library) -> String {
         format!("{self}")
     }
 
-    fn display_right(&self, library: Arc<Library>) -> String {
+    fn display_right(&self, library: &Library) -> String {
         let saved = if library.is_saved_show(self) {
             if library.cfg.values().use_nerdfont.unwrap_or(false) {
                 "\u{f62b} "
@@ -93,7 +93,7 @@ impl ListItem for Show {
         saved.to_owned()
     }
 
-    fn play(&mut self, queue: Arc<Queue>) {
+    fn play(&mut self, queue: &Queue) {
         self.load_all_episodes(queue.get_spotify());
 
         let playables = self
@@ -108,7 +108,7 @@ impl ListItem for Show {
         queue.play(index, true, true);
     }
 
-    fn play_next(&mut self, queue: Arc<Queue>) {
+    fn play_next(&mut self, queue: &Queue) {
         self.load_all_episodes(queue.get_spotify());
 
         if let Some(episodes) = self.episodes.as_ref() {
@@ -118,7 +118,7 @@ impl ListItem for Show {
         }
     }
 
-    fn queue(&mut self, queue: Arc<Queue>) {
+    fn queue(&mut self, queue: &Queue) {
         self.load_all_episodes(queue.get_spotify());
 
         for ep in self.episodes.as_ref().unwrap_or(&Vec::new()) {
@@ -126,7 +126,7 @@ impl ListItem for Show {
         }
     }
 
-    fn toggle_saved(&mut self, library: Arc<Library>) {
+    fn toggle_saved(&mut self, library: &Library) {
         if library.is_saved_show(self) {
             self.unsave(library);
         } else {
@@ -134,11 +134,11 @@ impl ListItem for Show {
         }
     }
 
-    fn save(&mut self, library: Arc<Library>) {
+    fn save(&mut self, library: &Library) {
         library.save_show(self);
     }
 
-    fn unsave(&mut self, library: Arc<Library>) {
+    fn unsave(&mut self, library: &Library) {
         library.unsave_show(self);
     }
 
@@ -151,7 +151,7 @@ impl ListItem for Show {
     }
 
     #[inline]
-    fn is_saved(&self, library: Arc<Library>) -> Option<bool> {
+    fn is_saved(&self, library: &Library) -> Option<bool> {
         Some(library.is_saved_show(self))
     }
 

--- a/src/model/track.rs
+++ b/src/model/track.rs
@@ -176,12 +176,12 @@ impl fmt::Debug for Track {
 }
 
 impl ListItem for Track {
-    fn is_playing(&self, queue: Arc<Queue>) -> bool {
+    fn is_playing(&self, queue: &Queue) -> bool {
         let current = queue.get_current();
         current.map(|t| t.id() == self.id).unwrap_or(false)
     }
 
-    fn display_left(&self, library: Arc<Library>) -> String {
+    fn display_left(&self, library: &Library) -> String {
         let formatting = library
             .cfg
             .values()
@@ -197,7 +197,7 @@ impl ListItem for Track {
         }
     }
 
-    fn display_center(&self, library: Arc<Library>) -> String {
+    fn display_center(&self, library: &Library) -> String {
         let formatting = library
             .cfg
             .values()
@@ -213,7 +213,7 @@ impl ListItem for Track {
         }
     }
 
-    fn display_right(&self, library: Arc<Library>) -> String {
+    fn display_right(&self, library: &Library) -> String {
         let formatting = library
             .cfg
             .values()
@@ -238,20 +238,20 @@ impl ListItem for Track {
         }
     }
 
-    fn play(&mut self, queue: Arc<Queue>) {
+    fn play(&mut self, queue: &Queue) {
         let index = queue.append_next(&vec![Playable::Track(self.clone())]);
         queue.play(index, true, false);
     }
 
-    fn play_next(&mut self, queue: Arc<Queue>) {
+    fn play_next(&mut self, queue: &Queue) {
         queue.insert_after_current(Playable::Track(self.clone()));
     }
 
-    fn queue(&mut self, queue: Arc<Queue>) {
+    fn queue(&mut self, queue: &Queue) {
         queue.append(Playable::Track(self.clone()));
     }
 
-    fn toggle_saved(&mut self, library: Arc<Library>) {
+    fn toggle_saved(&mut self, library: &Library) {
         if library.is_saved_track(&Playable::Track(self.clone())) {
             library.unsave_tracks(vec![self], true);
         } else {
@@ -259,11 +259,11 @@ impl ListItem for Track {
         }
     }
 
-    fn save(&mut self, library: Arc<Library>) {
+    fn save(&mut self, library: &Library) {
         library.save_tracks(vec![self], true);
     }
 
-    fn unsave(&mut self, library: Arc<Library>) {
+    fn unsave(&mut self, library: &Library) {
         library.unsave_tracks(vec![self], true);
     }
 
@@ -309,7 +309,7 @@ impl ListItem for Track {
             .map(|id| format!("https://open.spotify.com/track/{id}"))
     }
 
-    fn album(&self, queue: Arc<Queue>) -> Option<Album> {
+    fn album(&self, queue: &Queue) -> Option<Album> {
         let spotify = queue.get_spotify();
 
         match self.album_id {
@@ -333,7 +333,7 @@ impl ListItem for Track {
     }
 
     #[inline]
-    fn is_saved(&self, library: Arc<Library>) -> Option<bool> {
+    fn is_saved(&self, library: &Library) -> Option<bool> {
         Some(library.is_saved_track(&Playable::Track(self.clone())))
     }
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -336,8 +336,8 @@ impl Queue {
                     let default_body = NotificationFormat::default().body.unwrap();
                     let body = format.body.unwrap_or_else(|| default_body.clone());
 
-                    let summary_txt = Playable::format(track, &title, self.library.clone());
-                    let body_txt = Playable::format(track, &body, self.library.clone());
+                    let summary_txt = Playable::format(track, &title, &self.library);
+                    let body_txt = Playable::format(track, &body, &self.library);
                     let cover_url = track.cover_url();
                     move || send_notification(&summary_txt, &body_txt, cover_url, notification_id)
                 });

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -13,18 +13,18 @@ use crate::model::track::Track;
 use crate::queue::Queue;
 
 pub trait ListItem: Sync + Send + 'static {
-    fn is_playing(&self, queue: Arc<Queue>) -> bool;
-    fn display_left(&self, library: Arc<Library>) -> String;
-    fn display_center(&self, _library: Arc<Library>) -> String {
+    fn is_playing(&self, queue: &Queue) -> bool;
+    fn display_left(&self, library: &Library) -> String;
+    fn display_center(&self, _library: &Library) -> String {
         "".to_string()
     }
-    fn display_right(&self, library: Arc<Library>) -> String;
-    fn play(&mut self, queue: Arc<Queue>);
-    fn play_next(&mut self, queue: Arc<Queue>);
-    fn queue(&mut self, queue: Arc<Queue>);
-    fn toggle_saved(&mut self, library: Arc<Library>);
-    fn save(&mut self, library: Arc<Library>);
-    fn unsave(&mut self, library: Arc<Library>);
+    fn display_right(&self, library: &Library) -> String;
+    fn play(&mut self, queue: &Queue);
+    fn play_next(&mut self, queue: &Queue);
+    fn queue(&mut self, queue: &Queue);
+    fn toggle_saved(&mut self, library: &Library);
+    fn save(&mut self, library: &Library);
+    fn unsave(&mut self, library: &Library);
     fn open(&self, queue: Arc<Queue>, library: Arc<Library>) -> Option<Box<dyn ViewExt>>;
     fn open_recommendations(
         &mut self,
@@ -35,7 +35,7 @@ pub trait ListItem: Sync + Send + 'static {
     }
     fn share_url(&self) -> Option<String>;
 
-    fn album(&self, _queue: Arc<Queue>) -> Option<Album> {
+    fn album(&self, _queue: &Queue) -> Option<Album> {
         None
     }
 
@@ -49,7 +49,7 @@ pub trait ListItem: Sync + Send + 'static {
 
     #[allow(unused_variables)]
     #[inline]
-    fn is_saved(&self, library: Arc<Library>) -> Option<bool> {
+    fn is_saved(&self, library: &Library) -> Option<bool> {
         None
     }
 

--- a/src/ui/contextmenu.rs
+++ b/src/ui/contextmenu.rs
@@ -79,10 +79,8 @@ impl ContextMenu {
 
                 already_added_dialog.add_button("Add anyway", move |c| {
                     let mut playlist = playlist.clone();
-                    let spotify = spotify.clone();
-                    let library = library.clone();
 
-                    playlist.append_tracks(&[Playable::Track(track.clone())], spotify, library);
+                    playlist.append_tracks(&[Playable::Track(track.clone())], &spotify, &library);
                     c.pop_layer();
 
                     // Close add_track_dialog too
@@ -92,7 +90,7 @@ impl ContextMenu {
                 let modal = Modal::new(already_added_dialog);
                 s.add_layer(modal);
             } else {
-                playlist.append_tracks(&[Playable::Track(track)], spotify, library);
+                playlist.append_tracks(&[Playable::Track(track)], &spotify, &library);
                 s.pop_layer();
             }
         });
@@ -170,9 +168,9 @@ impl ContextMenu {
                 }
                 false => {
                     if library.clone().is_followed_artist(&moved_artist) {
-                        moved_artist.clone().unsave(library.clone());
+                        moved_artist.clone().unsave(&library);
                     } else {
-                        moved_artist.clone().save(library.clone());
+                        moved_artist.clone().save(&library);
                     }
                 }
             }
@@ -205,13 +203,13 @@ impl ContextMenu {
         let mut content: SelectView<ContextMenuAction> = SelectView::new();
 
         if item.is_playable() {
-            if item.is_playing(queue.clone())
+            if item.is_playing(&queue)
                 && queue.get_spotify().get_current_status()
                     == PlayerEvent::Paused(queue.get_spotify().get_current_progress())
             {
                 // the item is the current track, but paused
                 content.insert_item(0, "Resume", ContextMenuAction::TogglePlayback);
-            } else if !item.is_playing(queue.clone()) {
+            } else if !item.is_playing(&queue) {
                 // the item is not the current track
                 content.insert_item(0, "Play", ContextMenuAction::Play(item.as_listitem()));
             } else {
@@ -241,7 +239,7 @@ impl ContextMenu {
             }
         }
 
-        if let Some(a) = item.album(queue.clone()) {
+        if let Some(a) = item.album(&queue) {
             content.add_item("Show album", ContextMenuAction::ShowItem(Box::new(a)));
         }
 
@@ -250,7 +248,7 @@ impl ContextMenu {
             if let Some(url) = item.share_url() {
                 content.add_item("Share", ContextMenuAction::ShareUrl(url));
             }
-            if let Some(url) = item.album(queue.clone()).and_then(|a| a.share_url()) {
+            if let Some(url) = item.album(&queue).and_then(|a| a.share_url()) {
                 content.add_item("Share album", ContextMenuAction::ShareUrl(url));
             }
         }
@@ -266,7 +264,7 @@ impl ContextMenu {
             )
         }
         // If the item is saveable, its save state will be set
-        if let Some(savestatus) = item.is_saved(library.clone()) {
+        if let Some(savestatus) = item.is_saved(&library) {
             content.add_item(
                 match savestatus {
                     true => "Unsave",
@@ -276,8 +274,8 @@ impl ContextMenu {
             );
         }
 
-        if let Some(album) = item.album(queue.clone()) {
-            if let Some(savestatus) = album.is_saved(library.clone()) {
+        if let Some(album) = item.album(&queue) {
+            if let Some(savestatus) = album.is_saved(&library) {
                 content.add_item(
                     match savestatus {
                         true => "Unsave album",
@@ -326,18 +324,18 @@ impl ContextMenu {
                         s.add_layer(dialog);
                     }
                     ContextMenuAction::ToggleSavedStatus(item) => {
-                        item.as_listitem().toggle_saved(library)
+                        item.as_listitem().toggle_saved(&library)
                     }
-                    ContextMenuAction::Play(item) => item.as_listitem().play(queue),
-                    ContextMenuAction::PlayNext(item) => item.as_listitem().play_next(queue),
+                    ContextMenuAction::Play(item) => item.as_listitem().play(&queue),
+                    ContextMenuAction::PlayNext(item) => item.as_listitem().play_next(&queue),
                     ContextMenuAction::TogglePlayback => queue.toggleplayback(),
-                    ContextMenuAction::Queue(item) => item.as_listitem().queue(queue),
+                    ContextMenuAction::Queue(item) => item.as_listitem().queue(&queue),
                 }
             });
         }
 
         let dialog = Dialog::new()
-            .title(item.display_left(library))
+            .title(item.display_left(&library))
             .dismiss_button("Close")
             .padding(Margins::lrtb(1, 1, 1, 0))
             .content(content.with_name("contextmenu_select"));

--- a/src/ui/cover.rs
+++ b/src/ui/cover.rs
@@ -231,12 +231,12 @@ impl ViewExt for CoverView {
         match cmd {
             Command::Save => {
                 if let Some(mut track) = self.queue.get_current() {
-                    track.save(self.library.clone());
+                    track.save(&self.library);
                 }
             }
             Command::Delete => {
                 if let Some(mut track) = self.queue.get_current() {
-                    track.unsave(self.library.clone());
+                    track.unsave(&self.library);
                 }
             }
             #[cfg(feature = "share_clipboard")]
@@ -259,7 +259,7 @@ impl ViewExt for CoverView {
 
                     match mode {
                         GotoMode::Album => {
-                            if let Some(album) = track.album(queue.clone()) {
+                            if let Some(album) = track.album(&queue) {
                                 let view =
                                     AlbumView::new(queue, library, &album).into_boxed_view_ext();
                                 return Ok(CommandResult::View(view));

--- a/src/ui/listview.rs
+++ b/src/ui/listview.rs
@@ -142,7 +142,7 @@ impl<I: ListItem + Clone> ListView<I> {
             .iter()
             .enumerate()
             .filter(|(_, i)| {
-                i.display_left(self.library.clone())
+                i.display_left(&self.library)
                     .to_lowercase()
                     .contains(&query[..].to_lowercase())
             })
@@ -208,7 +208,7 @@ impl<I: ListItem + Clone> View for ListView<I> {
 
                 let item = &content[current_index];
 
-                let currently_playing = item.is_playing(self.queue.clone())
+                let currently_playing = item.is_playing(&self.queue)
                     && self.queue.get_current_index() == Some(current_index);
 
                 let style = if self.selected == i {
@@ -231,9 +231,9 @@ impl<I: ListItem + Clone> View for ListView<I> {
                     ColorStyle::primary()
                 };
 
-                let left = item.display_left(self.library.clone());
-                let center = item.display_center(self.library.clone());
-                let right = item.display_right(self.library.clone());
+                let left = item.display_left(&self.library);
+                let center = item.display_center(&self.library);
+                let right = item.display_right(&self.library);
                 let draw_center = !center.is_empty();
 
                 // draw left string
@@ -443,7 +443,7 @@ impl<I: ListItem + Clone> ViewExt for ListView<I> {
                 if !self.attempt_play_all_tracks() {
                     let mut content = self.content.write().unwrap();
                     if let Some(item) = content.get_mut(self.selected) {
-                        item.play(self.queue.clone());
+                        item.play(&self.queue);
                     }
                 }
 
@@ -453,7 +453,7 @@ impl<I: ListItem + Clone> ViewExt for ListView<I> {
                 info!("played next");
                 let mut content = self.content.write().unwrap();
                 if let Some(item) = content.get_mut(self.selected) {
-                    item.play_next(self.queue.clone());
+                    item.play_next(&self.queue);
                 }
 
                 return Ok(CommandResult::Consumed(None));
@@ -461,7 +461,7 @@ impl<I: ListItem + Clone> ViewExt for ListView<I> {
             Command::Queue => {
                 let mut content = self.content.write().unwrap();
                 if let Some(item) = content.get_mut(self.selected) {
-                    item.queue(self.queue.clone());
+                    item.queue(&self.queue);
                 }
 
                 return Ok(CommandResult::Consumed(None));
@@ -473,7 +473,7 @@ impl<I: ListItem + Clone> ViewExt for ListView<I> {
                 };
 
                 if let Some(item) = item.as_mut() {
-                    item.save(self.library.clone());
+                    item.save(&self.library);
                 }
 
                 return Ok(CommandResult::Consumed(None));
@@ -485,7 +485,7 @@ impl<I: ListItem + Clone> ViewExt for ListView<I> {
                 };
 
                 if let Some(item) = item.as_mut() {
-                    item.unsave(self.library.clone());
+                    item.unsave(&self.library);
                 }
 
                 return Ok(CommandResult::Consumed(None));
@@ -607,7 +607,7 @@ impl<I: ListItem + Clone> ViewExt for ListView<I> {
 
                     match mode {
                         GotoMode::Album => {
-                            if let Some(album) = item.album(queue.clone()) {
+                            if let Some(album) = item.album(&queue) {
                                 let view =
                                     AlbumView::new(queue, library, &album).into_boxed_view_ext();
                                 return Ok(CommandResult::View(view));

--- a/src/ui/playlist.rs
+++ b/src/ui/playlist.rs
@@ -82,7 +82,7 @@ impl ViewExt for PlaylistView {
             let pos = self.list.get_selected_index();
             if self
                 .playlist
-                .delete_track(pos, self.spotify.clone(), self.library.clone())
+                .delete_track(pos, self.spotify.clone(), &self.library)
             {
                 self.list.remove(pos);
             }

--- a/src/ui/statusbar.rs
+++ b/src/ui/statusbar.rs
@@ -79,7 +79,7 @@ impl StatusBar {
             .statusbar_format
             .clone()
             .unwrap_or_else(|| "%artists - %title".to_string());
-        Playable::format(t, &format, self.library.clone())
+        Playable::format(t, &format, &self.library)
     }
 }
 


### PR DESCRIPTION
Some basic cleanup of function signatures that took ownership of their parameters, even though they didn't need ownership. Switching over the usage of `Arc` to a normal borrow has the added benefit of cleaning up the code a bit since now a reference can be given instead of having to clone the values. The other benefit is that a lot of clones aren't necessary anymore. It's not going to have noticable performance benefits, but it is still a good thing to have less clones all over the code.