### PR TITLE
add %artist formatting option to only show single artist name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `%artist` formatting option to only show single artist name
+
 ### Fixed
 
 - Missing automatic man page generation for subcommands

--- a/doc/users.md
+++ b/doc/users.md
@@ -361,8 +361,9 @@ It's possible to customize how tracks are shown in Queue/Library views and the
 statusbar, whereas `statusbar_format` will hold the statusbar formatting and
 `[track_format]` the formatting for tracks in list views.
 If you don't define `center` for example, the default value will be used.
-Available options for tracks: `%artists`, `%title`, `%album`, `%saved`,
+Available options for tracks: `%artists`, `%artist`, `%title`, `%album`, `%saved`,
 `%duration`
+`%artists` will show all contributing artists, while `%artist` only shows the first listed artist
 
 Default configuration:
 

--- a/doc/users.md
+++ b/doc/users.md
@@ -362,8 +362,8 @@ statusbar, whereas `statusbar_format` will hold the statusbar formatting and
 `[track_format]` the formatting for tracks in list views.
 If you don't define `center` for example, the default value will be used.
 Available options for tracks: `%artists`, `%artist`, `%title`, `%album`, `%saved`,
-`%duration`
-`%artists` will show all contributing artists, while `%artist` only shows the first listed artist
+`%duration`.
+`%artists` will show all contributing artists, while `%artist` only shows the first listed artist.
 
 Default configuration:
 

--- a/src/model/playable.rs
+++ b/src/model/playable.rs
@@ -36,6 +36,15 @@ impl Playable {
                 .as_str(),
             )
             .replace(
+                "%artist",
+                if let Some(artists) = playable.artists() {
+                    artists.first().unwrap().clone().name
+                } else {
+                    String::new()
+                }
+                .as_str(),
+            )
+            .replace(
                 "%title",
                 match playable.clone() {
                     Self::Episode(episode) => episode.name,


### PR DESCRIPTION
## Changes
Added option to only show the first listed artist on a track.
### The problem and solution:
With `%artists`:
![image](https://github.com/user-attachments/assets/afd65ecb-d7ec-4b37-89b5-4488835fc93e)
With `%artist`:
![image](https://github.com/user-attachments/assets/6f2f8e37-e6a6-4ac9-b19e-906554d0a80f)
