### PR TITLE
fix: prevent 'called pause from invalid state' warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Warning in debug logs caused by pausing playback during startup
+
 ## [1.0.0] - 2023-12-16
 
 ### Added

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -72,9 +72,10 @@ impl Queue {
                 PlaybackState::Stopped => {
                     spotify.stop();
                 }
-                PlaybackState::Paused | PlaybackState::Playing | PlaybackState::Default => {
+                PlaybackState::Playing => {
                     spotify.pause();
                 }
+                _ => {}
             }
         }
 


### PR DESCRIPTION
Calling `pause()` on the Librespot player while it is already paused generates a warning. Don't call pause when the player is already paused.

## Describe your changes

- Don't send `Pause` to the player when it's already paused during queue setup

## Issue ticket number and link

## Checklist before requesting a review
- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)