### PR TITLE
chore(toolchain): update

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.77.1"
+channel = "1.77.2"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Automatic change by the [update-rust-toolchain](https://github.com/a-kenji/update-rust-toolchain) Github Action.

Github Actions will not run workflows on pull requests which are opened by a GitHub Action.

For examples on how to run an workflows on this pr, please go to the [readme](https://github.com/a-kenji/update-rust-toolchain/blob/main/README.md#running-github-actions-on-the-action).