### PR TITLE
chore(toolchain): update

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.77.2"
+channel = "1.78.0"
 components = ["rustfmt", "clippy", "rust-analyzer"]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -120,7 +120,7 @@ impl CommandManager {
                         queue.len(),
                         self.queue.get_current_index()
                     );
-                    s.queuestate.queue = queue.clone();
+                    s.queuestate.queue.clone_from(&queue);
                     s.queuestate.random_order = self.queue.get_random_order();
                     s.queuestate.current_track = self.queue.get_current_index();
                     s.queuestate.track_progress = self.spotify.get_current_progress();


### PR DESCRIPTION
Automatic change by the [update-rust-toolchain](https://github.com/a-kenji/update-rust-toolchain) Github Action.

Github Actions will not run workflows on pull requests which are opened by a GitHub Action.

For examples on how to run an workflows on this pr, please go to the [readme](https://github.com/a-kenji/update-rust-toolchain/blob/main/README.md#running-github-actions-on-the-action).