### PR TITLE
MPRIS: can_go_previous should always be true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - An unlikely crash when the UNIX IPC socket is removed before `ncspot` is closed
 - Guaranteed crash while quiting `ncspot` when using MPRIS
 - MPRIS volume not being updated when given numbers smaller than 0 or larger than 1
+- Allow previous track via MPRIS if first track in queue is playing
 
 ## [0.13.4] - 2023-07-24
 

--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -289,7 +289,7 @@ impl MprisPlayer {
 
     #[dbus_interface(property)]
     fn can_go_previous(&self) -> bool {
-        true
+        self.queue.get_current().is_some()
     }
 
     #[dbus_interface(property)]

--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -289,7 +289,7 @@ impl MprisPlayer {
 
     #[dbus_interface(property)]
     fn can_go_previous(&self) -> bool {
-        self.queue.previous_index().is_some()
+        true
     }
 
     #[dbus_interface(property)]


### PR DESCRIPTION
## Describe your changes
Currently, the MPRIS previous does nothing when the song is the first in the queue, when it should restart the song (as is the case if one uses the `previous` keyboard shortcut in the TUI).  This can fixed by making the MPRIS function `can_go_previous` identically true, rather than checking if there's a previous song in the queue.

## Issue ticket number and link
One might consider this is somewhat related to #1110?

## Checklist before requesting a review
- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
