### PR TITLE
Handle `SIGHUP` signals

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -61,7 +61,7 @@ async fn handle_signals(cursive_callback_sink: CbSink) {
     while let Some(signal) = signals.next().await {
         info!("Caught {}, cleaning up and closing", signal);
         match signal {
-            SIGTERM => {
+            SIGTERM | SIGHUP => {
                 cursive_callback_sink
                     .send(Box::new(|cursive| {
                         if let Some(data) = cursive.user_data::<UserData>().cloned() {


### PR DESCRIPTION
While this probably reintroduces the crashes it should handle `SIGHUP` again which currently leads into the `unreachable!()` branch.

Fixes #1309