### PR TITLE
Use native TLS only, don't mix it with rustls (2nd try)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - All requests are correctly proxied when the relevant environment variables are set
+- `ncspot` binary is simultaneously linked with the system TLS library (native-tls) and Rustls - only native-tls is used now
 
 ## [1.1.0] - 2024-03-05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3394,9 +3394,9 @@ checksum = "b833d8d034ea094b1ea68aa6d5c740e0d04bad9d16568d08ba6f76823a114316"
 
 [[package]]
 name = "rspotify"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f2cc614b66373d845df09177f6466457e5501cf593380c908ad91f0883afaf9"
+checksum = "efe9fecaed050e72eefa9a07702c3734abb0e82b70d7c867b32789e6f8fb5663"
 dependencies = [
  "base64 0.22.0",
  "chrono",
@@ -3415,9 +3415,9 @@ dependencies = [
 
 [[package]]
 name = "rspotify-http"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffede62dc961e7bccfbb93dbd3584bfa6b9d419aeff0a5eeeb776990d69284e"
+checksum = "612220388516c12ab0fc23917dd02a6693488dbb5ac615436ff60e7e88130ec1"
 dependencies = [
  "log",
  "maybe-async",
@@ -3428,15 +3428,15 @@ dependencies = [
 
 [[package]]
 name = "rspotify-macros"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e395720e0f07420e28b17ce7e6a1626d9574c42d5696a930c028d6dc44d23337"
+checksum = "6396935068e8615651966a7e44f1dbcfab7be02544862fb3ae65f1e086ad9a93"
 
 [[package]]
 name = "rspotify-model"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e741b3a6325998e117bb064b992ec5cc404d923ca3d25a5d226889997fc2878"
+checksum = "b94f104ee213b5cb53e6d797efc7e1825bb42981213265a2db7268efd51ecaff"
 dependencies = [
  "chrono",
  "enum_dispatch",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3363,21 +3363,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ring"
-version = "0.17.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom",
- "libc",
- "spin",
- "untrusted",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "rodio"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3421,6 +3406,7 @@ checksum = "612220388516c12ab0fc23917dd02a6693488dbb5ac615436ff60e7e88130ec1"
 dependencies = [
  "log",
  "maybe-async",
+ "native-tls",
  "serde_json",
  "thiserror",
  "ureq",
@@ -3495,34 +3481,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.21.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki",
- "sct",
-]
-
-[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -3566,16 +3530,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "security-framework"
@@ -3816,12 +3770,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"
@@ -4317,12 +4265,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
 name = "ureq"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4332,14 +4274,12 @@ dependencies = [
  "cookie",
  "cookie_store",
  "log",
+ "native-tls",
  "once_cell",
- "rustls",
- "rustls-webpki",
  "serde",
  "serde_json",
  "socks",
  "url",
- "webpki-roots",
 ]
 
 [[package]]
@@ -4570,12 +4510,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "weezl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ signal-hook = "0.3.0"
 [dependencies.rspotify]
 default-features = false
 features = ["client-ureq", "ureq-rustls-tls"]
-version = "0.13.0"
+version = "0.13.1"
 
 [dependencies.cursive]
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ signal-hook = "0.3.0"
 
 [dependencies.rspotify]
 default-features = false
-features = ["client-ureq", "ureq-rustls-tls"]
+features = ["client-ureq", "ureq-native-tls"]
 version = "0.13.1"
 
 [dependencies.cursive]


### PR DESCRIPTION
reqwest uses native TLS, but rspotify with ureq currently uses rustls, i.e. ncspot bundles rustls and is linked with the system TLS library at the same time.

This has already been fixed in 80da5a8, but this commit has been reverted in aeff120 due to a bug in rspotify that was fixed in 0.13.1 (ramsayleung/rspotify#471).

This time I properly tested that it works.

Related to #1159 #1153