### PR TITLE
chore(actions): remove unsupported `pr-branch` input

### DIFF
--- a/.github/workflows/update-rust-toolchain.yml
+++ b/.github/workflows/update-rust-toolchain.yml
@@ -17,5 +17,4 @@ jobs:
           token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
           toolchain-path: ./rust-toolchain.toml
           commit-msg: 'chore(toolchain): update'
-          pr-branch: main
           pr-title: 'chore(toolchain): update'


### PR DESCRIPTION
The latest version of the Rust toolchain update action supports a `pr-branch` input. It's not yet supported on `v1.1`.

## Describe your changes

- Remove the unsupported input from the action.

## Checklist before requesting a review
- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
