### PR TITLE
fix: crash on Termux due to missing runtime directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Crash on Android (Termux) due to unknown user runtime directory
+
 ## [1.0.0] - 2023-12-16
 
 ### Added


### PR DESCRIPTION
Instead of crashing on Termux, no IPC socket is created. This is a temporary solution until a suitable runtime directory for the Termux platform can be found.

## Describe your changes

- Make the IPC socket optional in case no suitable user runtime directory can be found on the platform.

## Issue ticket number and link

#1345 

## Checklist before requesting a review
- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
