### PR TITLE
Fix debian dependencies for Bookworm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ assets = [
   ["images/logo.svg", "usr/share/icons/hicolor/scalable/apps/ncspot.svg", "644"],
   ["README.md", "usr/share/doc/ncspot/README.md", "644"],
 ]
-depends = "$auto, pulseaudio"
+depends = "$auto"
 extended-description = """\
 ncurses Spotify client written in Rust using librespot. \
 It is heavily inspired by ncurses MPD clients, such as ncmpc."""


### PR DESCRIPTION
Bookworm favours pipewire over pulseaudio, so the dependency to the package "pulseaudio" from my previous PR #405 has to be removed. It seemes, it was never really necessary anyway, because "$auto" already adds the correct dependency to "libpulse0".