### PR TITLE
Fix for issues/1401

### DIFF
--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -83,11 +83,10 @@ impl Spotify {
         spotify.set_volume(volume);
 
         spotify.api.set_worker_channel(spotify.channel.clone());
-        ASYNC_RUNTIME
-            .get()
-            .unwrap()
-            .block_on(spotify.api.update_token().unwrap())
-            .ok();
+        spotify
+            .api
+            .update_token()
+            .map(move |h| ASYNC_RUNTIME.get().unwrap().block_on(h).ok());
 
         spotify.api.set_user(user);
 

--- a/src/spotify_api.rs
+++ b/src/spotify_api.rs
@@ -117,8 +117,7 @@ impl WebApi {
                 }
             }))
         } else {
-            error!("worker channel is not set");
-            None
+            panic!("worker channel is not set");
         }
     }
 

--- a/src/ui/search_results.rs
+++ b/src/ui/search_results.rs
@@ -392,11 +392,10 @@ impl SearchResultsView {
         // check if API token refresh is necessary before commencing multiple
         // requests to avoid deadlock, as the parallel requests might
         // simultaneously try to refresh the token
-        ASYNC_RUNTIME
-            .get()
-            .unwrap()
-            .block_on(self.spotify.api.update_token().unwrap())
-            .ok();
+        self.spotify
+            .api
+            .update_token()
+            .map(move |h| ASYNC_RUNTIME.get().unwrap().block_on(h).ok());
 
         // is the query a Spotify URI?
         if let Ok(uritype) = query.parse() {


### PR DESCRIPTION
## Describe your changes

1. `None` from `update_token` should only mean "no update needed", should not be used for errors. We now panic when worker channel is not set
2. Callers should correctly handle `None` result

## Issue ticket number and link

https://github.com/hrkfdn/ncspot/issues/1401

## Checklist before requesting a review
- [ ] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [ ] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
