### PR TITLE
MPRIS: Restructuring and cleanup

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -22,7 +22,7 @@ use crate::{authentication, ui, utils};
 use crate::{command, queue, spotify};
 
 #[cfg(feature = "mpris")]
-use crate::mpris::{self, MprisCommand, MprisManager};
+use crate::mpris::{self, MprisManager};
 
 #[cfg(unix)]
 use crate::ipc::{self, IpcSocket};

--- a/src/application.rs
+++ b/src/application.rs
@@ -22,7 +22,7 @@ use crate::{authentication, ui, utils};
 use crate::{command, queue, spotify};
 
 #[cfg(feature = "mpris")]
-use crate::mpris::{self, MprisManager};
+use crate::mpris::MprisManager;
 
 #[cfg(unix)]
 use crate::ipc::{self, IpcSocket};
@@ -68,9 +68,6 @@ pub struct Application {
     /// Internally shared
     event_manager: EventManager,
     /// An IPC implementation using the D-Bus MPRIS protocol, used to control and inspect ncspot.
-    #[cfg(feature = "mpris")]
-    mpris_manager: MprisManager,
-    /// An IPC implementation using a Unix domain socket, used to control and inspect ncspot.
     #[cfg(unix)]
     ipc: Option<IpcSocket>,
     /// The object to render to the terminal.
@@ -130,7 +127,7 @@ impl Application {
         ));
 
         #[cfg(feature = "mpris")]
