### PR TITLE
fix: support localized Spotify URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Handling localized Spotify URLs
+
 ## [1.1.1] - 2024-05-10
 
 ### Added

--- a/src/spotify_url.rs
+++ b/src/spotify_url.rs
@@ -98,7 +98,7 @@ mod tests {
         );
         test_cases.insert(
             "https://open.spotify.com/intl-pt/track/3Kj2M9gRU1Lwf5eiNjBtBp",
-            SpotifyUrl::new("3Kj2M9gRU1Lwf5eiNjBtBp", UriType::Track)
+            SpotifyUrl::new("3Kj2M9gRU1Lwf5eiNjBtBp", UriType::Track),
         );
         test_cases.insert(
             "https://open.spotify.com/user/~villainy~/playlist/0OgoSs65CLDPn6AF6tsZVg",

--- a/src/spotify_url.rs
+++ b/src/spotify_url.rs
@@ -47,8 +47,11 @@ impl SpotifyUrl {
 
         let mut path_segments = url.path_segments()?;
 
-        let entity = path_segments.next()?;
+        let mut entity = path_segments.next()?;
 
+        if entity.to_lowercase().as_str().starts_with("intl-") {
+            entity = path_segments.next()?
+        }
         let uri_type = match entity.to_lowercase().as_str() {
             "album" => Some(UriType::Album),
             "artist" => Some(UriType::Artist),
@@ -92,6 +95,10 @@ mod tests {
         test_cases.insert(
             "https://open.spotify.com/track/6fRJg3R90w0juYoCJXxj2d",
             SpotifyUrl::new("6fRJg3R90w0juYoCJXxj2d", UriType::Track),
+        );
+        test_cases.insert(
+            "https://open.spotify.com/intl-pt/track/3Kj2M9gRU1Lwf5eiNjBtBp",
+            SpotifyUrl::new("3Kj2M9gRU1Lwf5eiNjBtBp", UriType::Track)
         );
         test_cases.insert(
             "https://open.spotify.com/user/~villainy~/playlist/0OgoSs65CLDPn6AF6tsZVg",


### PR DESCRIPTION
## Describe your changes
Fixed issue where localized strings weren't properly handled.

## Issue ticket number and link
[#1455](https://github.com/hrkfdn/ncspot/issues/1455)

## Checklist before requesting a review
- [ ] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
