### PR TITLE
Corrected incorrect comment

### DIFF
--- a/src/queue.rs
+++ b/src/queue.rs
@@ -158,7 +158,7 @@ impl Queue {
     }
 
     /// Append `tracks` after the currently playing item, taking into account
-    /// shuffle status. Returns the amount of added items.
+    /// shuffle status. Returns the first index(in `self.queue`) of added items.
     pub fn append_next(&self, tracks: &Vec<Playable>) -> usize {
         let mut q = self.queue.write().unwrap();
 


### PR DESCRIPTION
## Describe your changes
There is an error in the comment of `append_next` function in `queue.rs`.

## Issue ticket number and link
Didn't create an issue

## Checklist before requesting a review
- [ ] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [ ] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
