### PR TITLE
fix: missing automatic man page generation for subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Missing automatic man page generation for subcommands
+
 ## [1.2.1] - 2024-10-31
 
 ### Fixed
@@ -215,6 +221,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Albums with more than 50 songs not showing all the songs when viewed in the library
 - Bug that could cause items to not load until the screen is filled on bigger screens
 
+[Unreleased]: https://github.com/hrkfdn/ncspot/compare/v1.2.1...HEAD
 [1.2.1]: https://github.com/hrkfdn/ncspot/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/hrkfdn/ncspot/compare/v1.1.2...v1.2.0
 [1.1.2]: https://github.com/hrkfdn/ncspot/compare/v1.1.1...v1.1.2

--- a/doc/package_maintainers.md
+++ b/doc/package_maintainers.md
@@ -18,7 +18,7 @@ generated. Execute `cargo xtask --help` for more information.
 - LICENSE
 - images/logo.svg (optional)
 - misc/ncspot.desktop (for Linux systems)
-- misc/ncspot.1 (for Linux systems)
+- misc/*.1 (for Linux systems)
 - misc/ncspot.bash (bash completions)
 - misc/\_ncspot (zsh completions)
 - misc/ncspot.fish (fish completions)

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -61,7 +61,7 @@ automation.",
                     .long("output")
                     .value_name("PATH")
                     .default_value("misc")
-                    .help("Output directory for the generated man page.")
+                    .help("Output directory for the generated man pages.")
                     .value_parser(PathBufValueParser::new())])
                 .about("Automatic man page generation."),
             clap::Command::new("generate-shell-completion")
@@ -110,15 +110,12 @@ fn generate_manpage(subcommand_arguments: &ArgMatches) -> Result<(), DynError> {
         .get_one::<PathBuf>("output")
         .unwrap_or(&default_output_directory);
     let cmd = ncspot::program_arguments();
-    let man = clap_mangen::Man::new(cmd);
-    let mut buffer: Vec<u8> = Default::default();
 
     if *output_directory == default_output_directory {
         fs::create_dir_all(DEFAULT_OUTPUT_DIRECTORY)?;
     }
 
-    man.render(&mut buffer)?;
-    std::fs::write(output_directory.join("ncspot.1"), buffer)?;
+    clap_mangen::generate_to(cmd, output_directory)?;
 
     Ok(())
 }


### PR DESCRIPTION
The main man page would point to man pages for subcommands, which weren't created automatically by the man page xtask.

## Describe your changes

- Use the new `clap_mangen::generate_to()` function to generate all man pages automatically
- Tweak some documentation to mention multiple man pages being generated

## Issue ticket number and link

\/

## Checklist before requesting a review
- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
