### PR TITLE
Add apple M1 build

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -43,10 +43,14 @@ jobs:
             os: macos-latest
             target: x86_64-apple-darwin
             features: '--no-default-features --features rodio_backend,pancurses_backend'
-          - build_target: macos-arm64
-            os: macos-latest
+          - build_target: linux-arm64
+            os: ubuntu-latest
+            container: rustembedded/cross:aarch64-unknown-linux-gnu-0.2.1
             target: aarch64-apple-darwin
             features: '--no-default-features --features alsa_backend,cursive/termion-backend'
+            dependencies: 'libasound2-dev:arm64 libssl-dev:arm64'
+            cross_arch: 'arm64'
+            pkg_config_path: '/usr/lib/aarch64-linux-gnu/pkgconfig/'
           - build_target: windows-x86_64
             os: windows-latest
             target: x86_64-pc-windows-msvc

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -47,8 +47,8 @@ jobs:
             os: macos-latest
             target: aarch64-apple-darwin
             features: '--no-default-features --features rodio_backend,pancurses_backend'
-            # cross_arch: 'arm64'
-            pkg_config_path: '/usr/lib/arm-linux-gnueabihf/pkgconfig/'
+            cross_arch: 'arm64'
+            pkg_config_path: '/usr/lib/aarch64-unknown-linux-gnu/pkgconfig/'
           - build_target: windows-x86_64
             os: windows-latest
             target: x86_64-pc-windows-msvc

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,7 +15,7 @@ jobs:
     container: ${{ matrix.container }}
     strategy:
       matrix:
-        build_target: [linux-x86_64, linux-arm64, linux-armhf, macos-x86_64, windows-x86_64]
+        build_target: [linux-x86_64, linux-arm64, linux-armhf, macos-x86_64, macos-arm64, windows-x86_64]
         include:
           - build_target: linux-x86_64
             os: ubuntu-latest
@@ -43,6 +43,12 @@ jobs:
             os: macos-latest
             target: x86_64-apple-darwin
             features: '--no-default-features --features rodio_backend,pancurses_backend'
+          - build_target: macos-arm64
+            os: macos-latest
+            target: aarch64-apple-darwin
+            features: '--no-default-features --features rodio_backend,pancurses_backend'
+            # cross_arch: 'arm64'
+            pkg_config_path: '/usr/lib/arm-linux-gnueabihf/pkgconfig/'
           - build_target: windows-x86_64
             os: windows-latest
             target: x86_64-pc-windows-msvc

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -44,13 +44,9 @@ jobs:
             target: x86_64-apple-darwin
             features: '--no-default-features --features rodio_backend,pancurses_backend'
           - build_target: macos-arm64
-            os: ubuntu-latest
-            container: rustembedded/cross:aarch64-unknown-linux-gnu-0.2.1
+            os: macos-latest
             target: aarch64-apple-darwin
             features: '--no-default-features --features alsa_backend,cursive/termion-backend'
-            dependencies: 'libasound2-dev:arm64 libssl-dev:arm64'
-            cross_arch: 'arm64'
-            pkg_config_path: '/usr/lib/aarch64-linux-gnu/pkgconfig/'
           - build_target: windows-x86_64
             os: windows-latest
             target: x86_64-pc-windows-msvc
@@ -66,6 +62,11 @@ jobs:
       - name: Install macOS dependencies
         if: matrix.os == 'macos-latest'
         run: brew install portaudio pkg-config
+      - name: Set up arm mac cross compilation
+        if: matrix.build_target == macos-arm64
+        run: |
+          echo "SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)" >> $GITHUB_ENV
+          echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version)" >> $GITHUB_ENV
       - name: Set up cross compilation
         if: matrix.cross_arch
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,9 +46,7 @@ jobs:
           - build_target: macos-arm64
             os: macos-latest
             target: aarch64-apple-darwin
-            features: '--no-default-features --features rodio_backend,pancurses_backend'
-            cross_arch: 'arm64'
-            pkg_config_path: '/usr/lib/aarch64-unknown-linux-gnu/pkgconfig/'
+            features: '--no-default-features --features alsa_backend,cursive/termion-backend'
           - build_target: windows-x86_64
             os: windows-latest
             target: x86_64-pc-windows-msvc

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -43,7 +43,7 @@ jobs:
             os: macos-latest
             target: x86_64-apple-darwin
             features: '--no-default-features --features rodio_backend,pancurses_backend'
-          - build_target: linux-arm64
+          - build_target: macos-arm64
             os: ubuntu-latest
             container: rustembedded/cross:aarch64-unknown-linux-gnu-0.2.1
             target: aarch64-apple-darwin


### PR DESCRIPTION
Will (hopefully) address #820

Attempting to add `aarch64-apple-darwin` cross-compilation  to the [CD](https://github.com/hrkfdn/ncspot/blob/main/.github/workflows/cd.yml) build.

Starting with a draft PR as I'm presently working through the following issue(s):

- [x] `ncurses` dependency failing to build (switched to termion back-end)
- [ ] Trying to figure out how to set up pkg-config

Note: I'm pretty new to Rust and cross-compilation -- taking this on as it's a good excuse to learn. Kinda fumbling around in the dark so I can't make any guarantees of a timely (or any) resolution.