### PR TITLE
Fix: Gracefully handle local files

### DIFF
--- a/src/model/playable.rs
+++ b/src/model/playable.rs
@@ -139,15 +139,17 @@ impl From<&PlayableItem> for Playable {
     }
 }
 
-impl From<&Playable> for rspotify::prelude::PlayableId<'_> {
+impl From<&Playable> for Option<rspotify::prelude::PlayableId<'_>> {
     fn from(p: &Playable) -> Self {
         match p {
-            Playable::Track(t) => rspotify::prelude::PlayableId::Track(
-                rspotify::model::TrackId::from_id(t.id.clone().unwrap()).unwrap(),
-            ),
-            Playable::Episode(e) => rspotify::prelude::PlayableId::Episode(
-                rspotify::model::EpisodeId::from_id(e.id.clone()).unwrap(),
-            ),
+            Playable::Track(t) => {
+                t.id.clone()
+                    .and_then(|id| rspotify::model::TrackId::from_id(id).ok())
+                    .map(rspotify::prelude::PlayableId::Track)
+            }
+            Playable::Episode(e) => rspotify::model::EpisodeId::from_id(e.id.clone())
+                .map(rspotify::prelude::PlayableId::Episode)
+                .ok(),
         }
     }
 }

--- a/src/model/track.rs
+++ b/src/model/track.rs
@@ -16,7 +16,7 @@ use crate::queue::Queue;
 use crate::traits::{IntoBoxedViewExt, ListItem, ViewExt};
 use crate::ui::listview::ListView;
 
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Track {
     pub id: Option<String>,
     pub uri: String,
@@ -33,6 +33,7 @@ pub struct Track {
     pub url: String,
     pub added_at: Option<DateTime<Utc>>,
     pub list_index: usize,
+    pub is_local: bool,
 }
 
 impl Track {
@@ -69,6 +70,7 @@ impl Track {
             url: track.id.as_ref().map(|id| id.url()).unwrap_or_default(),
             added_at: None,
             list_index: 0,
+            is_local: track.is_local,
         }
     }
 
@@ -106,6 +108,7 @@ impl From<&SimplifiedTrack> for Track {
             url: track.id.as_ref().map(|id| id.url()).unwrap_or_default(),
             added_at: None,
             list_index: 0,
+            is_local: track.is_local,
         }
     }
 }
@@ -145,6 +148,7 @@ impl From<&FullTrack> for Track {
             url: track.id.as_ref().map(|id| id.url()).unwrap_or_default(),
             added_at: None,
             list_index: 0,
+            is_local: track.is_local,
         }
     }
 }
@@ -160,18 +164,6 @@ impl From<&SavedTrack> for Track {
 impl fmt::Display for Track {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{} - {}", self.artists.join(", "), self.title)
-    }
-}
-
-impl fmt::Debug for Track {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "({} - {} ({:?}))",
-            self.artists.join(", "),
-            self.title,
-            self.id
-        )
     }
 }
 

--- a/src/spotify_api.rs
+++ b/src/spotify_api.rs
@@ -155,7 +155,10 @@ impl WebApi {
         position: Option<i32>,
     ) -> bool {
         self.api_with_retry(|api| {
-            let trackids: Vec<PlayableId> = tracks.iter().map(|playable| playable.into()).collect();
+            let trackids: Vec<PlayableId> = tracks
+                .iter()
+                .filter_map(|playable| playable.into())
+                .collect();
             api.playlist_add_items(
                 PlaylistId::from_id(playlist_id).unwrap(),
                 trackids.iter().map(|id| id.as_ref()),
@@ -172,8 +175,10 @@ impl WebApi {
         playables: &[Playable],
     ) -> bool {
         self.api_with_retry(move |api| {
-            let playable_ids: Vec<PlayableId> =
-                playables.iter().map(|playable| playable.into()).collect();
+            let playable_ids: Vec<PlayableId> = playables
+                .iter()
+                .filter_map(|playable| playable.into())
+                .collect();
             let positions = playables
                 .iter()
                 .map(|playable| [playable.list_index() as u32])
@@ -207,8 +212,10 @@ impl WebApi {
         };
 
         if let Some(()) = self.api_with_retry(|api| {
-            let playable_ids: Vec<PlayableId> =
-                tracks.iter().map(|playable| playable.into()).collect();
+            let playable_ids: Vec<PlayableId> = tracks
+                .iter()
+                .filter_map(|playable| playable.into())
+                .collect();
             api.playlist_replace_items(
                 PlaylistId::from_id(id).unwrap(),
                 playable_ids.iter().map(|p| p.as_ref()),

--- a/src/ui/listview.rs
+++ b/src/ui/listview.rs
@@ -220,11 +220,17 @@ impl<I: ListItem + Clone> View for ListView<I> {
                 let item = &content[i];
                 let currently_playing =
                     item.is_playing(&self.queue) && self.queue.get_current_index() == Some(i);
+                let is_local = item.track().map(|t| t.is_local).unwrap_or_default();
 
                 let style = if self.selected == i {
                     if currently_playing {
                         ColorStyle::new(
                             *printer.theme.palette.custom("playing_selected").unwrap(),
+                            ColorType::Palette(PaletteColor::Highlight),
+                        )
+                    } else if is_local {
+                        ColorStyle::new(
+                            ColorType::Palette(PaletteColor::Secondary),
                             ColorType::Palette(PaletteColor::Highlight),
                         )
                     } else {
@@ -235,6 +241,8 @@ impl<I: ListItem + Clone> View for ListView<I> {
                         ColorType::Color(*printer.theme.palette.custom("playing").unwrap()),
                         ColorType::Color(*printer.theme.palette.custom("playing_bg").unwrap()),
                     )
+                } else if is_local {
+                    ColorStyle::secondary()
                 } else {
                     ColorStyle::primary()
                 };

--- a/src/ui/playlist.rs
+++ b/src/ui/playlist.rs
@@ -80,13 +80,16 @@ impl ViewExt for PlaylistView {
     fn on_command(&mut self, s: &mut Cursive, cmd: &Command) -> Result<CommandResult, String> {
         if let Command::Delete = cmd {
             let pos = self.list.get_selected_index();
-            if self
+
+            return if self
                 .playlist
                 .delete_track(pos, self.spotify.clone(), &self.library)
             {
                 self.list.remove(pos);
-            }
-            return Ok(CommandResult::Consumed(None));
+                Ok(CommandResult::Consumed(None))
+            } else {
+                Err("Could not delete track.".to_string())
+            };
         }
 
         if let Command::Sort(key, direction) = cmd {


### PR DESCRIPTION
As reported in #1231:

Local files in playlists have no IDs. When trying to delete them ncspot crashes as it tries to extract a track ID.