### PR TITLE
fix: allow any value to set MPRIS volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multiple instances interfering with each other's MPRIS implementation
 - An unlikely crash when the UNIX IPC socket is removed before `ncspot` is closed
 - Guaranteed crash while quiting `ncspot` when using MPRIS
+- MPRIS volume not being updated when given numbers smaller than 0 or larger than 1
 
 ## [0.13.4] - 2023-07-24
 

--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -269,13 +269,12 @@ impl MprisPlayer {
     }
 
     #[dbus_interface(property)]
-    fn set_volume(&self, volume: f64) {
+    fn set_volume(&self, mut volume: f64) {
         log::info!("set volume: {volume}");
-        if (0.0..=1.0).contains(&volume) {
-            let vol = (VOLUME_PERCENT as f64) * volume * 100.0;
-            self.spotify.set_volume(vol as u16);
-            self.event.trigger();
-        }
+        volume = volume.clamp(0.0, 1.0);
+        let vol = (VOLUME_PERCENT as f64) * volume * 100.0;
+        self.spotify.set_volume(vol as u16);
+        self.event.trigger();
     }
 
     #[dbus_interface(property)]


### PR DESCRIPTION
This fixes a small inconsistency between the MPRIS implementation and the specification. The specification allows any number when setting the volume, which have to be clamped to the effectively allowed range in the application.
https://specifications.freedesktop.org/mpris-spec/2.2/Player_Interface.html#Property:Volume

## Describe your changes
- Instead of only changing the number if it is in the range 0.0..0.1, always set it after clamping it to that range.

## Issue ticket number and link
\/

## Checklist before requesting a review
- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
