### PR TITLE
refactor: remove `lazy_static` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1968,7 +1968,6 @@ dependencies = [
  "fern",
  "futures",
  "ioctl-rs",
- "lazy_static",
  "libc",
  "librespot-core",
  "librespot-playback",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ zbus = {version = "3.11.1", default-features = false, features = ["tokio"], opti
 fern = "0.6"
 futures = "0.3"
 ioctl-rs = {version = "0.2", optional = true}
-lazy_static = "1.3.0"
 libc = "0.2.142"
 librespot-core = "0.4.2"
 librespot-playback = "0.4.2"

--- a/src/command.rs
+++ b/src/command.rs
@@ -2,6 +2,7 @@ use crate::queue::RepeatSetting;
 use crate::spotify_url::SpotifyUrl;
 use std::collections::HashMap;
 use std::fmt;
+use std::sync::OnceLock;
 
 use strum_macros::Display;
 
@@ -291,8 +292,12 @@ fn register_aliases(map: &mut HashMap<&str, &str>, cmd: &'static str, names: Vec
     }
 }
 
-lazy_static! {
-    static ref ALIASES: HashMap<&'static str, &'static str> = {
+fn handle_aliases(input: &str) -> &str {
+    // NOTE: There is probably a better way to write this than a static HashMap. The HashMap doesn't
+    // improve performance as there's far too few keys, and the use of static doesn't seem good.
+    static ALIASES: OnceLock<HashMap<&'static str, &'static str>> = OnceLock::new();
+
+    let aliases = ALIASES.get_or_init(|| {
         let mut m = HashMap::new();
 
         register_aliases(&mut m, "quit", vec!["q", "x"]);
@@ -303,15 +308,14 @@ lazy_static! {
         );
         register_aliases(&mut m, "repeat", vec!["loop"]);
 
+        // TODO: FooBarBaz XD
         m.insert("1", "foo");
         m.insert("2", "bar");
         m.insert("3", "baz");
         m
-    };
-}
+    });
 
-fn handle_aliases(input: &str) -> &str {
-    if let Some(cmd) = ALIASES.get(input) {
+    if let Some(cmd) = aliases.get(input) {
         handle_aliases(cmd)
     } else {
         input

--- a/src/config.rs
+++ b/src/config.rs
@@ -175,10 +175,8 @@ impl Default for UserState {
     }
 }
 
-lazy_static! {
-    /// Configuration files are read/written relative to this directory.
-    pub static ref BASE_PATH: RwLock<Option<PathBuf>> = RwLock::new(None);
-}
+/// Configuration files are read/written relative to this directory.
+static BASE_PATH: RwLock<Option<PathBuf>> = RwLock::new(None);
 
 /// The complete configuration (state + user configuration) of ncspot.
 pub struct Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,6 @@
 #[macro_use]
 extern crate cursive;
 #[macro_use]
-extern crate lazy_static;
-#[macro_use]
 extern crate serde;
 
 use std::path::PathBuf;

--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -484,7 +484,7 @@ impl MprisManager {
 
         let (tx, rx) = mpsc::unbounded_channel::<()>();
 
-        ASYNC_RUNTIME.spawn(async {
+        ASYNC_RUNTIME.get().unwrap().spawn(async {
             let result = Self::serve(UnboundedReceiverStream::new(rx), root, player).await;
             if let Err(e) = result {
                 log::error!("MPRIS error: {e}");

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -71,7 +71,7 @@ impl Spotify {
 
         let (user_tx, user_rx) = oneshot::channel();
         spotify.start_worker(Some(user_tx));
-        spotify.user = ASYNC_RUNTIME.block_on(user_rx).ok();
+        spotify.user = ASYNC_RUNTIME.get().unwrap().block_on(user_rx).ok();
         let volume = cfg.state().volume;
         spotify.set_volume(volume);
 
@@ -95,7 +95,7 @@ impl Spotify {
             let events = self.events.clone();
             let volume = self.volume();
             let credentials = self.credentials.clone();
-            ASYNC_RUNTIME.spawn(Self::worker(
+            ASYNC_RUNTIME.get().unwrap().spawn(Self::worker(
                 worker_channel,
                 events,
                 rx,
@@ -122,6 +122,8 @@ impl Spotify {
     pub fn test_credentials(credentials: Credentials) -> Result<Session, SessionError> {
         let config = Self::session_config();
         ASYNC_RUNTIME
+            .get()
+            .unwrap()
             .block_on(Session::connect(config, credentials, None, true))
             .map(|r| r.0)
     }

--- a/src/spotify_api.rs
+++ b/src/spotify_api.rs
@@ -94,7 +94,7 @@ impl WebApi {
             .as_ref()
         {
             channel.send(cmd).expect("can't send message to worker");
-            let token_option = ASYNC_RUNTIME.block_on(token_rx).unwrap();
+            let token_option = ASYNC_RUNTIME.get().unwrap().block_on(token_rx).unwrap();
             if let Some(token) = token_option {
                 *self.api.token.lock().expect("can't writelock api token") = Some(Token {
                     access_token: token.access_token,


### PR DESCRIPTION
The `lazy_static` crate was superseded by the `once_cell` crate which has been included in Rust's standard library since version `1.70`. Remove the `lazy_static` dependency and refactor all use cases to use `std::sync::OnceLock` instead.