### PR TITLE
refactor: general small refactors to simplify code

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -113,8 +113,8 @@ impl CommandManager {
         match cmd {
             Command::Noop => Ok(None),
             Command::Quit => {
-                let queue = self.queue.queue.read().expect("can't readlock queue");
-                self.config.with_state_mut(move |mut s| {
+                let queue = self.queue.queue.read().unwrap();
+                self.config.with_state_mut(move |s| {
                     debug!(
                         "saving state, {} items, current track: {:?}",
                         queue.len(),

--- a/src/events.rs
+++ b/src/events.rs
@@ -39,14 +39,12 @@ impl EventManager {
 
     /// Send a new event to be handled.
     pub fn send(&self, event: Event) {
-        self.tx.send(event).expect("could not send event");
+        self.tx.send(event).unwrap();
         self.trigger();
     }
 
     /// Send a no-op to the Cursive event loop to trigger immediate processing of events.
     pub fn trigger(&self) {
-        self.cursive_sink
-            .send(Box::new(Cursive::noop))
-            .expect("could not send no-op event to cursive");
+        self.cursive_sink.send(Box::new(Cursive::noop)).unwrap();
     }
 }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -70,7 +70,7 @@ impl IpcSocket {
             mode: event.clone(),
             playable,
         };
-        self.tx.send(status).expect("Error publishing IPC update");
+        self.tx.send(status).unwrap();
     }
 
     async fn worker(listener: UnixListener, ev: EventManager, tx: Receiver<Status>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ use librespot_playback::audio_backend;
 pub const AUTHOR: &str = "Henrik Friedrichsen <henrik@affekt.org> and contributors";
 pub const BIN_NAME: &str = "ncspot";
 pub const CONFIGURATION_FILE_NAME: &str = "config.toml";
+pub const USER_STATE_FILE_NAME: &str = "userstate.cbor";
 
 /// Return the [Command](clap::Command) that models the program's command line arguments. The
 /// command can be used to parse the actual arguments passed to the program, or to automatically

--- a/src/library.rs
+++ b/src/library.rs
@@ -133,7 +133,7 @@ impl Library {
     /// Append `updated` to the local playlists or update the local version if it exists. Return the
     /// index of the appended/updated playlist.
     fn append_or_update(&self, updated: Playlist) -> usize {
-        let mut store = self.playlists.write().expect("can't writelock playlists");
+        let mut store = self.playlists.write().unwrap();
         for (index, local) in store.iter_mut().enumerate() {
             if local.id == updated.id {
                 *local = updated;
@@ -159,10 +159,7 @@ impl Library {
 
         if let Some(position) = position {
             if self.spotify.api.delete_playlist(id).is_ok() {
-                self.playlists
-                    .write()
-                    .expect("can't writelock playlists")
-                    .remove(position);
+                self.playlists.write().unwrap().remove(position);
                 self.save_cache(
                     &config::cache_path(CACHE_PLAYLISTS),
                     &self.playlists.read().unwrap(),
@@ -581,7 +578,7 @@ impl Library {
     /// If there is a local version of the playlist, update it and rewrite the cache.
     pub fn playlist_update(&self, updated: &Playlist) {
         {
-            let mut playlists = self.playlists.write().expect("can't writelock playlists");
+            let mut playlists = self.playlists.write().unwrap();
             if let Some(playlist) = playlists.iter_mut().find(|p| p.id == updated.id) {
                 *playlist = updated.clone();
             }

--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -372,9 +372,8 @@ impl MprisPlayer {
     fn open_uri(&self, uri: &str) {
         let spotify_url = if uri.contains("open.spotify.com") {
             SpotifyUrl::from_url(uri)
-        } else if UriType::from_uri(uri).is_some() {
+        } else if let Ok(uri_type) = uri.parse() {
             let id = &uri[uri.rfind(':').unwrap_or(0) + 1..uri.len()];
-            let uri_type = UriType::from_uri(uri).unwrap();
             Some(SpotifyUrl::new(id, uri_type))
         } else {
             None

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -423,7 +423,7 @@ impl Queue {
 
     /// Set the current repeat behavior and save it to the configuration.
     pub fn set_repeat(&self, new: RepeatSetting) {
-        self.cfg.with_state_mut(|mut s| s.repeat = new);
+        self.cfg.with_state_mut(|s| s.repeat = new);
     }
 
     /// Get the current shuffle behavior.
@@ -457,7 +457,7 @@ impl Queue {
 
     /// Set the current shuffle behavior.
     pub fn set_shuffle(&self, new: bool) {
-        self.cfg.with_state_mut(|mut s| s.shuffle = new);
+        self.cfg.with_state_mut(|s| s.shuffle = new);
         if new {
             self.generate_random_order();
         } else {

--- a/src/ui/playlist.rs
+++ b/src/ui/playlist.rs
@@ -93,7 +93,7 @@ impl ViewExt for PlaylistView {
         }
 
         if let Command::Sort(key, direction) = cmd {
-            self.library.cfg.with_state_mut(|mut state| {
+            self.library.cfg.with_state_mut(|state| {
                 let order = crate::config::SortingOrder {
                     key: key.clone(),
                     direction: direction.clone(),

--- a/src/ui/search_results.rs
+++ b/src/ui/search_results.rs
@@ -394,7 +394,7 @@ impl SearchResultsView {
         self.spotify.api.update_token();
 
         // is the query a Spotify URI?
-        if let Some(uritype) = UriType::from_uri(&query) {
+        if let Ok(uritype) = query.parse() {
             match uritype {
                 UriType::Track => {
                     self.perform_search(


### PR DESCRIPTION
Some small general refactoring to improve code readability and adhere to Rust conventions.

## Describe your changes
- Remove `expect` in favor of `unwrap` when the `Result`'s error variant contains the info in the `expect` anyway (eg. when locking things). The line number/context are given by the backtrace.
- Remove over-specification of types (`&T` instead of `&RWReadLockGuard`)
- Put reused values into constants
- `try_from` instead of manual function
- Change `if let Some(()) = ...` to `if T.is_some()`

## Checklist before requesting a review
- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
