### PR TITLE
added support for ap-port conf

### DIFF
--- a/doc/users.md
+++ b/doc/users.md
@@ -266,6 +266,7 @@ Possible configuration values are:
 | `[notification_format]`         | Set the text displayed in notifications<sup>[4]</sup>          | See [notification formatting](#notification-formatting)                               |                     |
 | `[theme]`                       | Custom theme                                                   | See [custom theme](#theming)                                                          |                     |
 | `[keybindings]`                 | Custom keybindings                                             | See [custom keybindings](#custom-keybindings)                                         |                     |
+| `ap-port`                       | Set ap-port for librespot                                | `0` (no port selected), `80`, `443`, `4070`                                                         | `0`               |
 
 1. If built with the `cover` feature.
 2. By default the statusbar will show a play icon when a track is playing and

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -45,7 +45,7 @@ pub fn get_credentials(configuration: &Config) -> Result<RespotCredentials, Stri
         }
     };
 
-    while let Err(error) = Spotify::test_credentials(credentials.clone()) {
+    while let Err(error) = Spotify::test_credentials(configuration, credentials.clone()) {
         let error_msg = format!("{error}");
         credentials = credentials_prompt(Some(error_msg))?;
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -102,6 +102,7 @@ pub struct ConfigValues {
     pub library_tabs: Option<Vec<LibraryTab>>,
     pub hide_display_names: Option<bool>,
     pub credentials: Option<Credentials>,
+    pub ap_port: Option<u16>,
 }
 
 /// Commands used to obtain user credentials automatically.


### PR DESCRIPTION
## Describe your changes
Added a config option `ap-port` to fix the port used to connect to `spotify` and pass it to `librespot`. Fixes issues with restrictive firewalls, after setting `ap-port = 443` in config file.
## Issue ticket number and link
Fixes #1404 
## Checklist before requesting a review
- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [ ] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
