### PR TITLE
fix: MPRIS loop `tokio::select!()` panic on exit

### DIFF
--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -513,13 +513,10 @@ impl MprisManager {
         let player_iface = player_iface_ref.get().await;
 
         loop {
-            tokio::select! {
-                Some(()) = rx.next() => {
-                    let ctx = player_iface_ref.signal_context();
-                    player_iface.playback_status_changed(ctx).await?;
-                    player_iface.metadata_changed(ctx).await?;
-                }
-            }
+            rx.next().await;
+            let ctx = player_iface_ref.signal_context();
+            player_iface.playback_status_changed(ctx).await?;
+            player_iface.metadata_changed(ctx).await?;
         }
     }
 


### PR DESCRIPTION
This fixes a bug that would cause a panic when quiting the process normally. `tokio::select!()` was used to await a single branch, which is useless as it can be replaced by a normal await.

closes #1298