### PR TITLE
fix(cover): init variables with value of 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [Unreleased]
+
+### Fixed
+
+- Initialize variables used in cover with value 1 to avoid divide by zero error
+
 ## [1.2.0] - 2024-10-15
 
 ### Added

--- a/src/ui/cover.rs
+++ b/src/ui/cover.rs
@@ -33,7 +33,7 @@ impl CoverView {
     pub fn new(queue: Arc<Queue>, library: Arc<Library>, config: &Config) -> Self {
         // Determine size of window both in pixels and chars
         let (rows, cols, mut xpixels, mut ypixels) = unsafe {
-            let query: (u16, u16, u16, u16) = (0, 0, 0, 0);
+            let query: (u16, u16, u16, u16) = (1, 1, 0, 0);
             ioctl(1, TIOCGWINSZ, &query);
             query
         };


### PR DESCRIPTION
## Describe your changes
Initializes `rows` and `cols` with a value of 1 instead of 0 to avoid dividing by zero.
## Issue ticket number and link
https://github.com/hrkfdn/ncspot/issues/1528
## Checklist before requesting a review
- [ ] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [X] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
