### PR TITLE
chore(auth): Remove credential program leftovers

### DIFF
--- a/doc/users.md
+++ b/doc/users.md
@@ -459,17 +459,3 @@ The credentials are stored in `librespot/credentials.json` in the user's cache d
 
 The `logout` command can be used to remove cached credentials. See
 [Vim-Like Commands](#vim-like-commands).
-
-### Using a Password Manager
-If you would like ncspot to retrieve your login data from command results,
-i.e. because you use a password manager like `pass`, you can add the following
-configuration:
-
-```toml
-[credentials]
-username_cmd = "echo username"
-password_cmd = "pass spotify.com/username"
-```
-
-Do note that this is only required for the initial login or when your credential
-token has expired.

--- a/src/config.rs
+++ b/src/config.rs
@@ -100,15 +100,7 @@ pub struct ConfigValues {
     pub statusbar_format: Option<String>,
     pub library_tabs: Option<Vec<LibraryTab>>,
     pub hide_display_names: Option<bool>,
-    pub credentials: Option<Credentials>,
     pub ap_port: Option<u16>,
-}
-
-/// Commands used to obtain user credentials automatically.
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
-pub struct Credentials {
-    pub username_cmd: Option<String>,
-    pub password_cmd: Option<String>,
 }
 
 /// The ncspot theme.


### PR DESCRIPTION
With the OAuth2 flow being default now the logic to fetch login credentials via external programs (i.e. `pass`) has become obsolote.

This change removes documentation/config leftovers.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [X] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [ ] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
