### PR TITLE
fix a panic when token update fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Crash due to misconfigured or unavailable audio backend
 - Missing MPRIS signal for volume changes when volume is changed from inside `ncspot`
 - Crash when `ncspot` tried to update an API token that was still valid
+- Panic when token update attempt fails
 - Complete freeze when `ncspot` was running for a long time
 
 ## [1.0.0] - 2023-12-16

--- a/src/spotify_api.rs
+++ b/src/spotify_api.rs
@@ -102,7 +102,7 @@ impl WebApi {
             let api_token = self.api.token.clone();
             let api_token_expiration = self.token_expiration.clone();
             Some(ASYNC_RUNTIME.get().unwrap().spawn_blocking(move || {
-                if let Some(token) = token_rx.recv().unwrap() {
+                if let Ok(Some(token)) = token_rx.recv() {
                     *api_token.lock().unwrap() = Some(Token {
                         access_token: token.access_token,
                         expires_in: chrono::Duration::seconds(token.expires_in.into()),


### PR DESCRIPTION
## Describe your changes
sometimes we get an `Err` from `token_rx.recv()`, shouldn't panic in such cases

## Issue ticket number and link
didn't create an issue

## Checklist before requesting a review
- [ ] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [ ] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
