### PR TITLE
docs: remove Snapcraft installation source

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,8 @@ free accounts.
 - Automatic authentication using a password manager
 
 ## Installation
-ncspot is available on macOS (Homebrew), Windows (Scoop), Linux (native package, Snapcraft and
-Flathub) and the BSD's. Detailed installation instructions for each platform can be found
-[here](/doc/users.md).
+ncspot is available on macOS (Homebrew), Windows (Scoop), Linux (native package and Flathub) and the
+BSD's. Detailed installation instructions for each platform can be found [here](/doc/users.md).
 
 ## Configuration
 A configuration file can be provided at `$XDG_CONFIG_HOME/ncspot/config.toml`. Detailed

--- a/doc/users.md
+++ b/doc/users.md
@@ -20,7 +20,6 @@ scoop install ncspot
 ### On Linux
 <div>
 <a href="https://flathub.org/apps/details/io.github.hrkfdn.ncspot"><img width="130" alt="Download on Flathub" src="https://flathub.org/assets/badges/flathub-badge-en.png"/></a>
-<a href="https://snapcraft.io/ncspot"><img alt="Download on Snapcraft" src="https://snapcraft.io//ncspot/badge.svg"/></a>
 </div>
 
 Your distribution may have packaged `ncspot` in its package repository.


### PR DESCRIPTION
The Snapcraft package seems to have been removed. Therefore the links in the documentation should also be removed.