### PR TITLE
docs: add missing password manager removal to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `%artist` formatting option to only show single artist name
 
+### Removed
+
+- Support for basic password managers as OAuth2 is now the only supported authentication flow
+
 ### Fixed
 
 - Missing automatic man page generation for subcommands
-- Users were forced to reset password when using ncspot
+- Bug causing forced password reset after using `ncpsot`
 
 ## [1.2.1] - 2024-10-31
 


### PR DESCRIPTION
As this is a breaking change, it should definitely be represented in the changelog, which is the primary source of information about any user-facing changes.

## Describe your changes
Add the removal of the password manager feature to the "Removed" section of the changelog.
Also update the wording for another item in the "Fixed" section to say exactly what was fixed.

## Issue ticket number and link
\/

## Checklist before requesting a review
- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)

(I'll also create a separate PR to remove some remaining documentation about the password manager feature.)