### PR TITLE
statusbar: update nerdfont glyphs

### DIFF
--- a/src/ui/statusbar.rs
+++ b/src/ui/statusbar.rs
@@ -47,9 +47,9 @@ impl StatusBar {
             .flip_status_indicators
             .unwrap_or(false);
 
-        const NF_PLAY: &str = "\u{f909} ";
-        const NF_PAUSE: &str = "\u{f8e3} ";
-        const NF_STOP: &str = "\u{f9da} ";
+        const NF_PLAY: &str = "\u{f04b} ";
+        const NF_PAUSE: &str = "\u{f04c} ";
+        const NF_STOP: &str = "\u{f04d} ";
         let indicators = match (nerdfont, flipped) {
             (false, false) => ("▶ ", "▮▮", "◼ "),
             (false, true) => ("▮▮", "▶ ", "▶ "),


### PR DESCRIPTION
As of https://github.com/ryanoasis/nerd-fonts/issues/1096 nf-mdi* glyphs are marked obsolete in nerd-fonts upstream

Update the glyphs to non-deprecated nf-fa* counterparts

## Details

The current glphys used in ncspot are marked obsolete:

| play | pause | stop |
|--------|--------|--------|
| ![image](https://user-images.githubusercontent.com/302375/226118977-85b2d35b-951d-4a8f-8a8e-fef224003d55.png)  | ![image](https://user-images.githubusercontent.com/302375/226119033-2231e56e-649d-46af-ac4a-16886d285782.png) | ![image](https://user-images.githubusercontent.com/302375/226119044-b259b6df-fad6-4e71-af04-8289619a63dc.png) | 

> From https://www.nerdfonts.com/cheat-sheet

An added bonus to the update may be a bugfix too! There is an issue opened here: https://github.com/hrkfdn/ncspot/issues/824 which is similar to my experience.

Here is what the glyphs look like for me just echoing the unicode (kitty 0.27.1, `TERM=xterm-kitty`, `font_family JetBrains Mono`, [my installed nerd-font packages][1])

`echo -e 'CURRENT:\n\uf909\n\uf8e3\n\uf9da\nNEW:\n\uf04b\n\uf04c\n\uf04d'`

![image](https://user-images.githubusercontent.com/302375/226117929-fc35be43-6623-455c-a82f-aa91f9f8404d.png)

and here is a comparison from my "current" ncspot distro (arch) ncspot (0.12.0) vs. "new" local release build:

#### current

![image](https://user-images.githubusercontent.com/302375/226118746-cb8e8256-d865-46dd-9b44-5635412c247b.png)

#### new

![image](https://user-images.githubusercontent.com/302375/226117334-f865663c-7065-4d51-a0c9-44df0c5517e4.png)

[1]: https://gist.github.com/cfebs/3c06bd89e5854a3dcd4841b0cd32ec35