### PR TITLE
docs: add Snapcraft installation source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add configuration variable to set Librespot AP port
+- Instructions for installation with `snap`
 
 ### Fixed
 - All requests are correctly proxied when the relevant environment variables are set

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ free accounts.
 - Automatic authentication using a password manager
 
 ## Installation
-ncspot is available on macOS (Homebrew), Windows (Scoop, WinGet), Linux (native package and Flathub) and the
-BSD's. Detailed installation instructions for each platform can be found [here](/doc/users.md).
+ncspot is available on macOS (Homebrew), Windows (Scoop, WinGet), Linux (native package, Flathub and
+Snapcraft) and the BSD's. Detailed installation instructions for each platform can be found
+[here](/doc/users.md).
 
 ## Configuration
 A configuration file can be provided. The default location is `~/.config/ncspot`. Detailed

--- a/doc/users.md
+++ b/doc/users.md
@@ -26,6 +26,7 @@ winget install hrkfdn.ncspot
 ### On Linux
 <div>
 <a href="https://flathub.org/apps/details/io.github.hrkfdn.ncspot"><img width="130" alt="Download on Flathub" src="https://flathub.org/assets/badges/flathub-badge-en.png"/></a>
+<a href="https://snapcraft.io/ncspot"><img alt="Download on Snapcraft" src="https://snapcraft.io//ncspot/badge.svg"/></a>
 </div>
 
 Your distribution may have packaged `ncspot` in its package repository.


### PR DESCRIPTION
The Snapcraft installation method was removed in the past as the package disappeared from Snapcraft. It seems to be back and maintained, so it should be back in the documentation.

## Describe your changes

- Mention the Snapcraft installation method in the documentation and add the badge

## Issue ticket number and link

\/

## Checklist before requesting a review
- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
