### PR TITLE
chore(toolchain): update

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.79.0"
 components = ["rustfmt", "clippy", "rust-analyzer"]

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -32,7 +32,7 @@ use crate::spotify_worker::{Worker, WorkerCommand};
 
 /// One percent of the maximum supported [Player] volume, used when setting the volume to a certain
 /// percent.
-pub const VOLUME_PERCENT: u16 = ((u16::max_value() as f64) * 1.0 / 100.0) as u16;
+pub const VOLUME_PERCENT: u16 = ((u16::MAX as f64) * 1.0 / 100.0) as u16;
 
 /// Events sent by the [Player].
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]


### PR DESCRIPTION
Automatic change by the [update-rust-toolchain](https://github.com/a-kenji/update-rust-toolchain) Github Action.

Github Actions will not run workflows on pull requests which are opened by a GitHub Action.

For examples on how to run an workflows on this pr, please go to the [readme](https://github.com/a-kenji/update-rust-toolchain/blob/main/README.md#running-github-actions-on-the-action).