### PR TITLE
docs(worker): comment purpose of UI refresh task

### DIFF
--- a/src/spotify_worker.rs
+++ b/src/spotify_worker.rs
@@ -186,6 +186,7 @@ impl Worker {
                     },
                     _ => {}
                 },
+                // Update animated parts of the UI (e.g. statusbar during playback).
                 _ = ui_refresh.tick() => {
                     if self.active {
                         self.events.trigger();


### PR DESCRIPTION
The purpose of the manual ui refresh task isn't immediately clear. It was explained in the commit message of the commit that introduced it.

## Describe your changes

Add a comment that explains the purpose of the `refresh_ui` task in the worker thread.

## Checklist before requesting a review
- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
