### PR TITLE
style: share linting options across packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,13 @@ members = [
     "xtask"
 ]
 
+[workspace.lints.clippy]
+use_self = "deny"
+multiple_inherent_impl = "deny"
+
+[lints]
+workspace = true
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(clippy::use_self, clippy::multiple_inherent_impl)]
-
 #[macro_use]
 extern crate cursive;
 #[macro_use]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -13,3 +13,6 @@ clap = "4.4.12"
 [dependencies.ncspot]
 default-features = false
 path = ".."
+
+[lints]
+workspace = true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -20,8 +20,8 @@ impl TryFrom<&ArgMatches> for XTaskSubcommand {
     fn try_from(value: &ArgMatches) -> Result<Self, Self::Error> {
         if let Some(subcommand) = value.subcommand() {
             match subcommand.0 {
-                "generate-manpage" => Ok(XTaskSubcommand::GenerateManpage),
-                "generate-shell-completion" => Ok(XTaskSubcommand::GenerateShellCompletion),
+                "generate-manpage" => Ok(Self::GenerateManpage),
+                "generate-shell-completion" => Ok(Self::GenerateShellCompletion),
                 _ => Err(Error::new(clap::error::ErrorKind::InvalidSubcommand)),
             }
         } else {


### PR DESCRIPTION
Move the Rust and Clippy linting options into the Cargo manifest and share them with all the packages in the workspace. This ensures a consistent style in all packages.

## Describe your changes

- Move all the linting options into the Cargo manifest under a `workspace.lints` table
- Enable workspace lints in all packages
- Remove the previous Clippy lints from the `main.rs` in the `ncspot` package
- Fix `use_self` style issue in `xtask` package

## Checklist before requesting a review
- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
