### PR TITLE
fix(cargo): prevent crate filename collision

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ inherits = "release"
 lto = false
 codegen-units = 16
 
+[lib]
+name = "ncspot_common"
+
 [dependencies]
 chrono = "0.4"
 clap = "4.4.18"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -25,7 +25,7 @@ use cursive::traits::View;
 use cursive::views::Dialog;
 use cursive::Cursive;
 use log::{debug, error, info};
-use ncspot::CONFIGURATION_FILE_NAME;
+use ncspot_common::CONFIGURATION_FILE_NAME;
 use std::cell::RefCell;
 
 pub enum CommandResult {

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@ use std::{fs, process};
 
 use cursive::theme::Theme;
 use log::{debug, error};
-use ncspot::{CONFIGURATION_FILE_NAME, USER_STATE_FILE_NAME};
+use ncspot_common::{CONFIGURATION_FILE_NAME, USER_STATE_FILE_NAME};
 use platform_dirs::AppDirs;
 
 use crate::command::{SortDirection, SortKey};

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use std::{path::PathBuf, process::exit};
 use application::{setup_logging, Application};
 use config::set_configuration_base_path;
 use log::error;
-use ncspot::program_arguments;
+use ncspot_common::program_arguments;
 
 mod application;
 mod authentication;

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -5,7 +5,7 @@ use cursive::utils::markup::StyledString;
 use cursive::view::ViewWrapper;
 use cursive::views::{ScrollView, TextView};
 use cursive::Cursive;
-use ncspot::CONFIGURATION_FILE_NAME;
+use ncspot_common::CONFIGURATION_FILE_NAME;
 
 use crate::command::{Command, MoveAmount, MoveMode};
 use crate::commands::CommandResult;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,5 +1,5 @@
 use cursive::{Cursive, CursiveRunner};
-use ncspot::BIN_NAME;
+use ncspot_common::BIN_NAME;
 
 pub mod album;
 pub mod artist;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -5,7 +5,7 @@ use clap::builder::PathBufValueParser;
 use clap::error::{Error, ErrorKind};
 use clap::ArgMatches;
 use clap_complete::Shell;
-use ncspot::{AUTHOR, BIN_NAME};
+use ncspot_common::{AUTHOR, BIN_NAME};
 
 static DEFAULT_OUTPUT_DIRECTORY: &str = "misc";
 
@@ -109,7 +109,7 @@ fn generate_manpage(subcommand_arguments: &ArgMatches) -> Result<(), DynError> {
     let output_directory = subcommand_arguments
         .get_one::<PathBuf>("output")
         .unwrap_or(&default_output_directory);
-    let cmd = ncspot::program_arguments();
+    let cmd = ncspot_common::program_arguments();
     let man = clap_mangen::Man::new(cmd);
     let mut buffer: Vec<u8> = Default::default();
 
@@ -154,7 +154,7 @@ fn generate_shell_completion(subcommand_arguments: &ArgMatches) -> Result<(), Dy
     for shell in shells {
         clap_complete::generate_to(
             shell,
-            &mut ncspot::program_arguments(),
+            &mut ncspot_common::program_arguments(),
             BIN_NAME,
             output_directory,
         )?;


### PR DESCRIPTION
`cargo` has a bug that prevents correct handling of similarly named crates in the same package. Rename the internal library crate to prevent error messages. https://github.com/rust-lang/cargo/issues/10368

## Describe your changes

Rename the library crate in the `ncspot` package. Instead of the implicit name `ncspot`, give it a name in the `cargo` manifest.

## Checklist before requesting a review
- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
