### PR TITLE
style(editorconfig): add EditorConfig file for consistent style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+insert_final_newline = false
+
+[*.rs]
+max_line_length = 100
+
+[*.md]
+max_line_length = 100


### PR DESCRIPTION
Add an EditorConfig file to ensure all editors know how to edit files correctly. Apply conservative settings based on the existing files. Rust options are based on the defaults of `rustfmt`.

Wondering whether the repository should include one of those `.vscode/settings.json` files to recommend the EditorConfig extension as Visual Studio Code doesn't come with support for EditorConfig by default. I'm not a fan of adding editor-specific files to a repository but I guess it would benefit the project if files (other than Rust files which are formatted anyway) have a consistent style.

## Describe your changes
- Add an `.editorconfig` file with options based on existing files

## Issue ticket number and link
\/

## Checklist before requesting a review
- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
