### PR TITLE
refactor(library): various Rust style optimizations

### DIFF
--- a/src/model/playlist.rs
+++ b/src/model/playlist.rs
@@ -29,7 +29,7 @@ pub struct Playlist {
 }
 
 impl Playlist {
-    pub fn load_tracks(&mut self, spotify: Spotify) {
+    pub fn load_tracks(&mut self, spotify: &Spotify) {
         if self.tracks.is_some() {
             return;
         }
@@ -37,7 +37,7 @@ impl Playlist {
         self.tracks = Some(self.get_all_tracks(spotify));
     }
 
-    fn get_all_tracks(&self, spotify: Spotify) -> Vec<Playable> {
+    fn get_all_tracks(&self, spotify: &Spotify) -> Vec<Playable> {
         let tracks_result = spotify.api.user_playlist_tracks(&self.id);
         while !tracks_result.at_end() {
             tracks_result.next();
@@ -221,7 +221,7 @@ impl ListItem for Playlist {
     }
 
     fn play(&mut self, queue: &Queue) {
-        self.load_tracks(queue.get_spotify());
+        self.load_tracks(&queue.get_spotify());
 
         if let Some(tracks) = &self.tracks {
             let index = queue.append_next(tracks);
@@ -230,7 +230,7 @@ impl ListItem for Playlist {
     }
 
     fn play_next(&mut self, queue: &Queue) {
-        self.load_tracks(queue.get_spotify());
+        self.load_tracks(&queue.get_spotify());
 
         if let Some(tracks) = self.tracks.as_ref() {
             for track in tracks.iter().rev() {
@@ -240,7 +240,7 @@ impl ListItem for Playlist {
     }
 
     fn queue(&mut self, queue: &Queue) {
-        self.load_tracks(queue.get_spotify());
+        self.load_tracks(&queue.get_spotify());
 
         if let Some(tracks) = self.tracks.as_ref() {
             for track in tracks.iter() {
@@ -258,12 +258,12 @@ impl ListItem for Playlist {
         if library.is_saved_playlist(self) {
             library.delete_playlist(&self.id);
         } else {
-            library.follow_playlist(self);
+            library.follow_playlist(self.clone());
         }
     }
 
     fn save(&mut self, library: &Library) {
-        library.follow_playlist(self);
+        library.follow_playlist(self.clone());
     }
 
     fn unsave(&mut self, library: &Library) {
@@ -279,7 +279,7 @@ impl ListItem for Playlist {
         queue: Arc<Queue>,
         library: Arc<Library>,
     ) -> Option<Box<dyn ViewExt>> {
-        self.load_tracks(queue.get_spotify());
+        self.load_tracks(&queue.get_spotify());
         const MAX_SEEDS: usize = 5;
         let track_ids: Vec<String> = self
             .tracks

--- a/src/model/track.rs
+++ b/src/model/track.rs
@@ -249,18 +249,18 @@ impl ListItem for Track {
 
     fn toggle_saved(&mut self, library: &Library) {
         if library.is_saved_track(&Playable::Track(self.clone())) {
-            library.unsave_tracks(vec![self], true);
+            library.unsave_tracks(&[self]);
         } else {
-            library.save_tracks(vec![self], true);
+            library.save_tracks(&[self]);
         }
     }
 
     fn save(&mut self, library: &Library) {
-        library.save_tracks(vec![self], true);
+        library.save_tracks(&[self]);
     }
 
     fn unsave(&mut self, library: &Library) {
-        library.unsave_tracks(vec![self], true);
+        library.unsave_tracks(&[self]);
     }
 
     fn open(&self, _queue: Arc<Queue>, _library: Arc<Library>) -> Option<Box<dyn ViewExt>> {

--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -409,8 +409,7 @@ impl MprisPlayer {
             Some(UriType::Playlist) => {
                 if let Some(p) = self.spotify.api.playlist(&id) {
                     let mut playlist = Playlist::from(&p);
-                    let spotify = self.spotify.clone();
-                    playlist.load_tracks(spotify);
+                    playlist.load_tracks(&self.spotify);
                     if let Some(tracks) = &playlist.tracks {
                         let should_shuffle = self.queue.get_shuffle();
                         self.queue.clear();

--- a/src/spotify_api.rs
+++ b/src/spotify_api.rs
@@ -499,7 +499,7 @@ impl WebApi {
         self.api_with_retry(|api| api.get_saved_show_manual(Some(50), Some(offset)))
     }
 
-    pub fn save_shows(&self, ids: Vec<&str>) -> bool {
+    pub fn save_shows(&self, ids: &[&str]) -> bool {
         self.api_with_retry(|api| {
             api.save_shows(
                 ids.iter()
@@ -510,7 +510,7 @@ impl WebApi {
         .is_some()
     }
 
-    pub fn unsave_shows(&self, ids: Vec<&str>) -> bool {
+    pub fn unsave_shows(&self, ids: &[&str]) -> bool {
         self.api_with_retry(|api| {
             api.remove_users_saved_shows(
                 ids.iter()

--- a/src/ui/contextmenu.rs
+++ b/src/ui/contextmenu.rs
@@ -61,7 +61,7 @@ impl ContextMenu {
         let mut list_select: SelectView<Playlist> = SelectView::new();
         let current_user_id = library.user_id.as_ref().unwrap();
 
-        for list in library.playlists().iter() {
+        for list in library.playlists.read().unwrap().iter() {
             if current_user_id == &list.owner_id || list.collaborative {
                 list_select.add_item(list.name.clone(), list.clone());
             }

--- a/src/ui/playlist.rs
+++ b/src/ui/playlist.rs
@@ -25,7 +25,7 @@ pub struct PlaylistView {
 impl PlaylistView {
     pub fn new(queue: Arc<Queue>, library: Arc<Library>, playlist: &Playlist) -> Self {
         let mut playlist = playlist.clone();
-        playlist.load_tracks(queue.get_spotify());
+        playlist.load_tracks(&queue.get_spotify());
 
         if let Some(order) = library.cfg.state().playlist_orders.get(&playlist.id) {
             playlist.sort(&order.key, &order.direction);

--- a/src/ui/playlists.rs
+++ b/src/ui/playlists.rs
@@ -27,7 +27,7 @@ impl PlaylistsView {
     }
 
     pub fn delete_dialog(&mut self) -> Option<Modal<Dialog>> {
-        let playlists = self.library.playlists();
+        let playlists = self.library.playlists.read().unwrap();
         let current = playlists.get(self.list.get_selected_index());
 
         if let Some(playlist) = current {

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -67,7 +67,7 @@ impl QueueView {
         let mut list_select: SelectView<Option<String>> = SelectView::new().autojump();
         list_select.add_item("[Create new]", None);
 
-        for list in library.playlists().iter() {
+        for list in library.playlists.read().unwrap().iter() {
             list_select.add_item(list.name.clone(), Some(list.id.clone()));
         }
 


### PR DESCRIPTION
Lots of small fixes to the APIs and functions in the `library` module, mostly following best practices outlined in the Rust library guidelines. Changes outside the `library` module were mostly required changes after changing function signatures.

## Describe your changes

- Function signature changes to make them more general (e.g. `&[T]` instead of `Vec<T>` when possible)
- Add documentation comments to most functions in the `library` module
- Remove a bunch of clones in favor of borrows when possible
- Change function signatures to accept mutable types directly instead of `Arc<RWLock<T>>` leaving locking up to the caller
- Restructure some function bodies to make their inner working clearer at first glance, but keeping their functionality the same
- Write serialized cache data directly to cache file instead of serializing to in-memory string first
- Add/remove variables to make code clearer

## Checklist before requesting a review
- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
