### PR TITLE
fix(auth): Switch back to Spotify client ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Missing automatic man page generation for subcommands
+- Users were forced to reset password when using ncspot
 
 ## [1.2.1] - 2024-10-31
 

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -7,7 +7,6 @@ use crate::config::{self, Config};
 use crate::spotify::Spotify;
 
 pub const SPOTIFY_CLIENT_ID: &str = "65b708073fc0480ea92a077233ca87bd";
-pub const NCSPOT_CLIENT_ID: &str = "d420a117a32841c2b3474932e49fb54b";
 pub const CLIENT_REDIRECT_URI: &str = "http://127.0.0.1:8989/login";
 
 static OAUTH_SCOPES: &[&str] = &[

--- a/src/spotify_worker.rs
+++ b/src/spotify_worker.rs
@@ -1,4 +1,3 @@
-use crate::authentication;
 use crate::events::{Event, EventManager};
 use crate::model::playable::Playable;
 use crate::queue::QueueEvent;
@@ -75,7 +74,7 @@ impl Worker {
         let scopes = "user-read-private,playlist-read-private,playlist-read-collaborative,playlist-modify-public,playlist-modify-private,user-follow-modify,user-follow-read,user-library-read,user-library-modify,user-top-read,user-read-recently-played";
         session
             .token_provider()
-            .get_token_with_client_id(scopes, authentication::NCSPOT_CLIENT_ID)
+            .get_token(scopes)
             .map(|response| sender.send(response.ok()).expect("token channel is closed"))
             .await;
     }


### PR DESCRIPTION
This reverts commit fa298f4f44a66d5039749f589185ab61fefbcbdf.

Fixes #1547

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
