### PR TITLE
style: deny `clippy::multiple_inherent_impls` lint

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#![deny(clippy::use_self)]
+#![deny(clippy::use_self, clippy::multiple_inherent_impl)]
 
 #[macro_use]
 extern crate cursive;

--- a/src/spotify_worker.rs
+++ b/src/spotify_worker.rs
@@ -62,16 +62,7 @@ impl Worker {
             mixer,
         }
     }
-}
 
-impl Drop for Worker {
-    fn drop(&mut self) {
-        debug!("Worker thread is shutting down, stopping player");
-        self.player.stop();
-    }
-}
-
-impl Worker {
     fn get_token(
         &self,
         sender: oneshot::Sender<Option<Token>>,
@@ -209,5 +200,12 @@ impl Worker {
                 }
             }
         }
+    }
+}
+
+impl Drop for Worker {
+    fn drop(&mut self) {
+        debug!("Worker thread is shutting down, stopping player");
+        self.player.stop();
     }
 }


### PR DESCRIPTION
## Describe your changes
Found there were two inherent `impl`s for `Worker`, for which there is apparently a Clippy lint.

## Checklist before requesting a review
- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)