### PR TITLE
Refactor the entry point to make it more readable

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -13,20 +13,22 @@ use signal_hook::{consts::SIGHUP, consts::SIGTERM, iterator::Signals};
 
 use crate::command::{Command, JumpMode};
 use crate::commands::CommandManager;
-use crate::config::{cache_path, Config};
+use crate::config::Config;
 use crate::events::{Event, EventManager};
 use crate::ext_traits::CursiveExt;
-use crate::ipc::IpcSocket;
 use crate::library::Library;
 use crate::queue::Queue;
 use crate::spotify::{PlayerEvent, Spotify};
 use crate::ui::contextmenu::ContextMenu;
 use crate::ui::create_cursive;
 use crate::{authentication, ui};
-use crate::{command, ipc, queue, spotify};
+use crate::{command, queue, spotify};
 
 #[cfg(feature = "mpris")]
 use crate::mpris::{self, MprisManager};
+
+#[cfg(unix)]
+use crate::ipc::{self, IpcSocket};
 
 /// Set up the global logger to log to `filename`.
 pub fn setup_logging(filename: &Path) -> Result<(), fern::InitError> {
@@ -139,7 +141,7 @@ impl Application {
         #[cfg(unix)]
         let ipc = ipc::IpcSocket::new(
             ASYNC_RUNTIME.handle(),
-            cache_path("ncspot.sock"),
+            crate::config::cache_path("ncspot.sock"),
             event_manager.clone(),
         )
         .map_err(|e| e.to_string())?;

--- a/src/application.rs
+++ b/src/application.rs
@@ -1,0 +1,375 @@
+use crate::{command, ipc, mpris, queue, spotify, ASYNC_RUNTIME};
+use std::fs;
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use cursive::event::EventTrigger;
+use cursive::traits::Nameable;
+use cursive::{Cursive, CursiveRunner};
+use librespot_core::authentication::Credentials;
+use librespot_core::cache::Cache;
+use log::{error, info, trace};
+
+use ncspot::program_arguments;
+#[cfg(unix)]
+use signal_hook::{consts::SIGHUP, consts::SIGTERM, iterator::Signals};
+
+use crate::command::{Command, JumpMode};
+use crate::commands::CommandManager;
+use crate::config::{self, cache_path, Config};
+use crate::events::{Event, EventManager};
+use crate::ext_traits::CursiveExt;
+use crate::library::Library;
+use crate::spotify::{PlayerEvent, Spotify};
+use crate::ui::contextmenu::ContextMenu;
+use crate::{authentication, ui};
+
+fn credentials_prompt(error_message: Option<String>) -> Result<Credentials, String> {
+    if let Some(message) = error_message {
+        let mut siv = cursive::default();
+        let dialog = cursive::views::Dialog::around(cursive::views::TextView::new(format!(
+            "Connection error:\n{message}"
+        )))
+        .button("Ok", |s| s.quit());
+        siv.add_layer(dialog);
+        siv.run();
+    }
+
+    authentication::create_credentials()
+}
+
+fn setup_logging(filename: &str) -> Result<(), fern::InitError> {
+    fern::Dispatch::new()
+        // Perform allocation-free log formatting
+        .format(|out, message, record| {
+            out.finish(format_args!(
+                "{} [{}] [{}] {}",
+                chrono::Local::now().format("[%Y-%m-%d][%H:%M:%S]"),
+                record.target(),
+                record.level(),
+                message
+            ))
+        })
+        // Add blanket level filter -
+        .level(log::LevelFilter::Trace)
+        // - and per-module overrides
+        .level_for("librespot", log::LevelFilter::Debug)
+        // Output to stdout, files, and other Dispatch configurations
+        .chain(fern::log_file(filename)?)
+        // Apply globally
+        .apply()?;
+    Ok(())
+}
+
+pub type UserData = Arc<UserDataInner>;
+pub struct UserDataInner {
+    pub cmd: CommandManager,
+}
+
+/// The representation of an ncspot application.
+pub struct Application {
+    /// The Spotify library, which is obtained from the Spotify API using rspotify.
+    library: Arc<Library>,
+    /// Internally shared
+    spotify: Spotify,
+    /// The configuration provided in the config file.
+    config: Arc<Config>,
+    /// Internally shared
+    event_manager: EventManager,
+    /// The object to render to the terminal.
+    cursive: CursiveRunner<Cursive>,
+}
+
+impl Application {
+    pub fn new() -> Result<Self, String> {
+        let matches = program_arguments().get_matches();
+
+        if let Some(filename) = matches.get_one::<String>("debug") {
+            setup_logging(filename).expect("can't setup logging");
+        }
+
+        if let Some(basepath) = matches.get_one::<String>("basepath") {
+            let path = PathBuf::from_str(basepath).expect("invalid path");
+            if !path.exists() {
+                fs::create_dir_all(&path).expect("could not create basepath directory");
+            }
+            *config::BASE_PATH.write().unwrap() = Some(path);
+        }
+
+        // Things here may cause the process to abort; we must do them before creating curses windows
+        // otherwise the error message will not be seen by a user
+        let config: Arc<crate::config::Config> = Arc::new(Config::new(
+            matches
+                .get_one::<String>("config")
+                .unwrap_or(&"config.toml".to_string()),
+        ));
+        let mut credentials = {
+            let cache = Cache::new(Some(config::cache_path("librespot")), None, None, None)
+                .expect("Could not create librespot cache");
+            let cached_credentials = cache.credentials();
+            match cached_credentials {
+                Some(c) => {
+                    info!("Using cached credentials");
+                    c
+                }
+                None => {
+                    info!("Attempting to resolve credentials via username/password commands");
+                    let creds = config.values().credentials.clone().unwrap_or_default();
+
+                    match (creds.username_cmd, creds.password_cmd) {
+                        (Some(username_cmd), Some(password_cmd)) => {
+                            authentication::credentials_eval(&username_cmd, &password_cmd)?
+                        }
+                        _ => credentials_prompt(None)?,
+                    }
+                }
+            }
+        };
+
+        while let Err(error) = spotify::Spotify::test_credentials(credentials.clone()) {
+            let error_msg = format!("{error}");
+            credentials = credentials_prompt(Some(error_msg))?;
+        }
+
+        println!("Connecting to Spotify..");
+
+        // DON'T USE STDOUT AFTER THIS CALL!
+        let backend = cursive::backends::try_default().map_err(|e| e.to_string())?;
+        let buffered_backend = Box::new(cursive_buffered_backend::BufferedBackend::new(backend));
+
+        let mut cursive = cursive::CursiveRunner::new(cursive::Cursive::new(), buffered_backend);
+        cursive.set_window_title("ncspot");
+
+        let event_manager = EventManager::new(cursive.cb_sink().clone());
+
+        let spotify = spotify::Spotify::new(event_manager.clone(), credentials, config.clone());
+
+        let library = Arc::new(Library::new(
+            &event_manager,
+            spotify.clone(),
+            config.clone(),
+        ));
+
+        Ok(Self {
+            library,
+            spotify,
+            config,
+            event_manager,
+            cursive,
+        })
+    }
+
+    pub fn run(&mut self) -> Result<(), String> {
+        let theme = self.config.build_theme();
+        self.cursive.set_theme(theme.clone());
+
+        let queue = Arc::new(queue::Queue::new(
+            self.spotify.clone(),
+            self.config.clone(),
+            self.library.clone(),
+        ));
+
+        #[cfg(feature = "mpris")]
+        let mpris_manager = mpris::MprisManager::new(
+            self.event_manager.clone(),
+            queue.clone(),
+            self.library.clone(),
+            self.spotify.clone(),
+        );
+
+        let mut cmd_manager = CommandManager::new(
+            self.spotify.clone(),
+            queue.clone(),
+            self.library.clone(),
+            self.config.clone(),
+            self.event_manager.clone(),
+        );
+
+        cmd_manager.register_all();
+        cmd_manager.register_keybindings(&mut self.cursive);
+
+        let user_data: UserData = Arc::new(UserDataInner { cmd: cmd_manager });
+        self.cursive.set_user_data(user_data);
+
+        let search = ui::search::SearchView::new(
+            self.event_manager.clone(),
+            queue.clone(),
+            self.library.clone(),
+        );
+
+        let libraryview = ui::library::LibraryView::new(queue.clone(), self.library.clone());
+
+        let queueview = ui::queue::QueueView::new(queue.clone(), self.library.clone());
+
+        #[cfg(feature = "cover")]
+        let coverview =
+            ui::cover::CoverView::new(queue.clone(), self.library.clone(), &self.config);
+
+        let status = ui::statusbar::StatusBar::new(queue.clone(), Arc::clone(&self.library));
+
+        let mut layout = ui::layout::Layout::new(status, &self.event_manager, theme)
+            .screen("search", search.with_name("search"))
+            .screen("library", libraryview.with_name("library"))
+            .screen("queue", queueview);
+
+        #[cfg(feature = "cover")]
+        layout.add_screen("cover", coverview.with_name("cover"));
+
+        // initial screen is library
+        let initial_screen = self
+            .config
+            .values()
+            .initial_screen
+            .clone()
+            .unwrap_or_else(|| "library".to_string());
+        if layout.has_screen(&initial_screen) {
+            layout.set_screen(initial_screen);
+        } else {
+            error!("Invalid screen name: {}", initial_screen);
+            layout.set_screen("library");
+        }
+
+        let cmd_key = |cfg: Arc<Config>| cfg.values().command_key.unwrap_or(':');
+
+        {
+            let c = self.config.clone();
+            let config_clone = Arc::clone(&self.config);
+            self.cursive.set_on_post_event(
+                EventTrigger::from_fn(move |event| {
+                    event == &cursive::event::Event::Char(cmd_key(c.clone()))
+                }),
+                move |s| {
+                    if s.find_name::<ContextMenu>("contextmenu").is_none() {
+                        s.call_on_name("main", |v: &mut ui::layout::Layout| {
+                            v.enable_cmdline(cmd_key(config_clone.clone()));
+                        });
+                    }
+                },
+            );
+        }
+
+        self.cursive.add_global_callback('/', move |s| {
+            if s.find_name::<ContextMenu>("contextmenu").is_none() {
+                s.call_on_name("main", |v: &mut ui::layout::Layout| {
+                    v.enable_jump();
+                });
+            }
+        });
+
+        self.cursive
+            .add_global_callback(cursive::event::Key::Esc, move |s| {
+                if s.find_name::<ContextMenu>("contextmenu").is_none() {
+                    s.call_on_name("main", |v: &mut ui::layout::Layout| {
+                        v.clear_cmdline();
+                    });
+                }
+            });
+
+        layout.cmdline.set_on_edit(move |s, cmd, _| {
+            s.call_on_name("main", |v: &mut ui::layout::Layout| {
+                if cmd.is_empty() {
+                    v.clear_cmdline();
+                }
+            });
+        });
+
+        {
+            let ev = self.event_manager.clone();
+            layout.cmdline.set_on_submit(move |s, cmd| {
+                s.on_layout(|_, mut layout| layout.clear_cmdline());
+                let cmd_without_prefix = &cmd[1..];
+                if cmd.strip_prefix('/').is_some() {
+                    let command = Command::Jump(JumpMode::Query(cmd_without_prefix.to_string()));
+                    if let Some(data) = s.user_data::<UserData>().cloned() {
+                        data.cmd.handle(s, command);
+                    }
+                } else {
+                    match command::parse(cmd_without_prefix) {
+                        Ok(commands) => {
+                            if let Some(data) = s.user_data::<UserData>().cloned() {
+                                for cmd in commands {
+                                    data.cmd.handle(s, cmd);
+                                }
+                            }
+                        }
+                        Err(err) => {
+                            s.on_layout(|_, mut layout| layout.set_result(Err(err.to_string())));
+                        }
+                    }
+                }
+                ev.trigger();
+            });
+        }
+
+        self.cursive.add_fullscreen_layer(layout.with_name("main"));
+
+        #[cfg(all(unix, feature = "pancurses_backend"))]
+        self.cursive
+            .add_global_callback(cursive::event::Event::CtrlChar('z'), |_s| unsafe {
+                libc::raise(libc::SIGTSTP);
+            });
+
+        #[cfg(unix)]
+        let mut signals =
+            Signals::new([SIGTERM, SIGHUP]).expect("could not register signal handler");
+
+        #[cfg(unix)]
+        let ipc = {
+            ipc::IpcSocket::new(
+                ASYNC_RUNTIME.handle(),
+                cache_path("ncspot.sock"),
+                self.event_manager.clone(),
+            )
+            .map_err(|e| e.to_string())?
+        };
+
+        // cursive event loop
+        while self.cursive.is_running() {
+            self.cursive.step();
+            #[cfg(unix)]
+            for signal in signals.pending() {
+                if signal == SIGTERM || signal == SIGHUP {
+                    info!("Caught {}, cleaning up and closing", signal);
+                    if let Some(data) = self.cursive.user_data::<UserData>().cloned() {
+                        data.cmd.handle(&mut self.cursive, Command::Quit);
+                    }
+                }
+            }
+            for event in self.event_manager.msg_iter() {
+                match event {
+                    Event::Player(state) => {
+                        trace!("event received: {:?}", state);
+                        self.spotify.update_status(state.clone());
+
+                        #[cfg(feature = "mpris")]
+                        mpris_manager.update();
+
+                        #[cfg(unix)]
+                        ipc.publish(&state, queue.get_current());
+
+                        if state == PlayerEvent::FinishedTrack {
+                            queue.next(false);
+                        }
+                    }
+                    Event::Queue(event) => {
+                        queue.handle_event(event);
+                    }
+                    Event::SessionDied => self.spotify.start_worker(None),
+                    Event::IpcInput(input) => match command::parse(&input) {
+                        Ok(commands) => {
+                            if let Some(data) = self.cursive.user_data::<UserData>().cloned() {
+                                for cmd in commands {
+                                    info!("Executing command from IPC: {cmd}");
+                                    data.cmd.handle(&mut self.cursive, cmd);
+                                }
+                            }
+                        }
+                        Err(e) => error!("Parsing error: {e}"),
+                    },
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/application.rs
+++ b/src/application.rs
@@ -96,7 +96,6 @@ impl Application {
     ///
     /// # Arguments
     ///
-    /// * `configuration_base_path` - Path to the configuration directory
     /// * `configuration_file_path` - Relative path to the configuration file inside the base path
     pub fn new(configuration_file_path: Option<String>) -> Result<Self, String> {
         // Things here may cause the process to abort; we must do them before creating curses

--- a/src/application.rs
+++ b/src/application.rs
@@ -1,4 +1,4 @@
-use crate::{command, ipc, mpris, queue, spotify, ASYNC_RUNTIME};
+use crate::{command, ipc, mpris, queue, spotify};
 use std::fs;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -66,6 +66,14 @@ pub type UserData = Arc<UserDataInner>;
 pub struct UserDataInner {
     pub cmd: CommandManager,
 }
+
+lazy_static!(
+    /// The global Tokio runtime for running asynchronous tasks.
+    pub static ref ASYNC_RUNTIME: tokio::runtime::Runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+);
 
 /// The representation of an ncspot application.
 pub struct Application {

--- a/src/command.rs
+++ b/src/command.rs
@@ -43,6 +43,7 @@ impl Default for MoveAmount {
     }
 }
 
+/// Keys that can be used to sort songs on.
 #[derive(Display, Clone, Serialize, Deserialize, Debug)]
 #[strum(serialize_all = "lowercase")]
 pub enum SortKey {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::application::UserData;
 use crate::command::{
     parse, Command, GotoMode, JumpMode, MoveAmount, MoveMode, SeekDirection, ShiftMode, TargetMode,
 };
@@ -19,7 +20,6 @@ use crate::ui::help::HelpView;
 use crate::ui::layout::Layout;
 use crate::ui::modal::Modal;
 use crate::ui::search_results::SearchResultsView;
-use crate::UserData;
 use cursive::event::{Event, Key};
 use cursive::traits::View;
 use cursive::views::Dialog;

--- a/src/config.rs
+++ b/src/config.rs
@@ -254,6 +254,7 @@ impl Config {
         crate::theme::load(theme)
     }
 
+    /// Reload the configuration file.
     pub fn reload(&self) {
         let cfg = load(&self.filename.to_string_lossy()).expect("could not reload config");
         *self.values.write().expect("can't writelock config values") = cfg
@@ -326,4 +327,14 @@ pub fn cache_path(file: &str) -> PathBuf {
     let mut pb = cache_dir.to_path_buf();
     pb.push(file);
     pb
+}
+
+/// Set the configuration base path. All configuration files are read/written relative to this path.
+pub fn set_configuration_base_path(base_path: Option<PathBuf>) {
+    if let Some(basepath) = base_path {
+        if !basepath.exists() {
+            fs::create_dir_all(&basepath).expect("could not create basepath directory");
+        }
+        *BASE_PATH.write().unwrap() = Some(basepath);
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -182,7 +182,7 @@ lazy_static! {
 /// The complete configuration (state + user configuration) of ncspot.
 pub struct Config {
     /// The configuration file path.
-    filename: PathBuf,
+    filename: String,
     /// Configuration set by the user, read only.
     values: RwLock<ConfigValues>,
     /// Runtime state which can't be edited by the user, read/write.
@@ -191,8 +191,10 @@ pub struct Config {
 
 impl Config {
     /// Generate the configuration from the user configuration file and the runtime state file.
-    pub fn new(filename: PathBuf) -> Self {
-        let values = load(&filename.to_string_lossy()).unwrap_or_else(|e| {
+    /// `filename` can be used to look for a differently named configuration file.
+    pub fn new(filename: Option<String>) -> Self {
+        let filename = filename.unwrap_or("config.toml".to_owned());
+        let values = load(&filename).unwrap_or_else(|e| {
             eprintln!("could not load config: {e}");
             process::exit(1);
         });
@@ -256,7 +258,7 @@ impl Config {
 
     /// Reload the configuration file.
     pub fn reload(&self) {
-        let cfg = load(&self.filename.to_string_lossy()).expect("could not reload config");
+        let cfg = load(&self.filename).expect("could not reload config");
         *self.values.write().expect("can't writelock config values") = cfg
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -169,14 +169,14 @@ lazy_static! {
 }
 
 pub struct Config {
-    filename: String,
+    filename: PathBuf,
     values: RwLock<ConfigValues>,
     state: RwLock<UserState>,
 }
 
 impl Config {
-    pub fn new(filename: &str) -> Self {
-        let values = load(filename).unwrap_or_else(|e| {
+    pub fn new(filename: PathBuf) -> Self {
+        let values = load(&filename.to_string_lossy()).unwrap_or_else(|e| {
             eprintln!("could not load config: {e}");
             process::exit(1);
         });
@@ -200,7 +200,7 @@ impl Config {
         }
 
         Self {
-            filename: filename.to_string(),
+            filename,
             values: RwLock::new(values),
             state: RwLock::new(userstate),
         }
@@ -239,7 +239,7 @@ impl Config {
     }
 
     pub fn reload(&self) {
-        let cfg = load(&self.filename).expect("could not reload config");
+        let cfg = load(&self.filename.to_string_lossy()).expect("could not reload config");
         *self.values.write().expect("can't writelock config values") = cfg
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,6 @@ pub fn program_arguments() -> clap::Command {
                 .short('c')
                 .long("config")
                 .value_name("FILE")
-                .value_parser(PathBufValueParser::new())
                 .help("Filename of config file in basepath")
                 .default_value("config.toml"),
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use clap::builder::PathBufValueParser;
 use librespot_playback::audio_backend;
 
 pub const AUTHOR: &str = "Henrik Friedrichsen <henrik@affekt.org> and contributors";
@@ -22,6 +23,7 @@ pub fn program_arguments() -> clap::Command {
                 .short('d')
                 .long("debug")
                 .value_name("FILE")
+                .value_parser(PathBufValueParser::new())
                 .help("Enable debug logging to the specified file"),
         )
         .arg(
@@ -29,6 +31,7 @@ pub fn program_arguments() -> clap::Command {
                 .short('b')
                 .long("basepath")
                 .value_name("PATH")
+                .value_parser(PathBufValueParser::new())
                 .help("custom basepath to config/cache files"),
         )
         .arg(
@@ -36,6 +39,7 @@ pub fn program_arguments() -> clap::Command {
                 .short('c')
                 .long("config")
                 .value_name("FILE")
+                .value_parser(PathBufValueParser::new())
                 .help("Filename of config file in basepath")
                 .default_value("config.toml"),
         )

--- a/src/library.rs
+++ b/src/library.rs
@@ -42,7 +42,7 @@ pub struct Library {
 }
 
 impl Library {
-    pub fn new(ev: &EventManager, spotify: Spotify, cfg: Arc<Config>) -> Self {
+    pub fn new(ev: EventManager, spotify: Spotify, cfg: Arc<Config>) -> Self {
         let current_user = spotify.api.current_user();
         let user_id = current_user.as_ref().map(|u| u.id.id().to_string());
         let display_name = current_user.as_ref().and_then(|u| u.display_name.clone());
@@ -56,7 +56,7 @@ impl Library {
             is_done: Arc::new(RwLock::new(false)),
             user_id,
             display_name,
-            ev: ev.clone(),
+            ev,
             spotify,
             cfg,
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ extern crate serde;
 
 use std::path::PathBuf;
 
-use application::Application;
+use application::{setup_logging, Application};
 use ncspot::program_arguments;
 
 mod application;
@@ -43,13 +43,20 @@ fn main() -> Result<(), String> {
     // stdout is most likely in use by Cursive.
     panic::register_backtrace_panic_handler();
 
+    // Parse the command line arguments.
     let matches = program_arguments().get_matches();
 
+    // Enable debug logging to a file if specified on the command line.
+    if let Some(filename) = matches.get_one::<PathBuf>("debug") {
+        setup_logging(filename).expect("logger could not be initialized");
+    }
+
+    // Create the application.
     let mut application = Application::new(
-        matches.get_one::<PathBuf>("debug").cloned(),
         matches.get_one::<PathBuf>("basepath").cloned(),
         matches.get_one::<PathBuf>("config").cloned(),
     )?;
 
+    // Start the application event loop.
     application.run()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,22 +6,10 @@ extern crate lazy_static;
 extern crate serde;
 
 use std::backtrace;
-use std::fs::{self, File};
+use std::fs::File;
 use std::io::Write;
-use std::path::PathBuf;
-use std::str::FromStr;
-use std::sync::Arc;
 
-use cursive::event::EventTrigger;
-use cursive::traits::Nameable;
-use librespot_core::authentication::Credentials;
-use librespot_core::cache::Cache;
-use log::{error, info, trace};
-
-use ncspot::program_arguments;
-#[cfg(unix)]
-use signal_hook::{consts::SIGHUP, consts::SIGTERM, iterator::Signals};
-
+mod application;
 mod authentication;
 mod command;
 mod commands;
@@ -48,52 +36,10 @@ mod ipc;
 #[cfg(feature = "mpris")]
 mod mpris;
 
-use crate::command::{Command, JumpMode};
-use crate::commands::CommandManager;
-use crate::config::{cache_path, Config};
-use crate::events::{Event, EventManager};
-use crate::ext_traits::CursiveExt;
-use crate::library::Library;
-use crate::spotify::PlayerEvent;
-use crate::ui::contextmenu::ContextMenu;
+use crate::application::Application;
 
-fn setup_logging(filename: &str) -> Result<(), fern::InitError> {
-    fern::Dispatch::new()
-        // Perform allocation-free log formatting
-        .format(|out, message, record| {
-            out.finish(format_args!(
-                "{} [{}] [{}] {}",
-                chrono::Local::now().format("[%Y-%m-%d][%H:%M:%S]"),
-                record.target(),
-                record.level(),
-                message
-            ))
-        })
-        // Add blanket level filter -
-        .level(log::LevelFilter::Trace)
-        // - and per-module overrides
-        .level_for("librespot", log::LevelFilter::Debug)
-        // Output to stdout, files, and other Dispatch configurations
-        .chain(fern::log_file(filename)?)
-        // Apply globally
-        .apply()?;
-    Ok(())
-}
-
-fn credentials_prompt(error_message: Option<String>) -> Result<Credentials, String> {
-    if let Some(message) = error_message {
-        let mut siv = cursive::default();
-        let dialog = cursive::views::Dialog::around(cursive::views::TextView::new(format!(
-            "Connection error:\n{message}"
-        )))
-        .button("Ok", |s| s.quit());
-        siv.add_layer(dialog);
-        siv.run();
-    }
-
-    authentication::create_credentials()
-}
-
+/// Register a custom panic handler to write the backtrace to a file since stdout is in use by the
+/// Cursive TUI library during most of the application.
 fn register_backtrace_panic_handler() {
     // During most of the program, Cursive is responsible for drawing to the
     // tty. Since stdout probably doesn't work as expected during a panic, the
@@ -113,11 +59,6 @@ fn register_backtrace_panic_handler() {
     }));
 }
 
-type UserData = Arc<UserDataInner>;
-struct UserDataInner {
-    pub cmd: CommandManager,
-}
-
 lazy_static!(
     /// The global Tokio runtime for running asynchronous tasks.
     static ref ASYNC_RUNTIME: tokio::runtime::Runtime = tokio::runtime::Builder::new_multi_thread()
@@ -129,269 +70,7 @@ lazy_static!(
 fn main() -> Result<(), String> {
     register_backtrace_panic_handler();
 
-    let matches = program_arguments().get_matches();
+    let mut application = Application::new()?;
 
-    if let Some(filename) = matches.get_one::<String>("debug") {
-        setup_logging(filename).expect("can't setup logging");
-    }
-
-    if let Some(basepath) = matches.get_one::<String>("basepath") {
-        let path = PathBuf::from_str(basepath).expect("invalid path");
-        if !path.exists() {
-            fs::create_dir_all(&path).expect("could not create basepath directory");
-        }
-        *config::BASE_PATH.write().unwrap() = Some(path);
-    }
-
-    // Things here may cause the process to abort; we must do them before creating curses windows
-    // otherwise the error message will not be seen by a user
-    let cfg: Arc<crate::config::Config> = Arc::new(Config::new(
-        matches
-            .get_one::<String>("config")
-            .unwrap_or(&"config.toml".to_string()),
-    ));
-    let mut credentials = {
-        let cache = Cache::new(Some(config::cache_path("librespot")), None, None, None)
-            .expect("Could not create librespot cache");
-        let cached_credentials = cache.credentials();
-        match cached_credentials {
-            Some(c) => {
-                info!("Using cached credentials");
-                c
-            }
-            None => {
-                info!("Attempting to resolve credentials via username/password commands");
-                let creds = cfg.values().credentials.clone().unwrap_or_default();
-
-                match (creds.username_cmd, creds.password_cmd) {
-                    (Some(username_cmd), Some(password_cmd)) => {
-                        authentication::credentials_eval(&username_cmd, &password_cmd)?
-                    }
-                    _ => credentials_prompt(None)?,
-                }
-            }
-        }
-    };
-
-    while let Err(error) = spotify::Spotify::test_credentials(credentials.clone()) {
-        let error_msg = format!("{error}");
-        credentials = credentials_prompt(Some(error_msg))?;
-    }
-
-    println!("Connecting to Spotify..");
-
-    // DON'T USE STDOUT AFTER THIS CALL!
-    let backend = cursive::backends::try_default().map_err(|e| e.to_string())?;
-    let buffered_backend = Box::new(cursive_buffered_backend::BufferedBackend::new(backend));
-
-    let mut cursive = cursive::CursiveRunner::new(cursive::Cursive::new(), buffered_backend);
-    cursive.set_window_title("ncspot");
-
-    let theme = cfg.build_theme();
-    cursive.set_theme(theme.clone());
-
-    let event_manager = EventManager::new(cursive.cb_sink().clone());
-
-    let spotify = spotify::Spotify::new(event_manager.clone(), credentials, cfg.clone());
-
-    let library = Arc::new(Library::new(&event_manager, spotify.clone(), cfg.clone()));
-
-    let queue = Arc::new(queue::Queue::new(
-        spotify.clone(),
-        cfg.clone(),
-        library.clone(),
-    ));
-
-    #[cfg(feature = "mpris")]
-    let mpris_manager = mpris::MprisManager::new(
-        event_manager.clone(),
-        queue.clone(),
-        library.clone(),
-        spotify.clone(),
-    );
-
-    let mut cmd_manager = CommandManager::new(
-        spotify.clone(),
-        queue.clone(),
-        library.clone(),
-        cfg.clone(),
-        event_manager.clone(),
-    );
-
-    cmd_manager.register_all();
-    cmd_manager.register_keybindings(&mut cursive);
-
-    let user_data: UserData = Arc::new(UserDataInner { cmd: cmd_manager });
-    cursive.set_user_data(user_data);
-
-    let search = ui::search::SearchView::new(event_manager.clone(), queue.clone(), library.clone());
-
-    let libraryview = ui::library::LibraryView::new(queue.clone(), library.clone());
-
-    let queueview = ui::queue::QueueView::new(queue.clone(), library.clone());
-
-    #[cfg(feature = "cover")]
-    let coverview = ui::cover::CoverView::new(queue.clone(), library.clone(), &cfg);
-
-    let status = ui::statusbar::StatusBar::new(queue.clone(), library);
-
-    let mut layout = ui::layout::Layout::new(status, &event_manager, theme)
-        .screen("search", search.with_name("search"))
-        .screen("library", libraryview.with_name("library"))
-        .screen("queue", queueview);
-
-    #[cfg(feature = "cover")]
-    layout.add_screen("cover", coverview.with_name("cover"));
-
-    // initial screen is library
-    let initial_screen = cfg
-        .values()
-        .initial_screen
-        .clone()
-        .unwrap_or_else(|| "library".to_string());
-    if layout.has_screen(&initial_screen) {
-        layout.set_screen(initial_screen);
-    } else {
-        error!("Invalid screen name: {}", initial_screen);
-        layout.set_screen("library");
-    }
-
-    let cmd_key = |cfg: Arc<Config>| cfg.values().command_key.unwrap_or(':');
-
-    {
-        let c = cfg.clone();
-        cursive.set_on_post_event(
-            EventTrigger::from_fn(move |event| {
-                event == &cursive::event::Event::Char(cmd_key(c.clone()))
-            }),
-            move |s| {
-                if s.find_name::<ContextMenu>("contextmenu").is_none() {
-                    s.call_on_name("main", |v: &mut ui::layout::Layout| {
-                        v.enable_cmdline(cmd_key(cfg.clone()));
-                    });
-                }
-            },
-        );
-    }
-
-    cursive.add_global_callback('/', move |s| {
-        if s.find_name::<ContextMenu>("contextmenu").is_none() {
-            s.call_on_name("main", |v: &mut ui::layout::Layout| {
-                v.enable_jump();
-            });
-        }
-    });
-
-    cursive.add_global_callback(cursive::event::Key::Esc, move |s| {
-        if s.find_name::<ContextMenu>("contextmenu").is_none() {
-            s.call_on_name("main", |v: &mut ui::layout::Layout| {
-                v.clear_cmdline();
-            });
-        }
-    });
-
-    layout.cmdline.set_on_edit(move |s, cmd, _| {
-        s.call_on_name("main", |v: &mut ui::layout::Layout| {
-            if cmd.is_empty() {
-                v.clear_cmdline();
-            }
-        });
-    });
-
-    {
-        let ev = event_manager.clone();
-        layout.cmdline.set_on_submit(move |s, cmd| {
-            s.on_layout(|_, mut layout| layout.clear_cmdline());
-            let cmd_without_prefix = &cmd[1..];
-            if cmd.strip_prefix('/').is_some() {
-                let command = Command::Jump(JumpMode::Query(cmd_without_prefix.to_string()));
-                if let Some(data) = s.user_data::<UserData>().cloned() {
-                    data.cmd.handle(s, command);
-                }
-            } else {
-                match command::parse(cmd_without_prefix) {
-                    Ok(commands) => {
-                        if let Some(data) = s.user_data::<UserData>().cloned() {
-                            for cmd in commands {
-                                data.cmd.handle(s, cmd);
-                            }
-                        }
-                    }
-                    Err(err) => {
-                        s.on_layout(|_, mut layout| layout.set_result(Err(err.to_string())));
-                    }
-                }
-            }
-            ev.trigger();
-        });
-    }
-
-    cursive.add_fullscreen_layer(layout.with_name("main"));
-
-    #[cfg(all(unix, feature = "pancurses_backend"))]
-    cursive.add_global_callback(cursive::event::Event::CtrlChar('z'), |_s| unsafe {
-        libc::raise(libc::SIGTSTP);
-    });
-
-    #[cfg(unix)]
-    let mut signals = Signals::new([SIGTERM, SIGHUP]).expect("could not register signal handler");
-
-    #[cfg(unix)]
-    let ipc = {
-        ipc::IpcSocket::new(
-            ASYNC_RUNTIME.handle(),
-            cache_path("ncspot.sock"),
-            event_manager.clone(),
-        )
-        .map_err(|e| e.to_string())?
-    };
-
-    // cursive event loop
-    while cursive.is_running() {
-        cursive.step();
-        #[cfg(unix)]
-        for signal in signals.pending() {
-            if signal == SIGTERM || signal == SIGHUP {
-                info!("Caught {}, cleaning up and closing", signal);
-                if let Some(data) = cursive.user_data::<UserData>().cloned() {
-                    data.cmd.handle(&mut cursive, Command::Quit);
-                }
-            }
-        }
-        for event in event_manager.msg_iter() {
-            match event {
-                Event::Player(state) => {
-                    trace!("event received: {:?}", state);
-                    spotify.update_status(state.clone());
-
-                    #[cfg(feature = "mpris")]
-                    mpris_manager.update();
-
-                    #[cfg(unix)]
-                    ipc.publish(&state, queue.get_current());
-
-                    if state == PlayerEvent::FinishedTrack {
-                        queue.next(false);
-                    }
-                }
-                Event::Queue(event) => {
-                    queue.handle_event(event);
-                }
-                Event::SessionDied => spotify.start_worker(None),
-                Event::IpcInput(input) => match command::parse(&input) {
-                    Ok(commands) => {
-                        if let Some(data) = cursive.user_data::<UserData>().cloned() {
-                            for cmd in commands {
-                                info!("Executing command from IPC: {cmd}");
-                                data.cmd.handle(&mut cursive, cmd);
-                            }
-                        }
-                    }
-                    Err(e) => error!("Parsing error: {e}"),
-                },
-            }
-        }
-    }
-
-    Ok(())
+    application.run()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,9 +5,6 @@ extern crate lazy_static;
 #[macro_use]
 extern crate serde;
 
-use std::backtrace;
-use std::fs::File;
-use std::io::Write;
 use std::path::PathBuf;
 
 use application::Application;
@@ -22,6 +19,7 @@ mod events;
 mod ext_traits;
 mod library;
 mod model;
+mod panic;
 mod queue;
 mod serialization;
 mod sharing;
@@ -40,31 +38,10 @@ mod ipc;
 #[cfg(feature = "mpris")]
 mod mpris;
 
-/// Register a custom panic handler to write the backtrace to a file since stdout is in use by the
-/// Cursive TUI library during most of the application.
-fn register_backtrace_panic_handler() {
-    // During most of the program, Cursive is responsible for drawing to the
-    // tty. Since stdout probably doesn't work as expected during a panic, the
-    // backtrace is written to a file at $USER_CACHE_DIR/ncspot/backtrace.log.
-    std::panic::set_hook(Box::new(|panic_info| {
-        // A panic hook will prevent the default panic handler from being
-        // called. An unwrap in this part would cause a hard crash of ncspot.
-        // Don't unwrap/expect/panic in here!
-        if let Ok(backtrace_log) = config::try_proj_dirs() {
-            let mut path = backtrace_log.cache_dir;
-            path.push("backtrace.log");
-            if let Ok(mut file) = File::create(path) {
-                writeln!(file, "{}", backtrace::Backtrace::force_capture()).unwrap_or_default();
-                writeln!(file, "{panic_info}").unwrap_or_default();
-            }
-        }
-    }));
-}
-
-// Functionality related to the operating system process itself is implemented here.
-// Functionality related to ncspot goes into `Application`.
 fn main() -> Result<(), String> {
-    register_backtrace_panic_handler();
+    // Set a custom backtrace hook that writes the backtrace to a file instead of stdout, since
+    // stdout is most likely in use by Cursive.
+    panic::register_backtrace_panic_handler();
 
     let matches = program_arguments().get_matches();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ extern crate serde;
 use std::path::PathBuf;
 
 use application::{setup_logging, Application};
+use config::set_configuration_base_path;
 use ncspot::program_arguments;
 
 mod application;
@@ -51,11 +52,12 @@ fn main() -> Result<(), String> {
         setup_logging(filename).expect("logger could not be initialized");
     }
 
+    // Set the configuration base path. All configuration files are read/written relative to this
+    // path.
+    set_configuration_base_path(matches.get_one::<PathBuf>("basepath").cloned());
+
     // Create the application.
-    let mut application = Application::new(
-        matches.get_one::<PathBuf>("basepath").cloned(),
-        matches.get_one::<PathBuf>("config").cloned(),
-    )?;
+    let mut application = Application::new(matches.get_one::<String>("config").cloned())?;
 
     // Start the application event loop.
     application.run()

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,10 @@ extern crate serde;
 use std::backtrace;
 use std::fs::File;
 use std::io::Write;
+use std::path::PathBuf;
+
+use application::Application;
+use ncspot::program_arguments;
 
 mod application;
 mod authentication;
@@ -36,8 +40,6 @@ mod ipc;
 #[cfg(feature = "mpris")]
 mod mpris;
 
-use crate::application::Application;
-
 /// Register a custom panic handler to write the backtrace to a file since stdout is in use by the
 /// Cursive TUI library during most of the application.
 fn register_backtrace_panic_handler() {
@@ -64,7 +66,13 @@ fn register_backtrace_panic_handler() {
 fn main() -> Result<(), String> {
     register_backtrace_panic_handler();
 
-    let mut application = Application::new()?;
+    let matches = program_arguments().get_matches();
+
+    let mut application = Application::new(
+        matches.get_one::<PathBuf>("debug").cloned(),
+        matches.get_one::<PathBuf>("basepath").cloned(),
+        matches.get_one::<PathBuf>("config").cloned(),
+    )?;
 
     application.run()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,14 +59,8 @@ fn register_backtrace_panic_handler() {
     }));
 }
 
-lazy_static!(
-    /// The global Tokio runtime for running asynchronous tasks.
-    static ref ASYNC_RUNTIME: tokio::runtime::Runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .unwrap();
-);
-
+// Functionality related to the operating system process itself is implemented here.
+// Functionality related to ncspot goes into `Application`.
 fn main() -> Result<(), String> {
     register_backtrace_panic_handler();
 

--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -8,6 +8,7 @@ use tokio_stream::StreamExt;
 use zbus::zvariant::{ObjectPath, Value};
 use zbus::{dbus_interface, ConnectionBuilder};
 
+use crate::application::ASYNC_RUNTIME;
 use crate::library::Library;
 use crate::model::album::Album;
 use crate::model::episode::Episode;
@@ -19,7 +20,6 @@ use crate::queue::RepeatSetting;
 use crate::spotify::UriType;
 use crate::spotify_url::SpotifyUrl;
 use crate::traits::ListItem;
-use crate::ASYNC_RUNTIME;
 use crate::{
     events::EventManager,
     queue::Queue,

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -1,0 +1,25 @@
+use std::io::Write;
+use std::{backtrace, fs::File};
+
+use crate::config;
+
+/// Register a custom panic handler to write backtraces to a file called `backtrace.log` inside the
+/// user's cache directory.
+pub fn register_backtrace_panic_handler() {
+    // During most of the program, Cursive is responsible for drawing to the
+    // tty. Since stdout probably doesn't work as expected during a panic, the
+    // backtrace is written to a file at $USER_CACHE_DIR/ncspot/backtrace.log.
+    std::panic::set_hook(Box::new(|panic_info| {
+        // A panic hook will prevent the default panic handler from being
+        // called. An unwrap in this part would cause a hard crash of ncspot.
+        // Don't unwrap/expect/panic in here!
+        if let Ok(backtrace_log) = config::try_proj_dirs() {
+            let mut path = backtrace_log.cache_dir;
+            path.push("backtrace.log");
+            if let Ok(mut file) = File::create(path) {
+                writeln!(file, "{}", backtrace::Backtrace::force_capture()).unwrap_or_default();
+                writeln!(file, "{panic_info}").unwrap_or_default();
+            }
+        }
+    }));
+}

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -1,14 +1,14 @@
 use std::cmp::Ordering;
 use std::sync::{Arc, RwLock};
 
-use log::{debug, error, info};
+use log::{debug, info};
 #[cfg(feature = "notify")]
 use notify_rust::{Hint, Notification, Urgency};
 
 use rand::prelude::*;
 use strum_macros::Display;
 
-use crate::config::{Config, NotificationFormat, PlaybackState};
+use crate::config::{Config, PlaybackState};
 use crate::library::Library;
 use crate::model::playable::Playable;
 use crate::spotify::PlayerEvent;
@@ -321,10 +321,10 @@ impl Queue {
                         .notification_format
                         .clone()
                         .unwrap_or_default();
-                    let default_title = NotificationFormat::default().title.unwrap();
+                    let default_title = crate::config::NotificationFormat::default().title.unwrap();
                     let title = format.title.unwrap_or_else(|| default_title.clone());
 
-                    let default_body = NotificationFormat::default().body.unwrap();
+                    let default_body = crate::config::NotificationFormat::default().body.unwrap();
                     let body = format.body.unwrap_or_else(|| default_body.clone());
 
                     let summary_txt = Playable::format(track, &title, &self.library);
@@ -503,7 +503,7 @@ pub fn send_notification(summary_txt: &str, body_txt: &str, cover_url: Option<St
         let path = crate::utils::cache_path_for_url(u.to_string());
         if !path.exists() {
             if let Err(e) = crate::utils::download(u, path.clone()) {
-                error!("Failed to download cover: {}", e);
+                log::error!("Failed to download cover: {}", e);
             }
         }
         n.icon(path.to_str().unwrap());
@@ -521,6 +521,6 @@ pub fn send_notification(summary_txt: &str, body_txt: &str, cover_url: Option<St
             #[cfg(all(unix, not(target_os = "macos")))]
             info!("Created notification: {}", handle.id());
         }
-        Err(e) => error!("Failed to send notification cover: {}", e),
+        Err(e) => log::error!("Failed to send notification cover: {}", e),
     }
 }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, RwLock};
 
 use log::{debug, info};
 #[cfg(feature = "notify")]
-use notify_rust::{Hint, Notification, Urgency};
+use notify_rust::Notification;
 
 use rand::prelude::*;
 use strum_macros::Display;
@@ -511,9 +511,9 @@ pub fn send_notification(summary_txt: &str, body_txt: &str, cover_url: Option<St
 
     // XDG desktop entry hints
     #[cfg(all(unix, not(target_os = "macos")))]
-    n.urgency(Urgency::Low)
-        .hint(Hint::Transient(true))
-        .hint(Hint::DesktopEntry("ncspot".into()));
+    n.urgency(notify_rust::Urgency::Low)
+        .hint(notify_rust::Hint::Transient(true))
+        .hint(notify_rust::Hint::DesktopEntry("ncspot".into()));
 
     match n.show() {
         Ok(handle) => {

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -40,6 +40,8 @@ pub enum PlayerEvent {
     FinishedTrack,
 }
 
+// TODO: Rename or document this as it isn't immediately clear what it represents/does from the
+// name.
 #[derive(Clone)]
 pub struct Spotify {
     events: EventManager,

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -23,12 +23,12 @@ use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, SystemTime};
 
+use crate::application::ASYNC_RUNTIME;
 use crate::config;
 use crate::events::{Event, EventManager};
 use crate::model::playable::Playable;
 use crate::spotify_api::WebApi;
 use crate::spotify_worker::{Worker, WorkerCommand};
-use crate::ASYNC_RUNTIME;
 
 pub const VOLUME_PERCENT: u16 = ((u16::max_value() as f64) * 1.0 / 100.0) as u16;
 

--- a/src/spotify_api.rs
+++ b/src/spotify_api.rs
@@ -1,3 +1,4 @@
+use crate::application::ASYNC_RUNTIME;
 use crate::model::album::Album;
 use crate::model::artist::Artist;
 use crate::model::category::Category;
@@ -7,7 +8,6 @@ use crate::model::playlist::Playlist;
 use crate::model::track::Track;
 use crate::spotify_worker::WorkerCommand;
 use crate::ui::pagination::{ApiPage, ApiResult};
-use crate::ASYNC_RUNTIME;
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use futures::channel::oneshot;
 use log::{debug, error, info};

--- a/src/ui/cover.rs
+++ b/src/ui/cover.rs
@@ -12,12 +12,12 @@ use log::{debug, error};
 
 use crate::command::{Command, GotoMode};
 use crate::commands::CommandResult;
+use crate::config::Config;
 use crate::library::Library;
 use crate::queue::Queue;
 use crate::traits::{IntoBoxedViewExt, ListItem, ViewExt};
 use crate::ui::album::AlbumView;
 use crate::ui::artist::ArtistView;
-use crate::Config;
 
 pub struct CoverView {
     queue: Arc<Queue>,

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -340,7 +340,7 @@ impl View for Layout {
 
     fn on_event(&mut self, event: Event) -> EventResult {
         match event {
-            Event::Char(':') => {
+            Event::Char(':') | Event::Char('/') => {
                 let result = if let Some(view) = self.get_current_view_mut() {
                     view.on_event(event.relativized((0, 1)))
                 } else {
@@ -348,13 +348,16 @@ impl View for Layout {
                 };
 
                 if let EventResult::Ignored = result {
-                    let command_key = self.configuration.values().command_key.unwrap_or(':');
-                    self.enable_cmdline(command_key);
+                    if let Event::Char(':') = event {
+                        let command_key = self.configuration.values().command_key.unwrap_or(':');
+                        self.enable_cmdline(command_key);
+                    } else {
+                        self.enable_jump();
+                    }
                 } else {
                     return EventResult::Ignored;
                 }
             }
-            Event::Char('/') => self.enable_jump(),
             Event::Key(Key::Esc) if self.cmdline_focus => self.clear_cmdline(),
             _ if self.cmdline_focus => {
                 let result = self.cmdline.on_event(event);

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::rc::Rc;
 use std::time::{Duration, SystemTime};
 
 use cursive::align::HAlign;
@@ -30,11 +31,11 @@ pub struct Layout {
     screenchange: bool,
     last_size: Vec2,
     ev: events::EventManager,
-    theme: Theme,
+    theme: Rc<Theme>,
 }
 
 impl Layout {
-    pub fn new<T: IntoBoxedView>(status: T, ev: &events::EventManager, theme: Theme) -> Layout {
+    pub fn new<T: IntoBoxedView>(status: T, ev: &events::EventManager, theme: Rc<Theme>) -> Layout {
         let style = ColorStyle::new(
             ColorType::Color(*theme.palette.custom("cmdline_bg").unwrap()),
             ColorType::Color(*theme.palette.custom("cmdline").unwrap()),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,3 +1,6 @@
+use cursive::{Cursive, CursiveRunner};
+use ncspot::BIN_NAME;
+
 pub mod album;
 pub mod artist;
 pub mod browse;
@@ -19,3 +22,14 @@ pub mod tabview;
 
 #[cfg(feature = "cover")]
 pub mod cover;
+
+/// Create a CursiveRunner which implements the drawing logic and event loop.
+pub fn create_cursive() -> Result<CursiveRunner<Cursive>, Box<dyn std::error::Error>> {
+    let backend = cursive::backends::try_default()?;
+    let buffered_backend = Box::new(cursive_buffered_backend::BufferedBackend::new(backend));
+    let mut cursive_runner = CursiveRunner::new(cursive::Cursive::new(), buffered_backend);
+
+    cursive_runner.set_window_title(BIN_NAME);
+
+    Ok(cursive_runner)
+}


### PR DESCRIPTION
Quite some Rust TUI applications move their 'global' data into a struct called `App` or `Application`. Other types of Rust (or non-Rust) applications might do this as well, I just checked TUI Rust applications. This makes it very clear what data belongs to the 'global' scope or in other words, to the application itself. For ncspot, this would be things like the queue, the library, the web API, probably the parsed configuration, Cursive and probably some other things. It makes the `main.rs` file more readable and less scary looking for new contributors, and gives a nice overview of what ncspot consists out of from looking at the `Application` struct definition.

Programs I checked were:

- zellij client
- spotify-tui
- wiki-tui
- gitui
- ox
- helix
- some others (I forgot)

I forgot which ones used this pattern exactly, but most of them used it in one way or another.

This is just a suggestion, in an attempt to clean up the code around the entry point a bit. The bigger idea, which I don't know whether it is a good idea or not, is to make the ownership of items a bit more clear. Personally I find it hard to get a grasp of 'who owns what'. I wanted to attempt to make this a bit clearer, and this would be a first step. This PR won't be finished for a bit, but I wanted to make it already to hear whether this idea was maybe not a good direction to go, in which case I will close it :slightly_smiling_face: 