### PR TITLE
chore: remove placeholder code

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -303,9 +303,6 @@ lazy_static! {
         );
         register_aliases(&mut m, "repeat", vec!["loop"]);
 
-        m.insert("1", "foo");
-        m.insert("2", "bar");
-        m.insert("3", "baz");
         m
     };
 }


### PR DESCRIPTION
Remove the placeholder entries from the command aliases.