### PR TITLE
chore(toolchain): update

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.87.0"
 components = ["rustfmt", "clippy", "rust-analyzer"]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -51,7 +51,7 @@ pub fn cache_path_for_url(url: String) -> std::path::PathBuf {
 
 pub fn download(url: String, path: std::path::PathBuf) -> Result<(), std::io::Error> {
     let mut resp = reqwest::blocking::get(url)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        .map_err(std::io::Error::other)?;
 
     std::fs::create_dir_all(path.parent().unwrap())?;
     let mut file = std::fs::File::create(path)?;


### PR DESCRIPTION
Automatic change by the [update-rust-toolchain](https://github.com/a-kenji/update-rust-toolchain) Github Action.

Github Actions will not run workflows on pull requests which are opened by a GitHub Action.

For examples on how to run an workflows on this pr, please go to the [readme](https://github.com/a-kenji/update-rust-toolchain/blob/main/README.md#running-github-actions-on-the-action).