### PR TITLE
chore(toolchain): update

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.84.1"
+channel = "1.85.0"
 components = ["rustfmt", "clippy", "rust-analyzer"]

--- a/src/spotify_api.rs
+++ b/src/spotify_api.rs
@@ -382,7 +382,6 @@ impl WebApi {
                 Some(offset),
             )
         })
-        .take()
         .ok_or(())
     }
 


### PR DESCRIPTION
Automatic change by the [update-rust-toolchain](https://github.com/a-kenji/update-rust-toolchain) Github Action.

Github Actions will not run workflows on pull requests which are opened by a GitHub Action.

For examples on how to run an workflows on this pr, please go to the [readme](https://github.com/a-kenji/update-rust-toolchain/blob/main/README.md#running-github-actions-on-the-action).