### PR TITLE
style(vscode): add EditorConfig extension recommendation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 indent_style = space
 indent_size = 4
 charset = utf-8
-insert_final_newline = false
+insert_final_newline = true
 
 [*.rs]
 max_line_length = 100

--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,6 @@
 
 tags
 
-/.vscode/
-
 # Ignore generated resources
 *.1
 /misc/_ncspot

--- a/.vscode/.gitignore
+++ b/.vscode/.gitignore
@@ -1,0 +1,3 @@
+/*
+!/.gitignore
+!/extensions.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "editorconfig.editorconfig"
+    ]
+}


### PR DESCRIPTION
As Visual Studio Code is the most popular editor at the moment, it makes sense to recommend the EditorConfig extension because it's not included by default. Also enable the final newline in files again as that was the default until the EditorConfig file was added.

## Describe your changes
- Add extension recommendation file for Visual Studio Code and recommend the EditorConfig extension
- Change the `insert_final_newline` option in the EditorConfig back to `true`

## Issue ticket number and link
\/

## Checklist before requesting a review
- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