-        let mpris_manager = mpris::MprisManager::new(
+        let mpris_manager = MprisManager::new(
             event_manager.clone(),
             queue.clone(),
             library.clone(),
@@ -229,8 +226,6 @@ impl Application {
             queue,
             spotify,
             event_manager,
-            #[cfg(feature = "mpris")]
-            mpris_manager,
             #[cfg(unix)]
             ipc,
             cursive,

--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -464,13 +464,14 @@ impl MprisPlayer {
 
 /// Commands to control the [MprisManager] worker thread.
 #[derive(Debug)]
+#[allow(clippy::enum_variant_names)]
 pub enum MprisCommand {
     /// Emit playback status
-    Playback,
+    EmitPlaybackStatus,
     /// Emit volume
-    Volume,
+    EmitVolumeStatus,
     /// Emit metadata
-    Metadata,
+    EmitMetadataStatus,
 }
 
 /// An MPRIS server that internally manager a thread which can be sent commands. This is internally
@@ -528,14 +529,14 @@ impl MprisManager {
         loop {
             let ctx = player_iface_ref.signal_context();
             match rx.next().await {
-                Some(MprisCommand::Playback) => {
+                Some(MprisCommand::EmitPlaybackStatus) => {
                     player_iface.playback_status_changed(ctx).await?;
                 }
-                Some(MprisCommand::Volume) => {
+                Some(MprisCommand::EmitVolumeStatus) => {
                     info!("sending MPRIS volume update signal");
                     player_iface.volume_changed(ctx).await?;
                 }
-                Some(MprisCommand::Metadata) => {
+                Some(MprisCommand::EmitMetadataStatus) => {
                     player_iface.metadata_changed(ctx).await?;
                 }
                 None => break,

--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -465,11 +465,12 @@ impl MprisPlayer {
 /// Commands to control the [MprisManager] worker thread.
 #[derive(Debug)]
 pub enum MprisCommand {
-    /// Notify about playback status and metadata updates.
-    PlaybackUpdate,
-    /// Notify about volume updates.
-    VolumeUpdate,
-    MetadataUpdate,
+    /// Emit playback status
+    Playback,
+    /// Emit volume
+    Volume,
+    /// Emit metadata
+    Metadata,
 }
 
 /// An MPRIS server that internally manager a thread which can be sent commands. This is internally
@@ -527,14 +528,14 @@ impl MprisManager {
         loop {
             let ctx = player_iface_ref.signal_context();
             match rx.next().await {
-                Some(MprisCommand::PlaybackUpdate) => {
+                Some(MprisCommand::Playback) => {
                     player_iface.playback_status_changed(ctx).await?;
                 }
-                Some(MprisCommand::VolumeUpdate) => {
+                Some(MprisCommand::Volume) => {
                     info!("sending MPRIS volume update signal");
                     player_iface.volume_changed(ctx).await?;
                 }
-                Some(MprisCommand::MetadataUpdate) => {
+                Some(MprisCommand::Metadata) => {
                     player_iface.metadata_changed(ctx).await?;
                 }
                 None => break,

--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -463,11 +463,13 @@ impl MprisPlayer {
 }
 
 /// Commands to control the [MprisManager] worker thread.
+#[derive(Debug)]
 pub enum MprisCommand {
     /// Notify about playback status and metadata updates.
     NotifyPlaybackUpdate,
     /// Notify about volume updates.
     NotifyVolumeUpdate,
+    NotifyMetadataUpdate,
 }
 
 /// An MPRIS server that internally manager a thread which can be sent commands. This is internally
@@ -527,11 +529,13 @@ impl MprisManager {
             match rx.next().await {
                 Some(MprisCommand::NotifyPlaybackUpdate) => {
                     player_iface.playback_status_changed(ctx).await?;
-                    player_iface.metadata_changed(ctx).await?;
                 }
                 Some(MprisCommand::NotifyVolumeUpdate) => {
                     info!("sending MPRIS volume update signal");
                     player_iface.volume_changed(ctx).await?;
+                }
+                Some(MprisCommand::NotifyMetadataUpdate) => {
+                    player_iface.metadata_changed(ctx).await?;
                 }
                 None => break,
             }

--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -466,10 +466,10 @@ impl MprisPlayer {
 #[derive(Debug)]
 pub enum MprisCommand {
     /// Notify about playback status and metadata updates.
-    NotifyPlaybackUpdate,
+    PlaybackUpdate,
     /// Notify about volume updates.
-    NotifyVolumeUpdate,
-    NotifyMetadataUpdate,
+    VolumeUpdate,
+    MetadataUpdate,
 }
 
 /// An MPRIS server that internally manager a thread which can be sent commands. This is internally
@@ -527,14 +527,14 @@ impl MprisManager {
         loop {
             let ctx = player_iface_ref.signal_context();
             match rx.next().await {
-                Some(MprisCommand::NotifyPlaybackUpdate) => {
+                Some(MprisCommand::PlaybackUpdate) => {
                     player_iface.playback_status_changed(ctx).await?;
                 }
-                Some(MprisCommand::NotifyVolumeUpdate) => {
+                Some(MprisCommand::VolumeUpdate) => {
                     info!("sending MPRIS volume update signal");
                     player_iface.volume_changed(ctx).await?;
                 }
-                Some(MprisCommand::NotifyMetadataUpdate) => {
+                Some(MprisCommand::MetadataUpdate) => {
                     player_iface.metadata_changed(ctx).await?;
                 }
                 None => break,

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -8,7 +8,7 @@ use notify_rust::Notification;
 use rand::prelude::*;
 use strum_macros::Display;
 
-use crate::config::{Config};
+use crate::config::Config;
 use crate::library::Library;
 use crate::model::playable::Playable;
 use crate::spotify::PlayerEvent;

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -8,10 +8,9 @@ use notify_rust::Notification;
 use rand::prelude::*;
 use strum_macros::Display;
 
-use crate::config::{Config, PlaybackState};
+use crate::config::{Config};
 use crate::library::Library;
 use crate::model::playable::Playable;
-use crate::mpris::MprisCommand;
 use crate::spotify::PlayerEvent;
 use crate::spotify::Spotify;
 

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -317,7 +317,7 @@ impl Spotify {
         ));
 
         #[cfg(feature = "mpris")]
-        self.send_mpris(MprisCommand::NotifyMetadataUpdate);
+        self.send_mpris(MprisCommand::MetadataUpdate);
     }
 
     /// Update the cached status of the [Player]. This makes sure the status
@@ -343,7 +343,7 @@ impl Spotify {
         *status = new_status;
 
         #[cfg(feature ="mpris")]
-        self.send_mpris(MprisCommand::NotifyPlaybackUpdate);
+        self.send_mpris(MprisCommand::PlaybackUpdate);
     }
 
     /// Reset the time tracking stats for the current song. This should be called when a new song is
@@ -435,7 +435,7 @@ impl Spotify {
         // MPRIS implementation.
         if notify {
             #[cfg(feature = "mpris")]
-            self.send_mpris(MprisCommand::NotifyVolumeUpdate)
+            self.send_mpris(MprisCommand::VolumeUpdate)
         }
     }
 

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -17,7 +17,7 @@ use librespot_playback::config::PlayerConfig;
 use librespot_playback::mixer::softmixer::SoftMixer;
 use librespot_playback::mixer::MixerConfig;
 use librespot_playback::player::Player;
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 use tokio::sync::mpsc;
 use url::Url;
 
@@ -315,6 +315,9 @@ impl Spotify {
             start_playing,
             position_ms,
         ));
+
+        #[cfg(feature = "mpris")]
+        self.send_mpris(MprisCommand::NotifyMetadataUpdate);
     }
 
     /// Update the cached status of the [Player]. This makes sure the status
@@ -338,6 +341,9 @@ impl Spotify {
 
         let mut status = self.status.write().unwrap();
         *status = new_status;
+
+        #[cfg(feature ="mpris")]
+        self.send_mpris(MprisCommand::NotifyPlaybackUpdate);
     }
 
     /// Reset the time tracking stats for the current song. This should be called when a new song is
@@ -359,6 +365,17 @@ impl Spotify {
             PlayerEvent::Playing(_) => self.pause(),
             PlayerEvent::Paused(_) => self.play(),
             _ => (),
+        }
+    }
+
+    /// Send an [MprisCommand] to the mpris thread.
+    #[cfg(feature ="mpris")]
+    fn send_mpris(&self, cmd: MprisCommand) {
+        debug!("Sending mpris command: {:?}", cmd);
+        if let Some(mpris_manager) = self.mpris.lock().unwrap().as_ref() {
+            mpris_manager.send(cmd);
+        } else {
+            warn!("mpris context is unitialized");
         }
     }
 
@@ -418,10 +435,7 @@ impl Spotify {
         // MPRIS implementation.
         if notify {
             #[cfg(feature = "mpris")]
-            if let Some(mpris_manager) = self.mpris.lock().unwrap().as_ref() {
-                info!("updating MPRIS volume");
-                mpris_manager.send(MprisCommand::NotifyVolumeUpdate);
-            }
+            self.send_mpris(MprisCommand::NotifyVolumeUpdate)
         }
     }
 

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -317,7 +317,7 @@ impl Spotify {
         ));
 
         #[cfg(feature = "mpris")]
-        self.send_mpris(MprisCommand::MetadataUpdate);
+        self.send_mpris(MprisCommand::Metadata);
     }
 
     /// Update the cached status of the [Player]. This makes sure the status
@@ -342,8 +342,8 @@ impl Spotify {
         let mut status = self.status.write().unwrap();
         *status = new_status;
 
-        #[cfg(feature ="mpris")]
-        self.send_mpris(MprisCommand::PlaybackUpdate);
+        #[cfg(feature = "mpris")]
+        self.send_mpris(MprisCommand::Playback);
     }
 
     /// Reset the time tracking stats for the current song. This should be called when a new song is
@@ -369,7 +369,7 @@ impl Spotify {
     }
 
     /// Send an [MprisCommand] to the mpris thread.
-    #[cfg(feature ="mpris")]
+    #[cfg(feature = "mpris")]
     fn send_mpris(&self, cmd: MprisCommand) {
         debug!("Sending mpris command: {:?}", cmd);
         if let Some(mpris_manager) = self.mpris.lock().unwrap().as_ref() {
@@ -435,7 +435,7 @@ impl Spotify {
         // MPRIS implementation.
         if notify {
             #[cfg(feature = "mpris")]
-            self.send_mpris(MprisCommand::VolumeUpdate)
+            self.send_mpris(MprisCommand::Volume)
         }
     }
 

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -317,7 +317,7 @@ impl Spotify {
         ));
 
         #[cfg(feature = "mpris")]
-        self.send_mpris(MprisCommand::Metadata);
+        self.send_mpris(MprisCommand::EmitMetadataStatus);
     }
 
     /// Update the cached status of the [Player]. This makes sure the status
@@ -343,7 +343,7 @@ impl Spotify {
         *status = new_status;
 
         #[cfg(feature = "mpris")]
-        self.send_mpris(MprisCommand::Playback);
+        self.send_mpris(MprisCommand::EmitPlaybackStatus);
     }
 
     /// Reset the time tracking stats for the current song. This should be called when a new song is
@@ -435,7 +435,7 @@ impl Spotify {
         // MPRIS implementation.
         if notify {
             #[cfg(feature = "mpris")]
-            self.send_mpris(MprisCommand::Volume)
+            self.send_mpris(MprisCommand::EmitVolumeStatus)
         }
     }
 


### PR DESCRIPTION
## Describe your changes

My pr addresses some of the inconsistencies in ncspot's mpris
implementation. While the previous logic is technically good enough, it
is inflexible and reports redundant information.
I've tried to address those issues to make it easier for software, that processes mpris events in
some way, to accurately react to player updates.

- 'Metadata' and 'Playback' updates have been separated into their own
  command
- Mpris commands are only emitted from within spotify.rs
- Some parts of the application creation logic has been
  restructured to allow for mpris events to be emitted upon startup
    - The initial song loading code has been moved from 'Queue::new'
      into 'Application::new'.

## Issue ticket number and link

This closes  #1514 

## Checklist before requesting a review
- [ ] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [ ] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)

Edit: An example of software that requires strict MPRIS compliance would be the [MPRIS module for yambar](https://codeberg.org/dnkl/yambar/pulls/402) that I am working on.

