### PR TITLE
docs: update users.md

### DIFF
--- a/doc/users.md
+++ b/doc/users.md
@@ -132,7 +132,7 @@ When pressing <kbd>O</kbd>:
 |------------------------------|--------------------------------------|
 | <kbd>C</kbd>                 | Clear the entire queue.              |
 | <kbd>D</kbd>                 | Delete the currently selected track. |
-| <kbd>Ctrl</kbd>+<kbd>S</kbd> | Save the current queue. |
+| <kbd>Ctrl</kbd>+<kbd>S</kbd> | Save the current queue.              |
 
 ### Library
 | Key          | Command                                 |

--- a/doc/users.md
+++ b/doc/users.md
@@ -132,7 +132,7 @@ When pressing <kbd>O</kbd>:
 |------------------------------|--------------------------------------|
 | <kbd>C</kbd>                 | Clear the entire queue.              |
 | <kbd>D</kbd>                 | Delete the currently selected track. |
-| <kbd>Ctrl</kbd>+<kbd>S</kbd> | Delete the currently selected track. |
+| <kbd>Ctrl</kbd>+<kbd>S</kbd> | Save the current queue. |
 
 ### Library
 | Key          | Command                                 |


### PR DESCRIPTION
This will fix the description of the default keybinding <kbd>Ctrl</kbd>+<kbd>s</kbd>

Links:
[1] https://github.com/hrkfdn/ncspot/blob/main/src/commands.rs#L430
[2] https://github.com/hrkfdn/ncspot/blob/main/src/ui/queue.rs#L166