### PR TITLE
fix: indicators were wrong

### DIFF
--- a/src/ui/statusbar.rs
+++ b/src/ui/statusbar.rs
@@ -58,8 +58,8 @@ impl StatusBar {
         };
 
         match status {
-            PlayerEvent::Playing(_) => indicators.0,
-            PlayerEvent::Paused(_) => indicators.1,
+            PlayerEvent::Playing(_) => indicators.1,
+            PlayerEvent::Paused(_) => indicators.0,
             PlayerEvent::Stopped | PlayerEvent::FinishedTrack => indicators.2,
         }
     }


### PR DESCRIPTION
I fixed the Indicators, as it was showing "Playing" when the track was paused, and "Paused" when the track was playing.