### PR TITLE
fix: gracefully exit when misconfigured or unavailable audio backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Crash on Android (Termux) due to unknown user runtime directory
+- Crash due to misconfigured or unavailable audio backend
 
 ## [1.0.0] - 2023-12-16
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,10 +3,11 @@ extern crate cursive;
 #[macro_use]
 extern crate serde;
 
-use std::path::PathBuf;
+use std::{path::PathBuf, process::exit};
 
 use application::{setup_logging, Application};
 use config::set_configuration_base_path;
+use log::error;
 use ncspot::program_arguments;
 
 mod application;
@@ -60,10 +61,20 @@ fn main() -> Result<(), String> {
         Some((_, _)) => unreachable!(),
         None => {
             // Create the application.
-            let mut application = Application::new(matches.get_one::<String>("config").cloned())?;
+            let mut application =
+                match Application::new(matches.get_one::<String>("config").cloned()) {
+                    Ok(application) => application,
+                    Err(error) => {
+                        eprintln!("{error}");
+                        error!("{error}");
+                        exit(-1);
+                    }
+                };
 
             // Start the application event loop.
             application.run()
         }
-    }
+    }?;
+
+    Ok(())
 }


### PR DESCRIPTION
When the user has an error in their audio backend configuration or doesn't have audio backends available, gracefully exit instead of panicking.

## Describe your changes

Move audio backend initialization into the main thread for simpler error handling. Propagate errors up to the main function and log/print them there before quitting. This makes sure that everything that needs to be dropped is dropped automatically (e.g. not the case when manual exit from `Application::new()` which needs manual drop of `CursiveRunner` to reset terminal).

## Issue ticket number and link

closes #1383 

## Checklist before requesting a review
- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
