### PR TITLE
chore: keep track of used toolchain version

### DIFF
--- a/.github/workflows/update-rust-toolchain.yml
+++ b/.github/workflows/update-rust-toolchain.yml
@@ -1,0 +1,21 @@
+name: update-rust-toolchain
+on:
+  workflow_dispatch: # allows manual triggering
+  schedule:
+    - cron: '0 9 * * wed' # runs at 9 am on every wednesday
+
+jobs:
+  update-rust-toolchain:
+    name: "Update Rust Toolchain (rust-toolchain.toml)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: update rust toolchain
+        uses: a-kenji/update-rust-toolchain@v1.1
+        with:
+          token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
+          toolchain-path: ./rust-toolchain.toml
+          commit-msg: 'chore(toolchain): update'
+          pr-branch: main
+          pr-title: 'chore(toolchain): update'

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.73.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Keeping the used toolchain version in version control makes sure that when building older versions, the same toolchain is used every time. For example, when `ncspot 0.12.0` has always been compiled with Rust version `1.67.0` but the currently installed version is `1.73.0`, this file would cause Rustup to download the older version again.