### PR TITLE
Update documentation: recommend Ueberzug++

### DIFF
--- a/doc/users.md
+++ b/doc/users.md
@@ -33,7 +33,7 @@ here are the runtime dependencies:
 - `dbus`, `libncurses`, `libssl`
 - `libpulse` (or `portaudio`, if built using the PortAudio backend)
 - `libxcb` (if built with the `clipboard` feature)
-- `ueberzug` (if built with the `cover` feature)
+- `ueberzug` or a compatible implementation (e.g. `ueberzugpp`) (if built with the `cover` feature)
 
 ### On BSD's
 Your distribution may have packaged `ncspot` in its package repository.
@@ -427,8 +427,10 @@ body = "%artists"
 ### Cover Drawing
 When compiled with the `cover` feature, `ncspot` can draw the album art of the
 current track in a dedicated view (`:focus cover` or <kbd>F8</kbd> by default)
-using [Überzug](https://github.com/seebye/ueberzug). For more information on
-installation and terminal compatibility, consult that repository.
+using Überzug. The original project has been abandoned, therefore using a
+compatible implementation such as [Überzug++](https://github.com/jstkdng/ueberzugpp)
+is recommended. For more information on installation and terminal
+compatibility, consult that repository.
 
 To allow scaling up the album art beyond its native resolution (640x640 for
 Spotify covers), use the config key `cover_max_scale`. This is especially useful


### PR DESCRIPTION
The original project has seen very little activity since 2021 and was officially abandoned early this year. It would be a good idea to recommend an alternate implementation.

Also worth looking into is [libsixel](https://github.com/saitoha/libsixel), which is already supported by a good number of terminals ([source](https://www.arewesixelyet.com/)). But that can wait.