### PR TITLE
Fix next/prev shortcuts

### DIFF
--- a/doc/users.md
+++ b/doc/users.md
@@ -84,8 +84,8 @@ playback depending on your desktop environment settings. Have a look at the
 | <kbd>Shift</kbd>+<kbd>P</kbd> | Toggle playback (i.e. Play/Pause).                             |
 | <kbd>Shift</kbd>+<kbd>S</kbd> | Stop playback.                                                 |
 | <kbd>Shift</kbd>+<kbd>U</kbd> | Update the library cache (tracks, artists, albums, playlists). |
-| <kbd><</kbd>                  | Play the previous track.                                       |
-| <kbd>></kbd>                  | Play the next track.                                           |
+| <kbd>Shift</kbd>+<kbd><</kbd> | Play the previous track.                                       |
+| <kbd>Shift</kbd>+<kbd>></kbd> | Play the next track.                                           |
 | <kbd>F</kbd>                  | Seek forward by 1 second.                                      |
 | <kbd>Shift</kbd>+<kbd>F</kbd> | Seek forward by 10 seconds.                                    |
 | <kbd>B</kbd>                  | Seek backward by 1 second.                                     |


### PR DESCRIPTION
Using `>` or `<` doesn't see to have any effect. It works with `shift`.