### PR TITLE
docs: Rename `ap-port` option as `ap_port`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.1] - 2024-05-10
 
 ### Added
-- `ap-port` configuration variable to choose what Spotify access point port to use
+- `ap_port` configuration variable to choose what Spotify access point port to use
 - Instructions for installation with `snap`
 
 ### Fixed

--- a/doc/users.md
+++ b/doc/users.md
@@ -267,7 +267,7 @@ Possible configuration values are:
 | `[notification_format]`         | Set the text displayed in notifications<sup>[4]</sup>          | See [notification formatting](#notification-formatting)                               |                     |
 | `[theme]`                       | Custom theme                                                   | See [custom theme](#theming)                                                          |                     |
 | `[keybindings]`                 | Custom keybindings                                             | See [custom keybindings](#custom-keybindings)                                         |                     |
-| `ap-port`                       | Set ap-port for librespot (for restrictive firewalls)          | `80`, `443`, `4070`                                                                   |                     |
+| `ap_port`                       | Set ap-port for librespot (for restrictive firewalls)          | `80`, `443`, `4070`                                                                   |                     |
 
 1. If built with the `cover` feature.
 2. By default the statusbar will show a play icon when a track is playing and


### PR DESCRIPTION
#1420 introduced the option `ac_port` to specify the port used by librespot.
This option works great, except when following the documentation and example only.

- The option is named `ap-port` in librespot.
- The option is named `ap_port` in [ConfigValues](https://github.com/hrkfdn/ncspot/blob/9624c03264bb4038138f03374c4bfb70db7bc850/src/config.rs#L105).
- However, the option is named `ac-port` in the documentation and in #1420, which doesn't work, as described below.

In ncspot/config.toml:
- ❌ `ap-port = 443` does nothing, librespot uses port 4070
- ✅ `ap_port = 443` librespot uses HTTPS

## Describe your changes
Rename `ap-port` option by `ap_port` in the documentation.

## Issue ticket number and link

## Checklist before requesting a review
- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [ ] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)

## Before merge
Should the changelog be updated too?
Changelog of 1.1.1 contains `ap-port`, which is misleading.