### PR TITLE
feat(ci): Lint + Build for aarch64

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,14 +13,17 @@ jobs:
   publish:
     name: Publishing ${{ matrix.build_target }}
     runs-on: ${{ matrix.os }}
-    container: ${{ matrix.container }}
     strategy:
       matrix:
         include:
           - build_target: linux-x86_64
             os: ubuntu-latest
-            container: rust
             target: x86_64-unknown-linux-gnu
+            features: ''
+            dependencies: 'libpulse-dev libdbus-1-dev libncursesw5-dev libxcb-shape0-dev libxcb-xfixes0-dev'
+          - build_target: linux-arm64
+            os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
             features: ''
             dependencies: 'libpulse-dev libdbus-1-dev libncursesw5-dev libxcb-shape0-dev libxcb-xfixes0-dev'
           - build_target: macos-x86_64
@@ -53,17 +56,17 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: brew install portaudio pkg-config
       - name: Install Linux dependencies
-        if: startsWith(matrix.build_target, 'linux-')
+        if: runner.os == 'Linux'
         run: |
-          apt update
-          apt install -y ${{ matrix.dependencies }}
+          sudo apt update
+          sudo apt install -y ${{ matrix.dependencies }}
       - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry/index/
             ~/.cargo/registry/
             ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Running cargo build
         run: cargo build --release --target ${{ matrix.target }} ${{ matrix.features }}
       - name: Extract git tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,22 +19,18 @@ jobs:
         include:
           - build_target: linux-x86_64
             os: ubuntu-latest
-            artifact_suffix: linux-x86_64
             target: x86_64-unknown-linux-gnu
             features: ''
           - build_target: linux-arm64
             os: ubuntu-24.04-arm
-            artifact_suffix: linux-aarch64
             target: aarch64-unknown-linux-gnu
             features: ''
           - build_target: macos-aarch64
             os: macos-14
-            artifact_suffix: macos-aarch64
             target: aarch64-apple-darwin
             features: '--no-default-features --features rodio_backend,pancurses_backend'
           - build_target: windows-x86_64
             os: windows-latest
-            artifact_suffix: windows-x86_64
             target: x86_64-pc-windows-msvc
             features: '--no-default-features --features rodio_backend,pancurses_backend,share_clipboard,notify'
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ jobs:
             artifact_suffix: linux-x86_64
             target: x86_64-unknown-linux-gnu
             features: ''
+          - build_target: linux-arm64
+            os: ubuntu-24.04-arm
+            artifact_suffix: linux-aarch64
+            target: aarch64-unknown-linux-gnu
+            features: ''
           - build_target: macos-aarch64
             os: macos-14
             artifact_suffix: macos-aarch64
@@ -43,7 +48,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install rustup
         if: runner.os != 'Windows'
         shell: bash
@@ -58,7 +63,7 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: brew install portaudio pkg-config
       - name: Install Linux dependencies
-        if: matrix.os == 'ubuntu-latest'
+        if: runner.os == 'Linux'
         run: |
           sudo apt update
           sudo apt install libpulse-dev libdbus-1-dev libncursesw5-dev libxcb-shape0-dev libxcb-xfixes0-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `%artist` formatting option to only show single artist name
+- Build release for aarch64 on Linux
 
 ### Removed
 


### PR DESCRIPTION
## Describe your changes
Extend checks and release binary output to use [newly released](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/) Arm64 runners.

## Issue ticket number and link
- #1555

## Checklist before requesting a review
- [ ] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [ ] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
