### PR TITLE
chore: remove unnecessary asynchronous channel

### DIFF
--- a/src/spotify_worker.rs
+++ b/src/spotify_worker.rs
@@ -63,7 +63,6 @@ impl Worker {
         }
     }
 
-impl Worker {
     fn get_token(&self, sender: Sender<Option<Token>>) -> Pin<Box<dyn Future<Output = ()> + Send>> {
         let client_id = config::CLIENT_ID;
         let scopes = "user-read-private,playlist-read-private,playlist-read-collaborative,playlist-modify-public,playlist-modify-private,user-follow-modify,user-follow-read,user-library-read,user-library-modify,user-top-read,user-read-recently-played";

--- a/src/spotify_worker.rs
+++ b/src/spotify_worker.rs
@@ -3,7 +3,6 @@ use crate::events::{Event, EventManager};
 use crate::model::playable::Playable;
 use crate::queue::QueueEvent;
 use crate::spotify::PlayerEvent;
-use futures::channel::oneshot;
 use futures::{Future, FutureExt};
 use librespot_core::keymaster::Token;
 use librespot_core::session::Session;
@@ -11,6 +10,7 @@ use librespot_core::spotify_id::{SpotifyAudioType, SpotifyId};
 use librespot_playback::mixer::Mixer;
 use librespot_playback::player::{Player, PlayerEvent as LibrespotPlayerEvent};
 use log::{debug, error, info, warn};
+use std::sync::mpsc::Sender;
 use std::time::Duration;
 use std::{pin::Pin, time::SystemTime};
 use tokio::sync::mpsc;
@@ -26,7 +26,7 @@ pub(crate) enum WorkerCommand {
     Stop,
     Seek(u32),
     SetVolume(u16),
-    RequestToken(oneshot::Sender<Option<Token>>),
+    RequestToken(Sender<Option<Token>>),
     Preload(Playable),
     Shutdown,
 }
@@ -72,10 +72,7 @@ impl Drop for Worker {
 }
 
 impl Worker {
-    fn get_token(
-        &self,
-        sender: oneshot::Sender<Option<Token>>,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+    fn get_token(&self, sender: Sender<Option<Token>>) -> Pin<Box<dyn Future<Output = ()> + Send>> {
         let client_id = config::CLIENT_ID;
         let scopes = "user-read-private,playlist-read-private,playlist-read-collaborative,playlist-modify-public,playlist-modify-private,user-follow-modify,user-follow-read,user-library-read,user-library-modify,user-top-read,user-read-recently-played";
         let url =
@@ -94,7 +91,7 @@ impl Worker {
                         Some(token)
                     })
                 })
-                .map(|result| sender.send(result).unwrap()),
+                .map(move |result| sender.send(result).unwrap()),
         )
     }
 


### PR DESCRIPTION
The channel does not need to be asynchronous as the receiving end is used in a blocking manner and the sending end of a regular channel never blocks.

## Describe your changes

- Remove the asynchronous futures `oneshot` channel in favor of a regular one

## Issue ticket number and link

## Checklist before requesting a review
- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
