### PR TITLE
fix: add leading slash to gitignore paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,8 @@ tags
 
 # Ignore generated resources
 *.1
-misc/_ncspot
-misc/ncspot.bash
-misc/ncspot.fish
-misc/ncspot.elv
-misc/_ncspot.ps1
+/misc/_ncspot
+/misc/ncspot.bash
+/misc/ncspot.fish
+/misc/ncspot.elv
+/misc/_ncspot.ps1


### PR DESCRIPTION
The leading slash forces Git to only look for the mentioned files from the root of the directory, not inside allowed subdirectories.