### PR TITLE
attempt to fix https://github.com/hrkfdn/ncspot/issues/1358

### DIFF
--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -83,7 +83,11 @@ impl Spotify {
         spotify.set_volume(volume);
 
         spotify.api.set_worker_channel(spotify.channel.clone());
-        ASYNC_RUNTIME.get().unwrap().block_on(spotify.api.update_token().unwrap()).ok();
+        ASYNC_RUNTIME
+            .get()
+            .unwrap()
+            .block_on(spotify.api.update_token().unwrap())
+            .ok();
 
         spotify.api.set_user(user);
 

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -83,7 +83,7 @@ impl Spotify {
         spotify.set_volume(volume);
 
         spotify.api.set_worker_channel(spotify.channel.clone());
-        spotify.api.update_token();
+        ASYNC_RUNTIME.get().unwrap().block_on(spotify.api.update_token().unwrap()).ok();
 
         spotify.api.set_user(user);
 

--- a/src/spotify_api.rs
+++ b/src/spotify_api.rs
@@ -101,9 +101,8 @@ impl WebApi {
             channel.send(cmd).unwrap();
             let api_token = self.api.token.clone();
             let api_token_expiration = self.token_expiration.clone();
-            let token_option = token_rx.recv().unwrap();
             Some(ASYNC_RUNTIME.get().unwrap().spawn_blocking(move || {
-                if let Some(token) = token_option {
+                if let Some(token) = token_rx.recv().unwrap() {
                     *api_token.lock().unwrap() = Some(Token {
                         access_token: token.access_token,
                         expires_in: chrono::Duration::seconds(token.expires_in.into()),

--- a/src/spotify_api.rs
+++ b/src/spotify_api.rs
@@ -15,6 +15,8 @@ use rspotify::model::{
 };
 use rspotify::{prelude::*, AuthCodeSpotify, ClientError, ClientResult, Config, Token};
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use crate::application::ASYNC_RUNTIME;
 
 use crate::model::album::Album;
 use crate::model::artist::Artist;
@@ -79,7 +81,7 @@ impl WebApi {
     }
 
     /// Update the authentication token when it expires.
-    pub fn update_token(&self) {
+    pub fn update_token(&self) -> Option<JoinHandle<()>> {
         {
             let token_expiration = self.token_expiration.read().unwrap();
             let now = Utc::now();
@@ -87,7 +89,7 @@ impl WebApi {
 
             // token is valid for 5 more minutes, renewal is not necessary yet
             if delta.num_seconds() > 60 * 5 {
-                return;
+                return None;
             }
 
             info!("Token will expire in {}, renewing", delta);
@@ -97,22 +99,27 @@ impl WebApi {
         let cmd = WorkerCommand::RequestToken(token_tx);
         if let Some(channel) = self.worker_channel.read().unwrap().as_ref() {
             channel.send(cmd).unwrap();
+            let api_token = self.api.token.clone();
+            let api_token_expiration = self.token_expiration.clone();
             let token_option = token_rx.recv().unwrap();
-            if let Some(token) = token_option {
-                *self.api.token.lock().unwrap() = Some(Token {
-                    access_token: token.access_token,
-                    expires_in: chrono::Duration::seconds(token.expires_in.into()),
-                    scopes: HashSet::from_iter(token.scope),
-                    expires_at: None,
-                    refresh_token: None,
-                });
-                *self.token_expiration.write().unwrap() =
-                    Utc::now() + ChronoDuration::seconds(token.expires_in.into());
-            } else {
-                error!("Failed to update token");
-            }
+            Some(ASYNC_RUNTIME.get().unwrap().spawn_blocking(move || {
+                if let Some(token) = token_option {
+                    *api_token.lock().unwrap() = Some(Token {
+                        access_token: token.access_token,
+                        expires_in: chrono::Duration::seconds(token.expires_in.into()),
+                        scopes: HashSet::from_iter(token.scope),
+                        expires_at: None,
+                        refresh_token: None,
+                    });
+                    *api_token_expiration.write().unwrap() =
+                        Utc::now() + ChronoDuration::seconds(token.expires_in.into());
+                } else {
+                    error!("Failed to update token");
+                }
+            }))
         } else {
             error!("worker channel is not set");
+            None
         }
     }
 
@@ -138,8 +145,7 @@ impl WebApi {
                         }
                         401 => {
                             debug!("token unauthorized. trying refresh..");
-                            self.update_token();
-                            api_call(&self.api).ok()
+                            self.update_token().and_then(move |_| {api_call(&self.api).ok()})
                         }
                         _ => {
                             error!("unhandled api error: {:?}", response);

--- a/src/spotify_api.rs
+++ b/src/spotify_api.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, RwLock};
 use std::thread;
 use std::time::Duration;
 
+use crate::application::ASYNC_RUNTIME;
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use log::{debug, error, info};
 use rspotify::http::HttpError;
@@ -16,7 +17,6 @@ use rspotify::model::{
 use rspotify::{prelude::*, AuthCodeSpotify, ClientError, ClientResult, Config, Token};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
-use crate::application::ASYNC_RUNTIME;
 
 use crate::model::album::Album;
 use crate::model::artist::Artist;
@@ -145,7 +145,8 @@ impl WebApi {
                         }
                         401 => {
                             debug!("token unauthorized. trying refresh..");
-                            self.update_token().and_then(move |_| {api_call(&self.api).ok()})
+                            self.update_token()
+                                .and_then(move |_| api_call(&self.api).ok())
                         }
                         _ => {
                             error!("unhandled api error: {:?}", response);

--- a/src/ui/search_results.rs
+++ b/src/ui/search_results.rs
@@ -1,3 +1,4 @@
+use crate::application::ASYNC_RUNTIME;
 use crate::command::Command;
 use crate::commands::CommandResult;
 use crate::events::EventManager;
@@ -20,7 +21,6 @@ use cursive::Cursive;
 use rspotify::model::search::SearchResult;
 use rspotify::model::SearchType;
 use std::sync::{Arc, RwLock};
-use crate::application::ASYNC_RUNTIME;
 
 pub struct SearchResultsView {
     search_term: String,
@@ -392,7 +392,11 @@ impl SearchResultsView {
         // check if API token refresh is necessary before commencing multiple
         // requests to avoid deadlock, as the parallel requests might
         // simultaneously try to refresh the token
-        ASYNC_RUNTIME.get().unwrap().block_on(self.spotify.api.update_token().unwrap()).ok();
+        ASYNC_RUNTIME
+            .get()
+            .unwrap()
+            .block_on(self.spotify.api.update_token().unwrap())
+            .ok();
 
         // is the query a Spotify URI?
         if let Ok(uritype) = query.parse() {

--- a/src/ui/search_results.rs
+++ b/src/ui/search_results.rs
@@ -20,6 +20,7 @@ use cursive::Cursive;
 use rspotify::model::search::SearchResult;
 use rspotify::model::SearchType;
 use std::sync::{Arc, RwLock};
+use crate::application::ASYNC_RUNTIME;
 
 pub struct SearchResultsView {
     search_term: String,
@@ -391,7 +392,7 @@ impl SearchResultsView {
         // check if API token refresh is necessary before commencing multiple
         // requests to avoid deadlock, as the parallel requests might
         // simultaneously try to refresh the token
-        self.spotify.api.update_token();
+        ASYNC_RUNTIME.get().unwrap().block_on(self.spotify.api.update_token().unwrap()).ok();
 
         // is the query a Spotify URI?
         if let Ok(uritype) = query.parse() {


### PR DESCRIPTION
## Describe your changes

mpris runs inside `tokio::runtime.spawn`. At some point it hits `metadata_changed->WebApi::track->api_with_retry`, which gets 401 response and tries to update the token.

This goes into `update_token`, which at a certain point calls *blocking* `token_rx.recv()`. Tokio runtime is not happy about that, as it uses the same thread for the `run_loop` in the worker. That's why `tokio::select!` doesn't work, we're essentially deadlocking, so the worker never pick up `RequestToken` command and `update_token` block forever.

Here I'm changing `update_token` to wrap `recv` in `spawn_blocking`, which makes `update_token` return a `JoinHandle`, on which the caller has to await. This doesn't work nicely in case of mpris though, as it is not an async function, and I don't know how to make it async as it goes through the dbus `metadata_changed` interface. My best effort here is to do `and_then`, which seems to work, but I'm not confident that's the right approach.

I didn't do extensive testing, but so far seems to work.

## Issue ticket number and link

https://github.com/hrkfdn/ncspot/issues/1358

## Checklist before requesting a review
- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
