### PR TITLE
docs: remove remaining password manager documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ free accounts.
 - Support for a lot of platforms
 - Vim keybindings out of the box
 - IPC socket for remote control
-- Automatic authentication using a password manager
 
 ## Installation
 ncspot is available on macOS (Homebrew), Windows (Scoop, WinGet), Linux (native package, Flathub and

--- a/doc/users.md
+++ b/doc/users.md
@@ -452,8 +452,10 @@ cover_max_scale = 2
 ```
 
 ## Authentication
-`ncspot` prompts for a Spotify username and password on first launch, uses this
-to generate an OAuth token, and stores it to disk.
+`ncspot` uses OAuth2 for authentication. When launched for the first time, a link will be generated
+that can be opened in any browser. After logging in on the displayed page, you can start to use
+`ncspot`. The OAuth2 flow is the only supported one, as username/password authentication has been
+removed by Spotify.
 
 The credentials are stored in `librespot/credentials.json` in the user's cache directory. Run
 `ncspot info` to show the location of this directory.


### PR DESCRIPTION
## Describe your changes
Remove remaining password manager documentation and add some notes about the new OAuth2 flow.

## Issue ticket number and link
\/

## Checklist before requesting a review
- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)