### PR TITLE
Clippy: warn `enum_glob_use`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
 ]
 
 [workspace.lints.clippy]
+enum_glob_use = "warn"
 use_self = "deny"
 multiple_inherent_impl = "deny"
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::enum_glob_use)]
+
 use cursive::theme::BaseColor::*;
 use cursive::theme::Color::*;
 use cursive::theme::PaletteColor::*;


### PR DESCRIPTION
## Describe your changes

Warn `enum_glob_use`. This mostly has to do with my own code.

The rationale behind this is best explained by [this video](https://youtu.be/8j_FbjiowvE?t=97).

## Checklist before requesting a review

No user facing changes.

- [ ] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [ ] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
