### PR TITLE
style(clippy): enforce clippy `use_self` lint

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -39,7 +39,7 @@ pub enum MoveAmount {
 
 impl Default for MoveAmount {
     fn default() -> Self {
-        MoveAmount::Integer(1)
+        Self::Integer(1)
     }
 }
 
@@ -92,8 +92,8 @@ pub enum SeekDirection {
 impl fmt::Display for SeekDirection {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let repr = match self {
-            SeekDirection::Absolute(pos) => format!("{pos}"),
-            SeekDirection::Relative(delta) => {
+            Self::Absolute(pos) => format!("{pos}"),
+            Self::Relative(delta) => {
                 format!("{}{}", if delta > &0 { "+" } else { "" }, delta)
             }
         };
@@ -112,8 +112,8 @@ impl fmt::Display for InsertSource {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let repr = match self {
             #[cfg(feature = "share_clipboard")]
-            InsertSource::Clipboard => "".into(),
-            InsertSource::Input(url) => url.to_string(),
+            Self::Clipboard => "".into(),
+            Self::Input(url) => url.to_string(),
         };
         write!(f, "{repr}")
     }
@@ -169,23 +169,23 @@ impl fmt::Display for Command {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut repr_tokens = vec![self.basename().to_owned()];
         let mut extras_args = match self {
-            Command::Focus(tab) => vec![tab.to_owned()],
-            Command::Seek(direction) => vec![direction.to_string()],
-            Command::VolumeUp(amount) => vec![amount.to_string()],
-            Command::VolumeDown(amount) => vec![amount.to_string()],
-            Command::Repeat(mode) => match mode {
+            Self::Focus(tab) => vec![tab.to_owned()],
+            Self::Seek(direction) => vec![direction.to_string()],
+            Self::VolumeUp(amount) => vec![amount.to_string()],
+            Self::VolumeDown(amount) => vec![amount.to_string()],
+            Self::Repeat(mode) => match mode {
                 Some(mode) => vec![mode.to_string()],
                 None => vec![],
             },
-            Command::Shuffle(on) => match on {
+            Self::Shuffle(on) => match on {
                 Some(b) => vec![(if *b { "on" } else { "off" }).into()],
                 None => vec![],
             },
             #[cfg(feature = "share_clipboard")]
-            Command::Share(mode) => vec![mode.to_string()],
-            Command::Open(mode) => vec![mode.to_string()],
-            Command::Goto(mode) => vec![mode.to_string()],
-            Command::Move(mode, amount) => match (mode, amount) {
+            Self::Share(mode) => vec![mode.to_string()],
+            Self::Open(mode) => vec![mode.to_string()],
+            Self::Goto(mode) => vec![mode.to_string()],
+            Self::Move(mode, amount) => match (mode, amount) {
                 (MoveMode::Playing, _) => vec!["playing".to_string()],
                 (MoveMode::Up, MoveAmount::Extreme) => vec!["top".to_string()],
                 (MoveMode::Down, MoveAmount::Extreme) => vec!["bottom".to_string()],
@@ -194,40 +194,40 @@ impl fmt::Display for Command {
                 (mode, MoveAmount::Float(amount)) => vec![mode.to_string(), amount.to_string()],
                 (mode, MoveAmount::Integer(amount)) => vec![mode.to_string(), amount.to_string()],
             },
-            Command::Shift(mode, amount) => vec![mode.to_string(), amount.unwrap_or(1).to_string()],
-            Command::Search(term) => vec![term.to_owned()],
-            Command::Jump(mode) => match mode {
+            Self::Shift(mode, amount) => vec![mode.to_string(), amount.unwrap_or(1).to_string()],
+            Self::Search(term) => vec![term.to_owned()],
+            Self::Jump(mode) => match mode {
                 JumpMode::Previous | JumpMode::Next => vec![],
                 JumpMode::Query(term) => vec![term.to_owned()],
             },
-            Command::Insert(source) => vec![source.to_string()],
-            Command::NewPlaylist(name) => vec![name.to_owned()],
-            Command::Sort(key, direction) => vec![key.to_string(), direction.to_string()],
-            Command::ShowRecommendations(mode) => vec![mode.to_string()],
-            Command::Execute(cmd) => vec![cmd.to_owned()],
-            Command::Quit
-            | Command::TogglePlay
-            | Command::Stop
-            | Command::Previous
-            | Command::Next
-            | Command::Clear
-            | Command::Queue
-            | Command::PlayNext
-            | Command::Play
-            | Command::UpdateLibrary
-            | Command::Save
-            | Command::SaveCurrent
-            | Command::SaveQueue
-            | Command::Add
-            | Command::AddCurrent
-            | Command::Delete
-            | Command::Back
-            | Command::Help
-            | Command::ReloadConfig
-            | Command::Noop
-            | Command::Logout
-            | Command::Reconnect
-            | Command::Redraw => vec![],
+            Self::Insert(source) => vec![source.to_string()],
+            Self::NewPlaylist(name) => vec![name.to_owned()],
+            Self::Sort(key, direction) => vec![key.to_string(), direction.to_string()],
+            Self::ShowRecommendations(mode) => vec![mode.to_string()],
+            Self::Execute(cmd) => vec![cmd.to_owned()],
+            Self::Quit
+            | Self::TogglePlay
+            | Self::Stop
+            | Self::Previous
+            | Self::Next
+            | Self::Clear
+            | Self::Queue
+            | Self::PlayNext
+            | Self::Play
+            | Self::UpdateLibrary
+            | Self::Save
+            | Self::SaveCurrent
+            | Self::SaveQueue
+            | Self::Add
+            | Self::AddCurrent
+            | Self::Delete
+            | Self::Back
+            | Self::Help
+            | Self::ReloadConfig
+            | Self::Noop
+            | Self::Logout
+            | Self::Reconnect
+            | Self::Redraw => vec![],
         };
         repr_tokens.append(&mut extras_args);
         write!(f, "{}", repr_tokens.join(" "))
@@ -237,50 +237,50 @@ impl fmt::Display for Command {
 impl Command {
     pub fn basename(&self) -> &str {
         match self {
-            Command::Quit => "quit",
-            Command::TogglePlay => "playpause",
-            Command::Stop => "stop",
-            Command::Previous => "previous",
-            Command::Next => "next",
-            Command::Clear => "clear",
-            Command::Queue => "queue",
-            Command::PlayNext => "playnext",
-            Command::Play => "play",
-            Command::UpdateLibrary => "update",
-            Command::Save => "save",
-            Command::SaveCurrent => "save current",
-            Command::SaveQueue => "save queue",
-            Command::Add => "add",
-            Command::AddCurrent => "add current",
-            Command::Delete => "delete",
-            Command::Focus(_) => "focus",
-            Command::Seek(_) => "seek",
-            Command::VolumeUp(_) => "volup",
-            Command::VolumeDown(_) => "voldown",
-            Command::Repeat(_) => "repeat",
-            Command::Shuffle(_) => "shuffle",
+            Self::Quit => "quit",
+            Self::TogglePlay => "playpause",
+            Self::Stop => "stop",
+            Self::Previous => "previous",
+            Self::Next => "next",
+            Self::Clear => "clear",
+            Self::Queue => "queue",
+            Self::PlayNext => "playnext",
+            Self::Play => "play",
+            Self::UpdateLibrary => "update",
+            Self::Save => "save",
+            Self::SaveCurrent => "save current",
+            Self::SaveQueue => "save queue",
+            Self::Add => "add",
+            Self::AddCurrent => "add current",
+            Self::Delete => "delete",
+            Self::Focus(_) => "focus",
+            Self::Seek(_) => "seek",
+            Self::VolumeUp(_) => "volup",
+            Self::VolumeDown(_) => "voldown",
+            Self::Repeat(_) => "repeat",
+            Self::Shuffle(_) => "shuffle",
             #[cfg(feature = "share_clipboard")]
-            Command::Share(_) => "share",
-            Command::Back => "back",
-            Command::Open(_) => "open",
-            Command::Goto(_) => "goto",
-            Command::Move(_, _) => "move",
-            Command::Shift(_, _) => "shift",
-            Command::Search(_) => "search",
-            Command::Jump(JumpMode::Previous) => "jumpprevious",
-            Command::Jump(JumpMode::Next) => "jumpnext",
-            Command::Jump(JumpMode::Query(_)) => "jump",
-            Command::Help => "help",
-            Command::ReloadConfig => "reload",
-            Command::Noop => "noop",
-            Command::Insert(_) => "insert",
-            Command::NewPlaylist(_) => "newplaylist",
-            Command::Sort(_, _) => "sort",
-            Command::Logout => "logout",
-            Command::ShowRecommendations(_) => "similar",
-            Command::Redraw => "redraw",
-            Command::Execute(_) => "exec",
-            Command::Reconnect => "reconnect",
+            Self::Share(_) => "share",
+            Self::Back => "back",
+            Self::Open(_) => "open",
+            Self::Goto(_) => "goto",
+            Self::Move(_, _) => "move",
+            Self::Shift(_, _) => "shift",
+            Self::Search(_) => "search",
+            Self::Jump(JumpMode::Previous) => "jumpprevious",
+            Self::Jump(JumpMode::Next) => "jumpnext",
+            Self::Jump(JumpMode::Query(_)) => "jump",
+            Self::Help => "help",
+            Self::ReloadConfig => "reload",
+            Self::Noop => "noop",
+            Self::Insert(_) => "insert",
+            Self::NewPlaylist(_) => "newplaylist",
+            Self::Sort(_, _) => "sort",
+            Self::Logout => "logout",
+            Self::ShowRecommendations(_) => "similar",
+            Self::Redraw => "redraw",
+            Self::Execute(_) => "exec",
+            Self::Reconnect => "reconnect",
         }
     }
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -51,9 +51,9 @@ impl CommandManager {
         library: Arc<Library>,
         config: Arc<Config>,
         events: EventManager,
-    ) -> CommandManager {
+    ) -> Self {
         let bindings = RefCell::new(Self::get_bindings(&config));
-        CommandManager {
+        Self {
             aliases: HashMap::new(),
             bindings,
             spotify,

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,7 +47,7 @@ pub struct TrackFormat {
 
 impl TrackFormat {
     pub fn default() -> Self {
-        TrackFormat {
+        Self {
             left: Some(String::from("%artists - %title")),
             center: Some(String::from("%album")),
             right: Some(String::from("%saved %duration")),
@@ -64,7 +64,7 @@ pub struct NotificationFormat {
 
 impl NotificationFormat {
     pub fn default() -> Self {
-        NotificationFormat {
+        Self {
             title: Some(String::from("%title")),
             body: Some(String::from("%artists")),
         }
@@ -163,7 +163,7 @@ pub struct UserState {
 
 impl Default for UserState {
     fn default() -> Self {
-        UserState {
+        Self {
             volume: u16::MAX,
             shuffle: false,
             repeat: queue::RepeatSetting::None,

--- a/src/events.rs
+++ b/src/events.rs
@@ -21,10 +21,10 @@ pub struct EventManager {
 }
 
 impl EventManager {
-    pub fn new(cursive_sink: CbSink) -> EventManager {
+    pub fn new(cursive_sink: CbSink) -> Self {
         let (tx, rx) = unbounded();
 
-        EventManager {
+        Self {
             tx,
             rx,
             cursive_sink,

--- a/src/ext_traits.rs
+++ b/src/ext_traits.rs
@@ -14,7 +14,7 @@ pub trait CursiveExt {
 impl CursiveExt for cursive::Cursive {
     fn on_layout<F, R>(&mut self, cb: F) -> R
     where
-        F: FnOnce(&mut cursive::Cursive, ViewRef<Layout>) -> R,
+        F: FnOnce(&mut Self, ViewRef<Layout>) -> R,
     {
         let layout = self
             .find_name::<Layout>("main")

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -32,7 +32,7 @@ impl Drop for IpcSocket {
 }
 
 impl IpcSocket {
-    pub fn new(handle: &Handle, path: PathBuf, ev: EventManager) -> io::Result<IpcSocket> {
+    pub fn new(handle: &Handle, path: PathBuf, ev: EventManager) -> io::Result<Self> {
         let path = if path.exists() && Self::is_open_socket(&path) {
             let mut new_path = path;
             new_path.set_file_name(format!("ncspot.{}.sock", std::process::id()));
@@ -59,7 +59,7 @@ impl IpcSocket {
             Self::worker(listener, ev, rx.clone()).await;
         });
 
-        Ok(IpcSocket { tx, path })
+        Ok(Self { tx, path })
     }
 
     fn is_open_socket(path: &PathBuf) -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::use_self)]
+
 #[macro_use]
 extern crate cursive;
 #[macro_use]

--- a/src/model/category.rs
+++ b/src/model/category.rs
@@ -15,7 +15,7 @@ pub struct Category {
 
 impl From<&rspotify::model::Category> for Category {
     fn from(c: &rspotify::model::Category) -> Self {
-        Category {
+        Self {
             id: c.id.clone(),
             name: c.name.clone(),
         }

--- a/src/model/playable.rs
+++ b/src/model/playable.rs
@@ -20,7 +20,7 @@ pub enum Playable {
 }
 
 impl Playable {
-    pub fn format(playable: &Playable, formatting: &str, library: &Library) -> String {
+    pub fn format(playable: &Self, formatting: &str, library: &Library) -> String {
         formatting
             .replace(
                 "%artists",
@@ -38,15 +38,15 @@ impl Playable {
             .replace(
                 "%title",
                 match playable.clone() {
-                    Playable::Episode(episode) => episode.name,
-                    Playable::Track(track) => track.title,
+                    Self::Episode(episode) => episode.name,
+                    Self::Track(track) => track.title,
                 }
                 .as_str(),
             )
             .replace(
                 "%album",
                 match playable.clone() {
-                    Playable::Track(track) => track.album.unwrap_or_default(),
+                    Self::Track(track) => track.album.unwrap_or_default(),
                     _ => String::new(),
                 }
                 .as_str(),
@@ -54,8 +54,8 @@ impl Playable {
             .replace(
                 "%saved",
                 if library.is_saved_track(&match playable.clone() {
-                    Playable::Episode(episode) => Playable::Episode(episode),
-                    Playable::Track(track) => Playable::Track(track),
+                    Self::Episode(episode) => Self::Episode(episode),
+                    Self::Track(track) => Self::Track(track),
                 }) {
                     if library.cfg.values().use_nerdfont.unwrap_or_default() {
                         "\u{f012c}"
@@ -71,50 +71,50 @@ impl Playable {
 
     pub fn id(&self) -> Option<String> {
         match self {
-            Playable::Track(track) => track.id.clone(),
-            Playable::Episode(episode) => Some(episode.id.clone()),
+            Self::Track(track) => track.id.clone(),
+            Self::Episode(episode) => Some(episode.id.clone()),
         }
     }
 
     pub fn uri(&self) -> String {
         match self {
-            Playable::Track(track) => track.uri.clone(),
-            Playable::Episode(episode) => episode.uri.clone(),
+            Self::Track(track) => track.uri.clone(),
+            Self::Episode(episode) => episode.uri.clone(),
         }
     }
 
     pub fn cover_url(&self) -> Option<String> {
         match self {
-            Playable::Track(track) => track.cover_url.clone(),
-            Playable::Episode(episode) => episode.cover_url.clone(),
+            Self::Track(track) => track.cover_url.clone(),
+            Self::Episode(episode) => episode.cover_url.clone(),
         }
     }
 
     pub fn duration(&self) -> u32 {
         match self {
-            Playable::Track(track) => track.duration,
-            Playable::Episode(episode) => episode.duration,
+            Self::Track(track) => track.duration,
+            Self::Episode(episode) => episode.duration,
         }
     }
 
     pub fn list_index(&self) -> usize {
         match self {
-            Playable::Track(track) => track.list_index,
-            Playable::Episode(episode) => episode.list_index,
+            Self::Track(track) => track.list_index,
+            Self::Episode(episode) => episode.list_index,
         }
     }
 
     pub fn set_list_index(&mut self, index: usize) {
         match self {
-            Playable::Track(track) => track.list_index = index,
-            Playable::Episode(episode) => episode.list_index = index,
+            Self::Track(track) => track.list_index = index,
+            Self::Episode(episode) => episode.list_index = index,
         }
     }
 
     pub fn set_added_at(&mut self, added_at: Option<DateTime<Utc>>) {
         match self {
-            Playable::Track(track) => track.added_at = added_at,
-            Playable::Episode(episode) => episode.added_at = added_at,
+            Self::Track(track) => track.added_at = added_at,
+            Self::Episode(episode) => episode.added_at = added_at,
         }
     }
 
@@ -124,8 +124,8 @@ impl Playable {
 
     pub fn as_listitem(&self) -> Box<dyn ListItem> {
         match self {
-            Playable::Track(track) => track.as_listitem(),
-            Playable::Episode(episode) => episode.as_listitem(),
+            Self::Track(track) => track.as_listitem(),
+            Self::Episode(episode) => episode.as_listitem(),
         }
     }
 }
@@ -133,8 +133,8 @@ impl Playable {
 impl From<&PlayableItem> for Playable {
     fn from(item: &PlayableItem) -> Self {
         match item {
-            PlayableItem::Episode(episode) => Playable::Episode(episode.into()),
-            PlayableItem::Track(track) => Playable::Track(track.into()),
+            PlayableItem::Episode(episode) => Self::Episode(episode.into()),
+            PlayableItem::Track(track) => Self::Track(track.into()),
         }
     }
 }
@@ -157,8 +157,8 @@ impl From<&Playable> for Option<rspotify::prelude::PlayableId<'_>> {
 impl fmt::Display for Playable {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Playable::Track(track) => track.fmt(f),
-            Playable::Episode(episode) => episode.fmt(f),
+            Self::Track(track) => track.fmt(f),
+            Self::Episode(episode) => episode.fmt(f),
         }
     }
 }

--- a/src/model/playlist.rs
+++ b/src/model/playlist.rs
@@ -147,7 +147,7 @@ impl Playlist {
 
 impl From<&SimplifiedPlaylist> for Playlist {
     fn from(list: &SimplifiedPlaylist) -> Self {
-        Playlist {
+        Self {
             id: list.id.id().to_string(),
             name: list.name.clone(),
             owner_id: list.owner.id.id().to_string(),
@@ -162,7 +162,7 @@ impl From<&SimplifiedPlaylist> for Playlist {
 
 impl From<&FullPlaylist> for Playlist {
     fn from(list: &FullPlaylist) -> Self {
-        Playlist {
+        Self {
             id: list.id.id().to_string(),
             name: list.name.clone(),
             owner_id: list.owner.id.id().to_string(),

--- a/src/model/track.rs
+++ b/src/model/track.rs
@@ -37,7 +37,7 @@ pub struct Track {
 }
 
 impl Track {
-    pub fn from_simplified_track(track: &SimplifiedTrack, album: &FullAlbum) -> Track {
+    pub fn from_simplified_track(track: &SimplifiedTrack, album: &FullAlbum) -> Self {
         let artists = track
             .artists
             .iter()
@@ -270,12 +270,12 @@ impl ListItem for Track {
     ) -> Option<Box<dyn ViewExt>> {
         let spotify = queue.get_spotify();
 
-        let recommendations: Option<Vec<Track>> = if let Some(id) = &self.id {
+        let recommendations: Option<Vec<Self>> = if let Some(id) = &self.id {
             spotify
                 .api
                 .recommendations(None, None, Some(vec![id]))
                 .map(|r| r.tracks)
-                .map(|tracks| tracks.iter().map(Track::from).collect())
+                .map(|tracks| tracks.iter().map(Self::from).collect())
         } else {
             None
         };

--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -491,7 +491,7 @@ impl MprisManager {
             }
         });
 
-        MprisManager { tx }
+        Self { tx }
     }
 
     async fn serve(

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -49,10 +49,10 @@ pub struct Queue {
 }
 
 impl Queue {
-    pub fn new(spotify: Spotify, cfg: Arc<Config>, library: Arc<Library>) -> Queue {
+    pub fn new(spotify: Spotify, cfg: Arc<Config>, library: Arc<Library>) -> Self {
         let queue_state = cfg.state().queuestate.clone();
         let playback_state = cfg.state().playback_state.clone();
-        let queue = Queue {
+        let queue = Self {
             queue: Arc::new(RwLock::new(queue_state.queue)),
             spotify: spotify.clone(),
             current_track: RwLock::new(queue_state.current_track),

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -56,12 +56,8 @@ pub struct Spotify {
 }
 
 impl Spotify {
-    pub fn new(
-        events: EventManager,
-        credentials: Credentials,
-        cfg: Arc<config::Config>,
-    ) -> Spotify {
-        let mut spotify = Spotify {
+    pub fn new(events: EventManager, credentials: Credentials, cfg: Arc<config::Config>) -> Self {
+        let mut spotify = Self {
             events,
             credentials,
             cfg: cfg.clone(),
@@ -402,19 +398,19 @@ pub enum UriType {
 }
 
 impl UriType {
-    pub fn from_uri(s: &str) -> Option<UriType> {
+    pub fn from_uri(s: &str) -> Option<Self> {
         if s.starts_with("spotify:album:") {
-            Some(UriType::Album)
+            Some(Self::Album)
         } else if s.starts_with("spotify:artist:") {
-            Some(UriType::Artist)
+            Some(Self::Artist)
         } else if s.starts_with("spotify:track:") {
-            Some(UriType::Track)
+            Some(Self::Track)
         } else if s.starts_with("spotify:") && s.contains(":playlist:") {
-            Some(UriType::Playlist)
+            Some(Self::Playlist)
         } else if s.starts_with("spotify:show:") {
-            Some(UriType::Show)
+            Some(Self::Show)
         } else if s.starts_with("spotify:episode:") {
-            Some(UriType::Episode)
+            Some(Self::Episode)
         } else {
             None
         }

--- a/src/spotify_api.rs
+++ b/src/spotify_api.rs
@@ -56,7 +56,7 @@ impl Default for WebApi {
 }
 
 impl WebApi {
-    pub fn new() -> WebApi {
+    pub fn new() -> Self {
         Self::default()
     }
 

--- a/src/spotify_url.rs
+++ b/src/spotify_url.rs
@@ -25,8 +25,8 @@ impl fmt::Display for SpotifyUrl {
 }
 
 impl SpotifyUrl {
-    pub fn new(id: &str, uri_type: UriType) -> SpotifyUrl {
-        SpotifyUrl {
+    pub fn new(id: &str, uri_type: UriType) -> Self {
+        Self {
             id: id.to_string(),
             uri_type,
         }
@@ -39,7 +39,7 @@ impl SpotifyUrl {
     /// assert_eq!(result.id, "4uLU6hMCjMI75M1A2tKUQC");
     /// assert_eq!(result.uri_type, URIType::Track);
     /// ```
-    pub fn from_url<S: AsRef<str>>(s: S) -> Option<SpotifyUrl> {
+    pub fn from_url<S: AsRef<str>>(s: S) -> Option<Self> {
         let url = Url::parse(s.as_ref()).ok()?;
         if url.host() != Some(Host::Domain("open.spotify.com")) {
             return None;
@@ -71,7 +71,7 @@ impl SpotifyUrl {
 
         let id = path_segments.next()?;
 
-        Some(SpotifyUrl::new(id, uri_type))
+        Some(Self::new(id, uri_type))
     }
 }
 

--- a/src/spotify_worker.rs
+++ b/src/spotify_worker.rs
@@ -50,8 +50,8 @@ impl Worker {
         session: Session,
         player: Player,
         mixer: Box<dyn Mixer>,
-    ) -> Worker {
-        Worker {
+    ) -> Self {
+        Self {
             events,
             player_events: UnboundedReceiverStream::new(player_events),
             commands: UnboundedReceiverStream::new(commands),

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -17,7 +17,7 @@ pub struct HelpView {
 }
 
 impl HelpView {
-    pub fn new(bindings: HashMap<String, Vec<Command>>) -> HelpView {
+    pub fn new(bindings: HashMap<String, Vec<Command>>) -> Self {
         let mut text = StyledString::styled("Keybindings\n\n", Effect::Bold);
 
         let note = format!(
@@ -43,7 +43,7 @@ impl HelpView {
             text.append(binding);
         }
 
-        HelpView {
+        Self {
             view: ScrollView::new(TextView::new(text)),
         }
     }

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -42,7 +42,7 @@ impl Layout {
         ev: &events::EventManager,
         theme: Theme,
         configuration: Arc<Config>,
-    ) -> Layout {
+    ) -> Self {
         let style = ColorStyle::new(
             ColorType::Color(*theme.palette.custom("cmdline_bg").unwrap()),
             ColorType::Color(*theme.palette.custom("cmdline").unwrap()),
@@ -89,7 +89,7 @@ impl Layout {
             event_manager.trigger();
         });
 
-        Layout {
+        Self {
             screens: HashMap::new(),
             stack: HashMap::new(),
             statusbar: status.into_boxed_view(),

--- a/src/ui/modal.rs
+++ b/src/ui/modal.rs
@@ -8,13 +8,13 @@ pub struct Modal<T: View> {
 
 impl<T: View> Modal<T> {
     pub fn new(inner: T) -> Self {
-        Modal {
+        Self {
             block_events: true,
             inner,
         }
     }
     pub fn new_ext(inner: T) -> Self {
-        Modal {
+        Self {
             block_events: false,
             inner,
         }

--- a/src/ui/pagination.rs
+++ b/src/ui/pagination.rs
@@ -18,7 +18,7 @@ pub struct ApiResult<I> {
 }
 
 impl<I: ListItem + Clone> ApiResult<I> {
-    pub fn new(limit: u32, fetch_page: Arc<FetchPageFn<I>>) -> ApiResult<I> {
+    pub fn new(limit: u32, fetch_page: Arc<FetchPageFn<I>>) -> Self {
         let items = Arc::new(RwLock::new(Vec::new()));
         if let Some(first_page) = fetch_page(0) {
             debug!(
@@ -27,7 +27,7 @@ impl<I: ListItem + Clone> ApiResult<I> {
                 first_page.total
             );
             items.write().unwrap().extend(first_page.items);
-            ApiResult {
+            Self {
                 offset: Arc::new(RwLock::new(first_page.offset)),
                 limit,
                 total: first_page.total,
@@ -35,7 +35,7 @@ impl<I: ListItem + Clone> ApiResult<I> {
                 fetch_page: fetch_page.clone(),
             }
         } else {
-            ApiResult {
+            Self {
                 offset: Arc::new(RwLock::new(0)),
                 limit,
                 total: 0,
@@ -102,7 +102,7 @@ pub struct Pagination<I: ListItem> {
 
 impl<I: ListItem> Default for Pagination<I> {
     fn default() -> Self {
-        Pagination {
+        Self {
             loaded_content: Arc::new(RwLock::new(0)),
             max_content: Arc::new(RwLock::new(None)),
             callback: Arc::new(RwLock::new(None)),

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -22,10 +22,10 @@ pub struct QueueView {
 }
 
 impl QueueView {
-    pub fn new(queue: Arc<Queue>, library: Arc<Library>) -> QueueView {
+    pub fn new(queue: Arc<Queue>, library: Arc<Library>) -> Self {
         let list = ListView::new(queue.queue.clone(), queue.clone(), library.clone());
 
-        QueueView {
+        Self {
             list,
             library,
             queue,

--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -37,7 +37,7 @@ pub struct SearchView {
 pub const EDIT_ID: &str = "search_edit";
 
 impl SearchView {
-    pub fn new(events: EventManager, queue: Arc<Queue>, library: Arc<Library>) -> SearchView {
+    pub fn new(events: EventManager, queue: Arc<Queue>, library: Arc<Library>) -> Self {
         let searchfield = EditView::new()
             .on_submit(move |s, input| {
                 if !input.is_empty() {
@@ -52,7 +52,7 @@ impl SearchView {
             })
             .with_name(EDIT_ID);
 
-        SearchView {
+        Self {
             edit: searchfield,
             edit_focused: true,
         }

--- a/src/ui/search_results.rs
+++ b/src/ui/search_results.rs
@@ -49,7 +49,7 @@ impl SearchResultsView {
         events: EventManager,
         queue: Arc<Queue>,
         library: Arc<Library>,
-    ) -> SearchResultsView {
+    ) -> Self {
         let results_tracks = Arc::new(RwLock::new(Vec::new()));
         let results_albums = Arc::new(RwLock::new(Vec::new()));
         let results_artists = Arc::new(RwLock::new(Vec::new()));
@@ -79,7 +79,7 @@ impl SearchResultsView {
             .tab("shows", list_shows.with_title("Podcasts"))
             .tab("episodes", list_episodes.with_title("Podcast Episodes"));
 
-        let mut view = SearchResultsView {
+        let mut view = Self {
             search_term,
             results_tracks,
             pagination_tracks,

--- a/src/ui/statusbar.rs
+++ b/src/ui/statusbar.rs
@@ -22,10 +22,10 @@ pub struct StatusBar {
 }
 
 impl StatusBar {
-    pub fn new(queue: Arc<Queue>, library: Arc<Library>) -> StatusBar {
+    pub fn new(queue: Arc<Queue>, library: Arc<Library>) -> Self {
         let spotify = queue.get_spotify();
 
-        StatusBar {
+        Self {
             queue,
             spotify,
             library,


### PR DESCRIPTION
Clippy's `use_self` line ensures that `Self` is used instead of the real name whenever possible. This makes searching easier and cleans up the code a bit.

closes #1175 