### PR TITLE
fix(ui): ListView decrement selected on remove

### DIFF
--- a/src/ui/listview.rs
+++ b/src/ui/listview.rs
@@ -188,9 +188,17 @@ impl<I: ListItem + Clone> ListView<I> {
         }
     }
 
-    pub fn remove(&self, index: usize) {
+    /// Remove the item at `index` from the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is out of bounds.
+    pub fn remove(&mut self, index: usize) {
         let mut c = self.content.write().unwrap();
         c.remove(index);
+        if self.selected >= c.len() {
+            self.selected = self.selected.saturating_sub(1);
+        }
     }
 }
 


### PR DESCRIPTION
When removing an element, it is important to check whether it was the last element in the list and decrement the selected index if so.