### PR TITLE
fix(mpris): missing `PropertyChanged` signal for volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Crash on Android (Termux) due to unknown user runtime directory
 - Crash due to misconfigured or unavailable audio backend
+- Missing MPRIS signal for volume changes when volume is changed from inside `ncspot`
 
 ## [1.0.0] - 2023-12-16
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -196,7 +196,7 @@ impl CommandManager {
                     .spotify
                     .volume()
                     .saturating_add(VOLUME_PERCENT * amount);
-                self.spotify.set_volume(volume);
+                self.spotify.set_volume(volume, true);
                 Ok(None)
             }
             Command::VolumeDown(amount) => {
@@ -205,7 +205,7 @@ impl CommandManager {
                     .volume()
                     .saturating_sub(VOLUME_PERCENT * amount);
                 debug!("vol {}", volume);
-                self.spotify.set_volume(volume);
+                self.spotify.set_volume(volume, true);
                 Ok(None)
             }
             Command::Help => {

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -25,6 +25,8 @@ use crate::application::ASYNC_RUNTIME;
 use crate::config;
 use crate::events::{Event, EventManager};
 use crate::model::playable::Playable;
+#[cfg(feature = "mpris")]
+use crate::mpris::{MprisCommand, MprisManager};
 use crate::spotify_api::WebApi;
 use crate::spotify_worker::{Worker, WorkerCommand};
 
@@ -46,6 +48,8 @@ pub enum PlayerEvent {
 pub struct Spotify {
     events: EventManager,
     /// The credentials for the currently logged in user, used to authenticate to the Spotify API.
+    #[cfg(feature = "mpris")]
+    mpris: Arc<std::sync::Mutex<Option<MprisManager>>>,
     credentials: Credentials,
     cfg: Arc<config::Config>,
     /// Playback status of the [Player] owned by the worker thread.
@@ -67,6 +71,8 @@ impl Spotify {
     ) -> Result<Self, Box<dyn Error>> {
         let mut spotify = Self {
             events,
+            #[cfg(feature = "mpris")]
+            mpris: Default::default(),
             credentials,
             cfg: cfg.clone(),
             status: Arc::new(RwLock::new(PlayerEvent::Stopped)),
@@ -80,7 +86,7 @@ impl Spotify {
         spotify.start_worker(Some(user_tx))?;
         let user = ASYNC_RUNTIME.get().unwrap().block_on(user_rx).ok();
         let volume = cfg.state().volume;
-        spotify.set_volume(volume);
+        spotify.set_volume(volume, true);
 
         spotify.api.set_worker_channel(spotify.channel.clone());
         spotify.api.update_token();
@@ -393,11 +399,21 @@ impl Spotify {
         self.cfg.state().volume
     }
 
-    /// Set the current volume of the [Player].
-    pub fn set_volume(&self, volume: u16) {
+    /// Set the current volume of the [Player]. If `notify` is true, also notify MPRIS clients about
+    /// the update.
+    pub fn set_volume(&self, volume: u16, notify: bool) {
         info!("setting volume to {}", volume);
         self.cfg.with_state_mut(|s| s.volume = volume);
         self.send_worker(WorkerCommand::SetVolume(volume));
+        // HACK: This is a bit of a hack to prevent duplicate update signals when updating from the
+        // MPRIS implementation.
+        if notify {
+            #[cfg(feature = "mpris")]
+            if let Some(mpris_manager) = self.mpris.lock().unwrap().as_ref() {
+                info!("updating MPRIS volume");
+                mpris_manager.send(MprisCommand::NotifyVolumeUpdate);
+            }
+        }
     }
 
     /// Preload the given [Playable] in the [Player]. This makes sure it can be played immediately
@@ -409,6 +425,11 @@ impl Spotify {
     /// Shut down the worker thread.
     pub fn shutdown(&self) {
         self.send_worker(WorkerCommand::Shutdown);
+    }
+
+    #[cfg(feature = "mpris")]
+    pub fn set_mpris(&mut self, mpris: MprisManager) {
+        *self.mpris.lock().unwrap() = Some(mpris);
     }
 }
 

--- a/src/ui/statusbar.rs
+++ b/src/ui/statusbar.rs
@@ -238,7 +238,7 @@ impl View for StatusBar {
                         .volume()
                         .saturating_add(crate::spotify::VOLUME_PERCENT);
 
-                    self.spotify.set_volume(volume);
+                    self.spotify.set_volume(volume, true);
                 }
 
                 if event == MouseEvent::WheelDown {
@@ -247,7 +247,7 @@ impl View for StatusBar {
                         .volume()
                         .saturating_sub(crate::spotify::VOLUME_PERCENT);
 
-                    self.spotify.set_volume(volume);
+                    self.spotify.set_volume(volume, true);
                 }
             } else if event == MouseEvent::Press(MouseButton::Left) {
                 self.queue.toggleplayback();


### PR DESCRIPTION
When the volume is changed from inside `ncspot`, also send a `PropertyChanged` signal.

## Describe your changes

- Send a DBus `PropertyChanged` signal every time the volume is changed inside `Spotify`
- Make the `update()` command on the `MprisManager` more general with different signals

## Issue ticket number and link

closes #1328

## Checklist before requesting a review
- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
