### PR TITLE
cfg fix for linux

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -103,7 +103,7 @@ pub fn user_runtime_directory() -> Option<PathBuf> {
 
     if let Some(xdg_runtime_directory) = xdg_runtime_directory() {
         Some(xdg_runtime_directory.join("ncspot"))
-    } else if cfg!(linux) && linux_runtime_directory.exists() {
+    } else if cfg!(target_os = "linux") && linux_runtime_directory.exists() {
         Some(linux_runtime_directory.join("ncspot"))
     } else if unix_runtime_directory.exists() {
         Some(unix_runtime_directory.join(format!("ncspot-{}", unsafe { libc::getuid() })))


### PR DESCRIPTION
## Describe your changes
changed cfg!(linux) to cfg!(target_os = "linux") since the former is not actually valid, but produces no bug. this wasn't causing any problem that i know of, but if the code is in here it should probably do what it says, or be removed

## Issue ticket number and link
no issue created, just saw a warning when installing from master (though this warning is not showing up again for some reason)

## Checklist before requesting a review
- [ ] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [ ] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
