### PR TITLE
fix: Skip unplayable tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Skip unplayable tracks
+
 ## [1.2.2]
 
 ### Added
@@ -231,6 +237,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Albums with more than 50 songs not showing all the songs when viewed in the library
 - Bug that could cause items to not load until the screen is filled on bigger screens
 
+[Unreleased]: https://github.com/hrkfdn/ncspot/compare/v1.2.2..HEAD
 [1.2.2]: https://github.com/hrkfdn/ncspot/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/hrkfdn/ncspot/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/hrkfdn/ncspot/compare/v1.1.2...v1.2.0

--- a/src/application.rs
+++ b/src/application.rs
@@ -41,9 +41,9 @@ pub fn setup_logging(filename: &Path) -> Result<(), fern::InitError> {
             ))
         })
         // Add blanket level filter -
-        .level(log::LevelFilter::Trace)
+        .level(log::LevelFilter::Debug)
         // Set runtime log level for modules
-        .level_for("librespot", log::LevelFilter::Debug)
+        .level_for("ncspot", log::LevelFilter::Trace)
         // Output to stdout, files, and other Dispatch configurations
         .chain(fern::log_file(filename)?)
         // Apply globally

--- a/src/model/playable.rs
+++ b/src/model/playable.rs
@@ -173,6 +173,10 @@ impl fmt::Display for Playable {
 }
 
 impl ListItem for Playable {
+    fn is_playable(&self) -> bool {
+        self.as_listitem().is_playable()
+    }
+
     fn is_playing(&self, queue: &Queue) -> bool {
         self.as_listitem().is_playing(queue)
     }

--- a/src/model/track.rs
+++ b/src/model/track.rs
@@ -336,7 +336,7 @@ impl ListItem for Track {
 
     #[inline]
     fn is_playable(&self) -> bool {
-        true
+        self.is_playable == Some(true)
     }
 
     fn as_listitem(&self) -> Box<dyn ListItem> {

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -29,6 +29,7 @@ use crate::model::playable::Playable;
 use crate::mpris::{MprisCommand, MprisManager};
 use crate::spotify_api::WebApi;
 use crate::spotify_worker::{Worker, WorkerCommand};
+use crate::traits::ListItem;
 
 /// One percent of the maximum supported [Player] volume, used when setting the volume to a certain
 /// percent.
@@ -316,6 +317,13 @@ impl Spotify {
     /// `start_playing` is true. Start playing from `position_ms` in the song.
     pub fn load(&self, track: &Playable, start_playing: bool, position_ms: u32) {
         info!("loading track: {:?}", track);
+
+        if !track.is_playable() {
+            warn!("track {:?} can not be played, skipping..", track);
+            self.events.send(Event::Player(PlayerEvent::FinishedTrack));
+            return;
+        }
+
         self.send_worker(WorkerCommand::Load(
             track.clone(),
             start_playing,


### PR DESCRIPTION
- fix: Skip unplayable tracks
  I think this worked before but must have regressed. The value `is_playable`
  was not taken into account and instead overshadowed by a dummy method.
 
  Fixes #1552
 
- chore: Tweak log levels a little
  Use `Debug` level for all modules except `ncspot`, which shows `Trace` level 
  logs by default.