### PR TITLE
feat: add auth_port configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add a configuration option to change the authentication port
+
 ### Fixed
 
 - Skip unplayable tracks

--- a/doc/users.md
+++ b/doc/users.md
@@ -268,6 +268,7 @@ Possible configuration values are:
 | `[theme]`                       | Custom theme                                                   | See [custom theme](#theming)                                                          |                     |
 | `[keybindings]`                 | Custom keybindings                                             | See [custom keybindings](#custom-keybindings)                                         |                     |
 | `ap_port`                       | Set ap-port for librespot (for restrictive firewalls)          | `80`, `443`, `4070`                                                                   |                     |
+| `auth_port`                     | Set port for authenticating with Spotify                       | Integer                                                                               | `8989`              |
 
 1. If built with the `cover` feature.
 2. By default the statusbar will show a play icon when a track is playing and

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -7,7 +7,6 @@ use crate::config::{self, Config};
 use crate::spotify::Spotify;
 
 pub const SPOTIFY_CLIENT_ID: &str = "65b708073fc0480ea92a077233ca87bd";
-pub const CLIENT_REDIRECT_URI: &str = "http://127.0.0.1:8989/login";
 
 static OAUTH_SCOPES: &[&str] = &[
     "playlist-modify",
@@ -35,6 +34,12 @@ static OAUTH_SCOPES: &[&str] = &[
     "user-top-read",
 ];
 
+pub fn get_client_redirect_uri(configuration: &Config) -> Result<String, String> {
+    let auth_port = configuration.values().auth_port.unwrap_or(8989).to_string();
+    let redirect_url = format!("http://127.0.0.1:{auth_port}/login");
+    Ok(redirect_url)
+}
+
 /// Get credentials for use with librespot. This first tries to get cached credentials. If no cached
 /// credentials are available it will initiate the OAuth2 login process.
 pub fn get_credentials(configuration: &Config) -> Result<RespotCredentials, String> {
@@ -49,31 +54,31 @@ pub fn get_credentials(configuration: &Config) -> Result<RespotCredentials, Stri
             }
             None => {
                 info!("Attempting to login via OAuth2");
-                credentials_prompt(None)?
+                credentials_prompt(configuration, None)?
             }
         }
     };
 
     while let Err(error) = Spotify::test_credentials(configuration, credentials.clone()) {
         let error_msg = format!("{error}");
-        credentials = credentials_prompt(Some(error_msg))?;
+        credentials = credentials_prompt(configuration, Some(error_msg))?;
     }
     Ok(credentials)
 }
 
-fn credentials_prompt(error_message: Option<String>) -> Result<RespotCredentials, String> {
+fn credentials_prompt(configuration: &Config, error_message: Option<String>) -> Result<RespotCredentials, String> {
     if let Some(message) = error_message {
         eprintln!("Connection error: {message}");
     }
 
-    create_credentials()
+    create_credentials(configuration)
 }
 
-pub fn create_credentials() -> Result<RespotCredentials, String> {
+pub fn create_credentials(configuration: &Config) -> Result<RespotCredentials, String> {
     println!("To login you need to perform OAuth2 authorization using your web browser\n");
     get_access_token(
         SPOTIFY_CLIENT_ID,
-        CLIENT_REDIRECT_URI,
+        &get_client_redirect_uri(configuration)?,
         OAUTH_SCOPES.to_vec(),
     )
     .map(|token| RespotCredentials::with_access_token(token.access_token))

--- a/src/config.rs
+++ b/src/config.rs
@@ -101,6 +101,7 @@ pub struct ConfigValues {
     pub library_tabs: Option<Vec<LibraryTab>>,
     pub hide_display_names: Option<bool>,
     pub ap_port: Option<u16>,
+    pub auth_port: Option<u16>,
 }
 
 /// The ncspot theme.


### PR DESCRIPTION
## Describe your changes

Add a configuration option to set the authenticate port, by default its 8989

## Issue ticket number and link

#1637

## Checklist before requesting a review
- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
