### PR TITLE
fix(cover): Add mut to fix incorrect get of windowsize in cover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix error in fetching of window size leading to crashes with cover feature
+
 ## [1.2.0] - 2024-10-15
 
 ### Added

--- a/src/ui/cover.rs
+++ b/src/ui/cover.rs
@@ -33,8 +33,8 @@ impl CoverView {
     pub fn new(queue: Arc<Queue>, library: Arc<Library>, config: &Config) -> Self {
         // Determine size of window both in pixels and chars
         let (rows, cols, mut xpixels, mut ypixels) = unsafe {
-            let query: (u16, u16, u16, u16) = (0, 0, 0, 0);
-            ioctl(1, TIOCGWINSZ, &query);
+            let mut query: (u16, u16, u16, u16) = (0, 0, 0, 0);
+            ioctl(1, TIOCGWINSZ, &mut query);
             query
         };
 


### PR DESCRIPTION
## Describe your changes
Something seems to have broken the return of the variables from the unsafe block, leading to division by zero.
By making the query variable mutable the return works. 

## Issue ticket number and link
#1528

## Checklist before requesting a review
- [ ] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
