### PR TITLE
Add Seeked signal to Mpris interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Emit MPRIS `Seeked` signal
+
 ### Fixed
 
 - Switch to OAuth2 login mechanism

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -313,6 +313,10 @@ impl Queue {
                     move || send_notification(&summary_txt, &body_txt, cover_url)
                 });
             }
+
+            // Send a Seeked signal at start of new track
+            #[cfg(feature = "mpris")]
+            self.spotify.notify_seeked(0);
         }
 
         if reshuffle && self.get_shuffle() {

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -433,13 +433,15 @@ impl Spotify {
 
     /// Send a Seeked signal on Mpris interface
     #[cfg(feature = "mpris")]
-    pub fn notify_seeked(&self, position: u32) {
-        if let Some(mpris_manager) = self.mpris.lock().unwrap().as_ref() {
-            info!("Seeked event");
-            // Mpris spec requires microseconds
-            let new_position = position * 1000;
-            mpris_manager.send(MprisCommand::EmitSeekedStatus(new_position.into()));
-        }
+    pub fn notify_seeked(&self, position_ms: u32) {
+        let new_position = Duration::from_millis(position_ms.into());
+        let command = MprisCommand::EmitSeekedStatus(
+            new_position
+                .as_micros()
+                .try_into()
+                .expect("track position exceeds MPRIS datatype"),
+        );
+        self.send_mpris(command);
     }
 
     /// Set the current volume of the [Player]. If `notify` is true, also notify MPRIS clients about


### PR DESCRIPTION
NB I am new to Rust so may have made some horrible mistakes in here!

## Describe your changes

The Mpris2 spec includes a `Seeked` signal which should be fired when the track position changes in an unexpected way i.e. when the user seeks to a different part of the track.

This PR implements this signal on seek events and also when a new track begins. The latter is not strictly required but has been observed in other players (e.g. VLC).

## Issue ticket number and link

Closes #1492

## Checklist before requesting a review
- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
