### PR TITLE
feat: Use Spirc for player logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2127,6 +2127,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "librespot-connect"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2a21e9e19b906c6676b1a515fc5529d5414f69049f5a167dfb2ea3206e5a27"
+dependencies = [
+ "futures-util",
+ "librespot-core",
+ "librespot-playback",
+ "librespot-protocol",
+ "log",
+ "protobuf",
+ "rand 0.9.2",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-stream",
+ "uuid",
+]
+
+[[package]]
 name = "librespot-core"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2425,6 +2445,7 @@ dependencies = [
  "futures",
  "ioctl-rs",
  "libc",
+ "librespot-connect",
  "librespot-core",
  "librespot-oauth",
  "librespot-playback",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ fern = "0.7"
 futures = "0.3"
 ioctl-rs = {version = "0.2", optional = true}
 libc = "0.2.186"
+librespot-connect = "0.8.0"
 librespot-core = "0.8.0"
 librespot-oauth = "0.8.0"
 librespot-playback = {version = "0.8.0", default-features = false, features = ["native-tls"]}

--- a/src/application.rs
+++ b/src/application.rs
@@ -145,13 +145,11 @@ impl Application {
         let playback_state = configuration.state().playback_state.clone();
         let queue_state = configuration.state().queuestate.clone();
 
-        if let Some(playable) = queue.get_current() {
-            spotify.load(
-                &playable,
+        if queue.get_current().is_some() {
+            queue.load_current(
                 playback_state == PlaybackState::Playing,
                 queue_state.track_progress.as_millis() as u32,
             );
-            spotify.update_track();
             match playback_state {
                 PlaybackState::Stopped => {
                     spotify.stop();

--- a/src/application.rs
+++ b/src/application.rs
@@ -256,16 +256,18 @@ impl Application {
             }
             for event in self.event_manager.msg_iter() {
                 match event {
-                    Event::Player(state) => {
-                        trace!("event received: {state:?}");
-                        self.spotify.update_status(state.clone());
+                    Event::Player(event) => {
+                        trace!("player event received: {event:?}");
+                        self.spotify.handle_player_event(event.clone());
 
                         #[cfg(unix)]
-                        if let Some(ref ipc) = self.ipc {
-                            ipc.publish(&state, self.queue.get_current());
+                        if let Some(ref ipc) = self.ipc
+                            && let PlayerEvent::StatusChanged(ref status) = event
+                        {
+                            ipc.publish(status, self.queue.get_current());
                         }
 
-                        if state == PlayerEvent::FinishedTrack {
+                        if event == PlayerEvent::FinishedTrack {
                             self.queue.next(false);
                         }
                     }

--- a/src/application.rs
+++ b/src/application.rs
@@ -258,8 +258,17 @@ impl Application {
                         trace!("player event received: {event:?}");
                         self.spotify.handle_player_event(event.clone());
 
-                        if let PlayerEvent::TrackChanged(ref uri) = event {
-                            self.queue.sync_current_track(uri);
+                        match event {
+                            PlayerEvent::TrackChanged(ref uri) => {
+                                self.queue.sync_current_track(uri);
+                            }
+                            PlayerEvent::ShuffleChanged(shuffle) => {
+                                self.queue.sync_shuffle(shuffle);
+                            }
+                            PlayerEvent::RepeatChanged { context, track } => {
+                                self.queue.sync_repeat(context, track);
+                            }
+                            _ => {}
                         }
 
                         #[cfg(unix)]

--- a/src/application.rs
+++ b/src/application.rs
@@ -258,6 +258,10 @@ impl Application {
                         trace!("player event received: {event:?}");
                         self.spotify.handle_player_event(event.clone());
 
+                        if let PlayerEvent::TrackChanged(ref uri) = event {
+                            self.queue.sync_current_track(uri);
+                        }
+
                         #[cfg(unix)]
                         if let Some(ref ipc) = self.ipc
                             && let PlayerEvent::StatusChanged(ref status) = event

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -193,7 +193,7 @@ impl CommandManager {
                     .spotify
                     .volume()
                     .saturating_add(VOLUME_PERCENT * amount);
-                self.spotify.set_volume(volume, true);
+                self.spotify.set_volume(volume);
                 Ok(None)
             }
             Command::VolumeDown(amount) => {
@@ -202,7 +202,7 @@ impl CommandManager {
                     .volume()
                     .saturating_sub(VOLUME_PERCENT * amount);
                 debug!("vol {volume}");
-                self.spotify.set_volume(volume, true);
+                self.spotify.set_volume(volume);
                 Ok(None)
             }
             Command::Help => {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
 
 use crate::application::UserData;
 use crate::command::{
@@ -136,11 +135,7 @@ impl CommandManager {
                 Ok(None)
             }
             Command::Previous => {
-                if self.spotify.get_current_progress() < Duration::from_secs(5) {
-                    self.queue.previous();
-                } else {
-                    self.spotify.seek(0);
-                }
+                self.queue.previous();
                 Ok(None)
             }
             Command::Next => {

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -11,7 +11,7 @@ use tokio_util::codec::{FramedRead, FramedWrite, LinesCodec};
 
 use crate::events::{Event, EventManager};
 use crate::model::playable::Playable;
-use crate::spotify::PlayerEvent;
+use crate::spotify::PlayerStatus;
 
 pub struct IpcSocket {
     tx: Sender<Status>,
@@ -20,7 +20,7 @@ pub struct IpcSocket {
 
 #[derive(Clone, Debug, Serialize)]
 struct Status {
-    mode: PlayerEvent,
+    mode: PlayerStatus,
     playable: Option<Playable>,
 }
 
@@ -46,7 +46,7 @@ impl IpcSocket {
         info!("Creating IPC domain socket at {path:?}");
 
         let status = Status {
-            mode: PlayerEvent::Stopped,
+            mode: PlayerStatus::Stopped,
             playable: None,
         };
 
@@ -65,7 +65,7 @@ impl IpcSocket {
         std::os::unix::net::UnixStream::connect(path).is_ok()
     }
 
-    pub fn publish(&self, event: &PlayerEvent, playable: Option<Playable>) {
+    pub fn publish(&self, event: &PlayerStatus, playable: Option<Playable>) {
         let status = Status {
             mode: event.clone(),
             playable,

--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -21,13 +21,13 @@ use crate::model::playlist::Playlist;
 use crate::model::show::Show;
 use crate::model::track::Track;
 use crate::queue::RepeatSetting;
-use crate::spotify::UriType;
+use crate::spotify::{PlayerStatus, UriType};
 use crate::spotify_url::SpotifyUrl;
 use crate::traits::ListItem;
 use crate::{
     events::EventManager,
     queue::Queue,
-    spotify::{PlayerEvent, Spotify, VOLUME_PERCENT},
+    spotify::{Spotify, VOLUME_PERCENT},
 };
 
 struct MprisRoot {}
@@ -81,8 +81,8 @@ impl MprisPlayer {
     #[zbus(property)]
     fn playback_status(&self) -> &str {
         match self.spotify.get_current_status() {
-            PlayerEvent::Playing(_) | PlayerEvent::FinishedTrack => "Playing",
-            PlayerEvent::Paused(_) => "Paused",
+            PlayerStatus::Playing(_) => "Playing",
+            PlayerStatus::Paused(_) => "Paused",
             _ => "Stopped",
         }
     }
@@ -278,7 +278,7 @@ impl MprisPlayer {
         log::info!("set volume: {volume}");
         let clamped = volume.clamp(0.0, 1.0);
         let vol = (VOLUME_PERCENT as f64) * clamped * 100.0;
-        self.spotify.set_volume(vol as u16, false);
+        self.spotify.set_volume(vol as u16);
         self.event.trigger();
     }
 

--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -4,7 +4,6 @@ use log::info;
 use std::collections::HashMap;
 use std::error::Error;
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_stream::StreamExt;
 use tokio_stream::wrappers::UnboundedReceiverStream;
@@ -325,11 +324,7 @@ impl MprisPlayer {
     }
 
     fn previous(&self) {
-        if self.spotify.get_current_progress() < Duration::from_secs(5) {
-            self.queue.previous();
-        } else {
-            self.spotify.seek(0);
-        }
+        self.queue.previous();
     }
 
     fn pause(&self) {

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -150,6 +150,69 @@ impl Queue {
         }
     }
 
+    #[cfg(feature = "notify")]
+    fn notify_track(&self, track: Playable) {
+        if !self.cfg.values().notify.unwrap_or(false) {
+            return;
+        }
+
+        std::thread::spawn({
+            // use same parser as track_format, Playable::format
+            let format = self
+                .cfg
+                .values()
+                .notification_format
+                .clone()
+                .unwrap_or_default();
+            let default_title = crate::config::NotificationFormat::default().title.unwrap();
+            let title = format.title.unwrap_or_else(|| default_title.clone());
+
+            let default_body = crate::config::NotificationFormat::default().body.unwrap();
+            let body = format.body.unwrap_or_else(|| default_body.clone());
+
+            let summary_txt = Playable::format(&track, &title, &self.library);
+            let body_txt = Playable::format(&track, &body, &self.library);
+            let cover_url = track.cover_url();
+            move || send_notification(&summary_txt, &body_txt, cover_url)
+        });
+    }
+
+    /// Move the local queue cursor to the track Spirc reports as current.
+    pub fn sync_current_track(&self, uri: &str) {
+        let next = {
+            let q = self.queue.read().unwrap();
+            q.iter()
+                .enumerate()
+                .find(|(_, track)| track.uri() == uri)
+                .map(|(index, track)| (index, track.clone()))
+        };
+
+        let Some((index, track)) = next else {
+            debug!("Spirc changed to {uri}, which is not in the local queue");
+            return;
+        };
+
+        let changed = {
+            let mut current = self.current_track.write().unwrap();
+            if *current == Some(index) {
+                false
+            } else {
+                current.replace(index);
+                true
+            }
+        };
+
+        if changed {
+            self.spotify.update_track();
+
+            #[cfg(feature = "notify")]
+            self.notify_track(track);
+
+            #[cfg(feature = "mpris")]
+            self.spotify.notify_seeked(0);
+        }
+    }
+
     /// Insert `track` as the item that should logically follow the currently
     /// playing item, taking into account shuffle status.
     pub fn insert_after_current(&self, track: Playable) {
@@ -318,27 +381,7 @@ impl Queue {
             self.spotify.update_track();
 
             #[cfg(feature = "notify")]
-            if self.cfg.values().notify.unwrap_or(false) {
-                std::thread::spawn({
-                    // use same parser as track_format, Playable::format
-                    let format = self
-                        .cfg
-                        .values()
-                        .notification_format
-                        .clone()
-                        .unwrap_or_default();
-                    let default_title = crate::config::NotificationFormat::default().title.unwrap();
-                    let title = format.title.unwrap_or_else(|| default_title.clone());
-
-                    let default_body = crate::config::NotificationFormat::default().body.unwrap();
-                    let body = format.body.unwrap_or_else(|| default_body.clone());
-
-                    let summary_txt = Playable::format(&track, &title, &self.library);
-                    let body_txt = Playable::format(&track, &body, &self.library);
-                    let cover_url = track.cover_url();
-                    move || send_notification(&summary_txt, &body_txt, cover_url)
-                });
-            }
+            self.notify_track(track);
 
             // Send a Seeked signal at start of new track
             #[cfg(feature = "mpris")]

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -26,6 +26,26 @@ pub enum RepeatSetting {
     RepeatTrack,
 }
 
+impl RepeatSetting {
+    fn spirc_flags(self) -> (bool, bool) {
+        match self {
+            Self::None => (false, false),
+            Self::RepeatPlaylist => (true, false),
+            Self::RepeatTrack => (true, true),
+        }
+    }
+
+    fn from_spirc(context: bool, track: bool) -> Self {
+        if track {
+            Self::RepeatTrack
+        } else if context {
+            Self::RepeatPlaylist
+        } else {
+            Self::None
+        }
+    }
+}
+
 /// Events that are specific to the [Queue].
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum QueueEvent {
@@ -211,6 +231,27 @@ impl Queue {
             #[cfg(feature = "mpris")]
             self.spotify.notify_seeked(0);
         }
+    }
+
+    /// Mirror Spirc's shuffle state locally.
+    pub fn sync_shuffle(&self, new: bool) {
+        let was = self.cfg.state().shuffle;
+        self.cfg.with_state_mut(|s| s.shuffle = new);
+        if new {
+            let needs_order = !was || self.random_order.read().unwrap().is_none();
+            if needs_order {
+                self.generate_random_order();
+            }
+        } else {
+            let mut random_order = self.random_order.write().unwrap();
+            *random_order = None;
+        }
+    }
+
+    /// Mirror Spirc's repeat flags locally.
+    pub fn sync_repeat(&self, context: bool, track: bool) {
+        self.cfg
+            .with_state_mut(|s| s.repeat = RepeatSetting::from_spirc(context, track));
     }
 
     /// Insert `track` as the item that should logically follow the currently
@@ -421,11 +462,20 @@ impl Queue {
     /// used, and the next track will actually be played. This should be used
     /// when going to the next entry in the queue is the wanted behavior.
     pub fn next(&self, manual: bool) {
+        if manual {
+            let repeat = self.cfg.state().repeat;
+            self.spotify.next();
+            if repeat == RepeatSetting::RepeatTrack {
+                self.set_repeat(RepeatSetting::RepeatPlaylist);
+            }
+            return;
+        }
+
         let q = self.queue.read().unwrap();
         let current = *self.current_track.read().unwrap();
         let repeat = self.cfg.state().repeat;
 
-        if repeat == RepeatSetting::RepeatTrack && !manual {
+        if repeat == RepeatSetting::RepeatTrack {
             if let Some(index) = current
                 && q[index].is_playable()
             {
@@ -433,9 +483,6 @@ impl Queue {
             }
         } else if let Some(index) = self.next_index() {
             self.play(index, false, false);
-            if repeat == RepeatSetting::RepeatTrack && manual {
-                self.set_repeat(RepeatSetting::RepeatPlaylist);
-            }
         } else if repeat == RepeatSetting::RepeatPlaylist
             && !q.is_empty()
             && q.iter().any(|track| track.is_playable())
@@ -453,26 +500,7 @@ impl Queue {
 
     /// Play the previous item in the queue.
     pub fn previous(&self) {
-        let q = self.queue.read().unwrap();
-        let current = *self.current_track.read().unwrap();
-        let repeat = self.cfg.state().repeat;
-
-        if let Some(index) = self.previous_index() {
-            self.play(index, false, false);
-        } else if repeat == RepeatSetting::RepeatPlaylist && !q.is_empty() {
-            if self.get_shuffle() {
-                let random_order = self.random_order.read().unwrap();
-                self.play(
-                    random_order.as_ref().map(|o| o[q.len() - 1]).unwrap_or(0),
-                    false,
-                    false,
-                );
-            } else {
-                self.play(q.len() - 1, false, false);
-            }
-        } else if let Some(index) = current {
-            self.play(index, false, false);
-        }
+        self.spotify.previous();
     }
 
     /// Get the current repeat behavior.
@@ -483,6 +511,8 @@ impl Queue {
     /// Set the current repeat behavior and save it to the configuration.
     pub fn set_repeat(&self, new: RepeatSetting) {
         self.cfg.with_state_mut(|s| s.repeat = new);
+        let (context, track) = new.spirc_flags();
+        self.spotify.set_repeat(context, track);
     }
 
     /// Get the current shuffle behavior.
@@ -516,13 +546,8 @@ impl Queue {
 
     /// Set the current shuffle behavior.
     pub fn set_shuffle(&self, new: bool) {
-        self.cfg.with_state_mut(|s| s.shuffle = new);
-        if new {
-            self.generate_random_order();
-        } else {
-            let mut random_order = self.random_order.write().unwrap();
-            *random_order = None;
-        }
+        self.sync_shuffle(new);
+        self.spotify.set_shuffle(new);
     }
 
     /// Handle events that are specific to the queue.

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -123,6 +123,33 @@ impl Queue {
         *self.current_track.read().unwrap()
     }
 
+    fn playback_context_for(&self, index: usize) -> (Vec<Playable>, usize) {
+        let q = self.queue.read().unwrap();
+        let order = self
+            .random_order
+            .read()
+            .unwrap()
+            .clone()
+            .unwrap_or_else(|| (0..q.len()).collect());
+        let context_index = order.iter().position(|&i| i == index).unwrap_or(index);
+        let tracks = order
+            .iter()
+            .filter_map(|&i| q.get(i).cloned())
+            .collect::<Vec<_>>();
+
+        (tracks, context_index)
+    }
+
+    /// Load the currently selected queue item and its surrounding context into the player.
+    pub fn load_current(&self, start_playing: bool, position_ms: u32) {
+        if let Some(index) = self.get_current_index() {
+            let (tracks, context_index) = self.playback_context_for(index);
+            self.spotify
+                .load_context(&tracks, context_index, start_playing, position_ms);
+            self.spotify.update_track();
+        }
+    }
+
     /// Insert `track` as the item that should logically follow the currently
     /// playing item, taking into account shuffle status.
     pub fn insert_after_current(&self, track: Playable) {
@@ -283,8 +310,9 @@ impl Queue {
             index = rng.random_range(0..queue_length);
         }
 
-        if let Some(track) = &self.queue.read().unwrap().get(index) {
-            self.spotify.load(track, true, 0);
+        if let Some(track) = self.queue.read().unwrap().get(index).cloned() {
+            let (tracks, context_index) = self.playback_context_for(index);
+            self.spotify.load_context(&tracks, context_index, true, 0);
             let mut current = self.current_track.write().unwrap();
             current.replace(index);
             self.spotify.update_track();
@@ -305,8 +333,8 @@ impl Queue {
                     let default_body = crate::config::NotificationFormat::default().body.unwrap();
                     let body = format.body.unwrap_or_else(|| default_body.clone());
 
-                    let summary_txt = Playable::format(track, &title, &self.library);
-                    let body_txt = Playable::format(track, &body, &self.library);
+                    let summary_txt = Playable::format(&track, &title, &self.library);
+                    let body_txt = Playable::format(&track, &body, &self.library);
                     let cover_url = track.cover_url();
                     move || send_notification(&summary_txt, &body_txt, cover_url)
                 });

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -11,7 +11,7 @@ use strum_macros::Display;
 use crate::config::Config;
 use crate::library::Library;
 use crate::model::playable::Playable;
-use crate::spotify::PlayerEvent;
+use crate::spotify::PlayerStatus;
 use crate::spotify::Spotify;
 use crate::traits::ListItem;
 
@@ -326,14 +326,13 @@ impl Queue {
     /// play the next song if one is available, or restart from the start.
     pub fn toggleplayback(&self) {
         match self.spotify.get_current_status() {
-            PlayerEvent::Playing(_) | PlayerEvent::Paused(_) => {
+            PlayerStatus::Playing(_) | PlayerStatus::Paused(_) => {
                 self.spotify.toggleplayback();
             }
-            PlayerEvent::Stopped => match self.next_index() {
+            PlayerStatus::Stopped => match self.next_index() {
                 Some(_) => self.next(false),
                 None => self.play(0, false, false),
             },
-            _ => (),
         }
     }
 

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -50,6 +50,8 @@ pub enum PlayerEvent {
     TrackChanged(String),
     FinishedTrack,
     VolumeChanged(u16),
+    ShuffleChanged(bool),
+    RepeatChanged { context: bool, track: bool },
 }
 
 /// Wrapper around a worker thread that exposes methods to safely control it.
@@ -400,6 +402,7 @@ impl Spotify {
             PlayerEvent::VolumeChanged(volume) => {
                 self.update_volume(volume);
             }
+            PlayerEvent::ShuffleChanged(_) | PlayerEvent::RepeatChanged { .. } => {}
         }
 
         if let PlayerEvent::StatusChanged(new_status) = event {
@@ -467,6 +470,18 @@ impl Spotify {
         self.send_worker(WorkerCommand::Pause);
     }
 
+    /// Skip to the next item in Spirc's playback context.
+    pub fn next(&self) {
+        info!("next()");
+        self.send_worker(WorkerCommand::Next);
+    }
+
+    /// Skip to the previous item in Spirc's playback context.
+    pub fn previous(&self) {
+        info!("previous()");
+        self.send_worker(WorkerCommand::Previous);
+    }
+
     /// Stop playback of the [Player].
     pub fn stop(&self) {
         info!("stop()");
@@ -517,6 +532,16 @@ impl Spotify {
     /// the update.
     pub fn set_volume(&self, volume: u16) {
         self.send_worker(WorkerCommand::SetVolume(volume));
+    }
+
+    /// Set Spirc's shuffle mode.
+    pub fn set_shuffle(&self, shuffle: bool) {
+        self.send_worker(WorkerCommand::SetShuffle(shuffle));
+    }
+
+    /// Set Spirc's repeat flags.
+    pub fn set_repeat(&self, context: bool, track: bool) {
+        self.send_worker(WorkerCommand::SetRepeat { context, track });
     }
 
     /// Preload the given [Playable] in the [Player]. This makes sure it can be played immediately

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -117,7 +117,7 @@ impl Spotify {
             mpris: Default::default(),
             credentials: Credentials::with_password("test_user", "test_pass"),
             cfg,
-            status: Arc::new(RwLock::new(PlayerEvent::Stopped)),
+            status: Arc::new(RwLock::new(PlayerStatus::Stopped)),
             api: WebApi::new(),
             elapsed: Arc::new(RwLock::new(None)),
             since: Arc::new(RwLock::new(None)),
@@ -338,6 +338,23 @@ impl Spotify {
     /// Load `track` into the [Player]. Start playing immediately if
     /// `start_playing` is true. Start playing from `position_ms` in the song.
     pub fn load(&self, track: &Playable, start_playing: bool, position_ms: u32) {
+        self.load_context(&[track.clone()], 0, start_playing, position_ms);
+    }
+
+    /// Load a queue context into the player, starting at `index`.
+    pub fn load_context(
+        &self,
+        tracks: &[Playable],
+        index: usize,
+        start_playing: bool,
+        position_ms: u32,
+    ) {
+        let Some(track) = tracks.get(index) else {
+            error!("can't load queue context at missing index {index}");
+            self.events.send(Event::Player(PlayerEvent::FinishedTrack));
+            return;
+        };
+
         info!("loading track: {track:?}");
 
         if !track.is_playable() {
@@ -347,7 +364,8 @@ impl Spotify {
         }
 
         self.send_worker(WorkerCommand::Load(
-            track.clone(),
+            tracks.to_vec(),
+            index,
             start_playing,
             position_ms,
         ));

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -35,12 +35,18 @@ use crate::traits::ListItem;
 /// percent.
 pub const VOLUME_PERCENT: u16 = ((u16::MAX as f64) * 1.0 / 100.0) as u16;
 
-/// Events sent by the [Player].
+/// Player status
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
-pub enum PlayerEvent {
+pub enum PlayerStatus {
     Playing(SystemTime),
     Paused(Duration),
     Stopped,
+}
+
+/// Events sent by the [Player].
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub enum PlayerEvent {
+    StatusChanged(PlayerStatus),
     FinishedTrack,
 }
 
@@ -54,7 +60,7 @@ pub struct Spotify {
     credentials: Credentials,
     cfg: Arc<config::Config>,
     /// Playback status of the [Player] owned by the worker thread.
-    status: Arc<RwLock<PlayerEvent>>,
+    status: Arc<RwLock<PlayerStatus>>,
     pub api: WebApi,
     /// The amount of the current [Playable] that had elapsed when last paused.
     elapsed: Arc<RwLock<Option<Duration>>>,
@@ -76,7 +82,7 @@ impl Spotify {
             mpris: Default::default(),
             credentials,
             cfg: cfg.clone(),
-            status: Arc::new(RwLock::new(PlayerEvent::Stopped)),
+            status: Arc::new(RwLock::new(PlayerStatus::Stopped)),
             api: WebApi::new(),
             elapsed: Arc::new(RwLock::new(None)),
             since: Arc::new(RwLock::new(None)),
@@ -87,7 +93,7 @@ impl Spotify {
         spotify.start_worker(Some(user_tx))?;
         let user = ASYNC_RUNTIME.get().unwrap().block_on(user_rx).ok();
         let volume = cfg.state().volume;
-        spotify.set_volume(volume, true);
+        spotify.set_volume(volume);
 
         spotify.api.set_worker_channel(spotify.channel.clone());
         spotify
@@ -294,7 +300,7 @@ impl Spotify {
     }
 
     /// Get the current playback status of the [Player].
-    pub fn get_current_status(&self) -> PlayerEvent {
+    pub fn get_current_status(&self) -> PlayerStatus {
         let status = self.status.read().unwrap();
         (*status).clone()
     }
@@ -352,24 +358,26 @@ impl Spotify {
     /// Update the cached status of the [Player]. This makes sure the status
     /// doesn't have to be retrieved every time from the thread, which would be harder and more
     /// expensive.
-    pub fn update_status(&self, new_status: PlayerEvent) {
-        match new_status {
-            PlayerEvent::Paused(position) => {
+    pub fn handle_player_event(&self, event: PlayerEvent) {
+        match event {
+            PlayerEvent::StatusChanged(PlayerStatus::Paused(position)) => {
                 self.set_elapsed(Some(position));
                 self.set_since(None);
             }
-            PlayerEvent::Playing(playback_start) => {
+            PlayerEvent::StatusChanged(PlayerStatus::Playing(playback_start)) => {
                 self.set_since(Some(playback_start));
                 self.set_elapsed(None);
             }
-            PlayerEvent::Stopped | PlayerEvent::FinishedTrack => {
+            PlayerEvent::StatusChanged(PlayerStatus::Stopped) | PlayerEvent::FinishedTrack => {
                 self.set_elapsed(None);
                 self.set_since(None);
             }
         }
 
-        let mut status = self.status.write().unwrap();
-        *status = new_status;
+        if let PlayerEvent::StatusChanged(new_status) = event {
+            let mut status = self.status.write().unwrap();
+            *status = new_status;
+        };
 
         #[cfg(feature = "mpris")]
         self.send_mpris(MprisCommand::EmitPlaybackStatus);
@@ -391,8 +399,8 @@ impl Spotify {
     /// Toggle playback (play/pause) of the [Player].
     pub fn toggleplayback(&self) {
         match self.get_current_status() {
-            PlayerEvent::Playing(_) => self.pause(),
-            PlayerEvent::Paused(_) => self.play(),
+            PlayerStatus::Playing(_) => self.pause(),
+            PlayerStatus::Paused(_) => self.play(),
             _ => (),
         }
     }
@@ -456,6 +464,14 @@ impl Spotify {
         self.cfg.state().volume
     }
 
+    pub fn update_volume(&self, volume: u16) {
+        info!("setting volume to {volume}");
+        self.cfg.with_state_mut(|s| s.volume = volume);
+
+        #[cfg(feature = "mpris")]
+        self.send_mpris(MprisCommand::EmitVolumeStatus)
+    }
+
     /// Send a Seeked signal on Mpris interface
     #[cfg(feature = "mpris")]
     pub fn notify_seeked(&self, position_ms: u32) {
@@ -471,16 +487,8 @@ impl Spotify {
 
     /// Set the current volume of the [Player]. If `notify` is true, also notify MPRIS clients about
     /// the update.
-    pub fn set_volume(&self, volume: u16, notify: bool) {
-        info!("setting volume to {volume}");
-        self.cfg.with_state_mut(|s| s.volume = volume);
+    pub fn set_volume(&self, volume: u16) {
         self.send_worker(WorkerCommand::SetVolume(volume));
-        // HACK: This is a bit of a hack to prevent duplicate update signals when updating from the
-        // MPRIS implementation.
-        if notify {
-            #[cfg(feature = "mpris")]
-            self.send_mpris(MprisCommand::EmitVolumeStatus)
-        }
     }
 
     /// Preload the given [Playable] in the [Player]. This makes sure it can be played immediately

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -48,6 +48,7 @@ pub enum PlayerStatus {
 pub enum PlayerEvent {
     StatusChanged(PlayerStatus),
     FinishedTrack,
+    VolumeChanged(u16),
 }
 
 /// Wrapper around a worker thread that exposes methods to safely control it.
@@ -371,6 +372,9 @@ impl Spotify {
             PlayerEvent::StatusChanged(PlayerStatus::Stopped) | PlayerEvent::FinishedTrack => {
                 self.set_elapsed(None);
                 self.set_since(None);
+            }
+            PlayerEvent::VolumeChanged(volume) => {
+                self.update_volume(volume);
             }
         }
 

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -47,6 +47,7 @@ pub enum PlayerStatus {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub enum PlayerEvent {
     StatusChanged(PlayerStatus),
+    TrackChanged(String),
     FinishedTrack,
     VolumeChanged(u16),
 }
@@ -390,6 +391,11 @@ impl Spotify {
             PlayerEvent::StatusChanged(PlayerStatus::Stopped) | PlayerEvent::FinishedTrack => {
                 self.set_elapsed(None);
                 self.set_since(None);
+            }
+            PlayerEvent::TrackChanged(_) => {
+                self.update_track();
+                #[cfg(feature = "mpris")]
+                self.send_mpris(MprisCommand::EmitMetadataStatus);
             }
             PlayerEvent::VolumeChanged(volume) => {
                 self.update_volume(volume);

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -181,10 +181,7 @@ impl Spotify {
 
     /// Create a [Session] that respects the user configuration in `cfg` and with the given
     /// credentials.
-    async fn create_session(
-        cfg: &config::Config,
-        credentials: Credentials,
-    ) -> Result<Session, librespot_core::Error> {
+    async fn create_session(cfg: &config::Config) -> Session {
         let librespot_cache_path = config::cache_path("librespot");
         let audio_cache_path = match cfg.values().audio_cache {
             Some(false) => None,
@@ -201,8 +198,7 @@ impl Spotify {
         .expect("Could not create cache");
         debug!("opening spotify session");
         let session_config = Self::session_config(cfg);
-        let session = Session::new(session_config, Some(cache));
-        session.connect(credentials, true).await.map(|_| session)
+        Session::new(session_config, Some(cache))
     }
 
     /// Create and initialize the requested audio backend.
@@ -261,9 +257,7 @@ impl Spotify {
             ..Default::default()
         };
 
-        let session = Self::create_session(&cfg, credentials)
-            .await
-            .expect("Could not create session");
+        let session = Self::create_session(&cfg).await;
         user_tx.map(|tx| tx.send(session.username()));
 
         let mixer_factory_opt = librespot_playback::mixer::find(Some(SoftMixer::NAME));
@@ -283,12 +277,14 @@ impl Spotify {
 
         let mut worker = Worker::new(
             events.clone(),
+            credentials,
             player_events,
             commands,
             session,
             player,
             mixer,
-        );
+        )
+        .await;
         debug!("worker thread ready.");
         worker.run_loop().await;
 

--- a/src/spotify_worker.rs
+++ b/src/spotify_worker.rs
@@ -23,9 +23,13 @@ pub(crate) enum WorkerCommand {
     Load(Vec<Playable>, usize, bool, u32),
     Play,
     Pause,
+    Next,
+    Previous,
     Stop,
     Seek(u32),
     SetVolume(u16),
+    SetShuffle(bool),
+    SetRepeat { context: bool, track: bool },
     Preload(Playable),
     Shutdown,
 }
@@ -168,6 +172,16 @@ impl Worker {
                             error!("error pausing spirc: {e:?}");
                         }
                     }
+                    Some(WorkerCommand::Next) => {
+                        if let Err(e) = self.spirc.next() {
+                            error!("error skipping spirc to next track: {e:?}");
+                        }
+                    }
+                    Some(WorkerCommand::Previous) => {
+                        if let Err(e) = self.spirc.prev() {
+                            error!("error skipping spirc to previous track: {e:?}");
+                        }
+                    }
                     Some(WorkerCommand::Stop) => {
                         //todo!("stop spirc");
                     }
@@ -179,6 +193,19 @@ impl Worker {
                     Some(WorkerCommand::SetVolume(volume)) => {
                         if let Err(e) = self.spirc.set_volume(volume) {
                             error!("error setting spirc volume: {e:?}");
+                        }
+                    }
+                    Some(WorkerCommand::SetShuffle(shuffle)) => {
+                        if let Err(e) = self.spirc.shuffle(shuffle) {
+                            error!("error setting spirc shuffle: {e:?}");
+                        }
+                    }
+                    Some(WorkerCommand::SetRepeat { context, track }) => {
+                        if let Err(e) = self.spirc.repeat(context) {
+                            error!("error setting spirc repeat context: {e:?}");
+                        }
+                        if let Err(e) = self.spirc.repeat_track(track) {
+                            error!("error setting spirc repeat track: {e:?}");
                         }
                     }
                     Some(WorkerCommand::Preload(playable)) => {
@@ -238,6 +265,14 @@ impl Worker {
                     }
                     Some(LibrespotPlayerEvent::VolumeChanged { volume }) => {
                         let event = PlayerEvent::VolumeChanged(volume);
+                        self.events.send(Event::Player(event));
+                    }
+                    Some(LibrespotPlayerEvent::ShuffleChanged { shuffle }) => {
+                        let event = PlayerEvent::ShuffleChanged(shuffle);
+                        self.events.send(Event::Player(event));
+                    }
+                    Some(LibrespotPlayerEvent::RepeatChanged { context, track }) => {
+                        let event = PlayerEvent::RepeatChanged { context, track };
                         self.events.send(Event::Player(event));
                     }
                     Some(LibrespotPlayerEvent::TrackChanged { audio_item }) => {

--- a/src/spotify_worker.rs
+++ b/src/spotify_worker.rs
@@ -1,7 +1,7 @@
 use crate::events::{Event, EventManager};
 use crate::model::playable::Playable;
 use crate::queue::QueueEvent;
-use crate::spotify::PlayerEvent;
+use crate::spotify::{PlayerEvent, PlayerStatus};
 use librespot_connect::{ConnectConfig, LoadRequest, LoadRequestOptions, Spirc};
 use librespot_core::SpotifyUri;
 use librespot_core::session::Session;
@@ -30,7 +30,7 @@ pub(crate) enum WorkerCommand {
     Shutdown,
 }
 
-enum PlayerStatus {
+enum LibrespotPlayerStatus {
     Playing,
     Paused,
     Stopped,
@@ -40,7 +40,7 @@ pub struct Worker {
     events: EventManager,
     player_events: UnboundedReceiverStream<LibrespotPlayerEvent>,
     commands: UnboundedReceiverStream<WorkerCommand>,
-    player_status: PlayerStatus,
+    player_status: LibrespotPlayerStatus,
     session: Session,
     spirc: Spirc,
     spirc_task: Pin<Box<dyn Future<Output = ()> + Send>>,
@@ -67,7 +67,7 @@ impl Worker {
             events,
             player_events: UnboundedReceiverStream::new(player_events),
             commands: UnboundedReceiverStream::new(commands),
-            player_status: PlayerStatus::Stopped,
+            player_status: LibrespotPlayerStatus::Stopped,
             session,
             spirc,
             spirc_task: Box::pin(spirc_task),
@@ -80,7 +80,9 @@ impl Worker {
         loop {
             if self.session.is_invalid() {
                 info!("Librespot session invalidated, terminating worker");
-                self.events.send(Event::Player(PlayerEvent::Stopped));
+                self.events.send(Event::Player(PlayerEvent::StatusChanged(
+                    PlayerStatus::Stopped,
+                )));
                 break;
             }
 
@@ -161,8 +163,8 @@ impl Worker {
                         let position = Duration::from_millis(position_ms as u64);
                         let playback_start = SystemTime::now() - position;
                         self.events
-                            .send(Event::Player(PlayerEvent::Playing(playback_start)));
-                        self.player_status = PlayerStatus::Playing;
+                            .send(Event::Player(PlayerEvent::StatusChanged(PlayerStatus::Playing(playback_start))));
+                        self.player_status = LibrespotPlayerStatus::Playing;
                     }
                     Some(LibrespotPlayerEvent::Paused {
                         play_request_id: _,
@@ -171,12 +173,12 @@ impl Worker {
                     }) => {
                         let position = Duration::from_millis(position_ms as u64);
                         self.events
-                            .send(Event::Player(PlayerEvent::Paused(position)));
-                        self.player_status = PlayerStatus::Paused;
+                            .send(Event::Player(PlayerEvent::StatusChanged(PlayerStatus::Paused(position))));
+                        self.player_status = LibrespotPlayerStatus::Paused;
                     }
                     Some(LibrespotPlayerEvent::Stopped { .. }) => {
-                        self.events.send(Event::Player(PlayerEvent::Stopped));
-                        self.player_status = PlayerStatus::Stopped;
+                        self.events.send(Event::Player(PlayerEvent::StatusChanged(PlayerStatus::Stopped)));
+                        self.player_status = LibrespotPlayerStatus::Stopped;
                     }
                     Some(LibrespotPlayerEvent::EndOfTrack { .. }) => {
                         self.events.send(Event::Player(PlayerEvent::FinishedTrack));
@@ -187,15 +189,15 @@ impl Worker {
                     }
                     Some(LibrespotPlayerEvent::Seeked { play_request_id: _, track_id: _, position_ms}) => {
                         let position = Duration::from_millis(position_ms as u64);
-                        let event = match self.player_status {
-                            PlayerStatus::Playing => {
+                        let status = match self.player_status {
+                            LibrespotPlayerStatus::Playing => {
                                 let playback_start = SystemTime::now() - position;
-                                PlayerEvent::Playing(playback_start)
+                                PlayerStatus::Playing(playback_start)
                             },
-                            PlayerStatus::Paused => PlayerEvent::Paused(position),
-                            PlayerStatus::Stopped => PlayerEvent::Stopped,
+                            LibrespotPlayerStatus::Paused => PlayerStatus::Paused(position),
+                            LibrespotPlayerStatus::Stopped => PlayerStatus::Stopped,
                         };
-                        self.events.send(Event::Player(event));
+                        self.events.send(Event::Player(PlayerEvent::StatusChanged(status)));
                     }
                     Some(event) => {
                         debug!("Unhandled player event: {event:?}");
@@ -210,7 +212,7 @@ impl Worker {
                 },
                 // Update animated parts of the UI (e.g. statusbar during playback).
                 _ = ui_refresh.tick() => {
-                    if !matches!(self.player_status, PlayerStatus::Stopped) {
+                    if !matches!(self.player_status, LibrespotPlayerStatus::Stopped) {
                         self.events.trigger();
                     }
                 },

--- a/src/spotify_worker.rs
+++ b/src/spotify_worker.rs
@@ -199,6 +199,10 @@ impl Worker {
                         };
                         self.events.send(Event::Player(PlayerEvent::StatusChanged(status)));
                     }
+                    Some(LibrespotPlayerEvent::VolumeChanged { volume }) => {
+                        let event = PlayerEvent::VolumeChanged(volume);
+                        self.events.send(Event::Player(event));
+                    }
                     Some(event) => {
                         debug!("Unhandled player event: {event:?}");
                     }

--- a/src/spotify_worker.rs
+++ b/src/spotify_worker.rs
@@ -2,11 +2,14 @@ use crate::events::{Event, EventManager};
 use crate::model::playable::Playable;
 use crate::queue::QueueEvent;
 use crate::spotify::PlayerEvent;
+use librespot_connect::{ConnectConfig, LoadRequest, LoadRequestOptions, Spirc};
 use librespot_core::SpotifyUri;
 use librespot_core::session::Session;
 use librespot_playback::mixer::Mixer;
 use librespot_playback::player::{Player, PlayerEvent as LibrespotPlayerEvent};
 use log::{debug, error, info, warn};
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::SystemTime;
@@ -37,29 +40,37 @@ pub struct Worker {
     events: EventManager,
     player_events: UnboundedReceiverStream<LibrespotPlayerEvent>,
     commands: UnboundedReceiverStream<WorkerCommand>,
-    session: Session,
-    player: Arc<Player>,
     player_status: PlayerStatus,
-    mixer: Arc<dyn Mixer>,
+    session: Session,
+    spirc: Spirc,
+    spirc_task: Pin<Box<dyn Future<Output = ()> + Send>>,
 }
 
 impl Worker {
-    pub(crate) fn new(
+    pub(crate) async fn new(
         events: EventManager,
+        credentials: librespot_core::authentication::Credentials,
         player_events: mpsc::UnboundedReceiver<LibrespotPlayerEvent>,
         commands: mpsc::UnboundedReceiver<WorkerCommand>,
         session: Session,
         player: Arc<Player>,
         mixer: Arc<dyn Mixer>,
     ) -> Self {
+        let config = ConnectConfig {
+            name: "ncspot".to_string(),
+            ..Default::default()
+        };
+        let (spirc, spirc_task) = Spirc::new(config, session.clone(), credentials, player, mixer)
+            .await
+            .expect("Spirc should be initialized");
         Self {
             events,
             player_events: UnboundedReceiverStream::new(player_events),
             commands: UnboundedReceiverStream::new(commands),
-            player,
-            session,
             player_status: PlayerStatus::Stopped,
-            mixer,
+            session,
+            spirc,
+            spirc_task: Box::pin(spirc_task),
         }
     }
 
@@ -76,6 +87,9 @@ impl Worker {
             tokio::select! {
                 cmd = self.commands.next() => match cmd {
                     Some(WorkerCommand::Load(playable, start_playing, position_ms)) => {
+                        if let Err(e) = self.spirc.activate() {
+                            warn!("error activating spirc: {e:?}");
+                        }
                         match SpotifyUri::from_uri(&playable.uri()) {
                             Ok(uri) => {
                                 info!("player loading track: {uri:?}");
@@ -83,7 +97,18 @@ impl Worker {
                                     warn!("track is not playable");
                                     self.events.send(Event::Player(PlayerEvent::FinishedTrack));
                                 } else {
-                                    self.player.load(uri, start_playing, position_ms);
+                                    let options = LoadRequestOptions {
+                                        start_playing,
+                                        seek_to: position_ms,
+                                        context_options: None,
+                                        playing_track: None,
+                                    };
+                                    let req =
+                                        LoadRequest::from_tracks(vec![uri.to_uri().expect("uri")], options);
+                                    if let Err(e) = self.spirc.load(req) {
+                                        error!("error loading track into spirc: {e:?}");
+                                        self.events.send(Event::Player(PlayerEvent::FinishedTrack));
+                                    }
                                 }
                             }
                             Err(e) => {
@@ -93,29 +118,37 @@ impl Worker {
                         }
                     }
                     Some(WorkerCommand::Play) => {
-                        self.player.play();
+                        if let Err(e) = self.spirc.play() {
+                            error!("error resuming spirc: {e:?}");
+                        }
                     }
                     Some(WorkerCommand::Pause) => {
-                        self.player.pause();
+                        if let Err(e) = self.spirc.pause() {
+                            error!("error pausing spirc: {e:?}");
+                        }
                     }
                     Some(WorkerCommand::Stop) => {
-                        self.player.stop();
+                        //todo!("stop spirc");
                     }
                     Some(WorkerCommand::Seek(pos)) => {
-                        self.player.seek(pos);
+                        if let Err(e) = self.spirc.set_position_ms(pos) {
+                            error!("error seeking spirc: {e:?}");
+                        }
                     }
                     Some(WorkerCommand::SetVolume(volume)) => {
-                        self.mixer.set_volume(volume);
+                        if let Err(e) = self.spirc.set_volume(volume) {
+                            error!("error setting spirc volume: {e:?}");
+                        }
                     }
                     Some(WorkerCommand::Preload(playable)) => {
                         if let Ok(uri) = SpotifyUri::from_uri(&playable.uri()) {
                             debug!("Preloading {uri:?}");
-                            self.player.preload(uri);
                         }
                     }
                     Some(WorkerCommand::Shutdown) => {
-                        self.player.stop();
-                        self.session.shutdown();
+                        if let Err(e) = self.spirc.shutdown() {
+                            error!("error shutting down spirc: {e:?}");
+                        }
                     }
                     None => info!("empty stream")
                 },
@@ -172,6 +205,9 @@ impl Worker {
                         break
                     },
                 },
+                _ = self.spirc_task.as_mut() => {
+                    info!("spirc task tick");
+                },
                 // Update animated parts of the UI (e.g. statusbar during playback).
                 _ = ui_refresh.tick() => {
                     if !matches!(self.player_status, PlayerStatus::Stopped) {
@@ -186,6 +222,6 @@ impl Worker {
 impl Drop for Worker {
     fn drop(&mut self) {
         debug!("Worker thread is shutting down, stopping player");
-        self.player.stop();
+        let _ = self.spirc.shutdown();
     }
 }

--- a/src/spotify_worker.rs
+++ b/src/spotify_worker.rs
@@ -219,9 +219,7 @@ impl Worker {
                         self.events.send(Event::Player(PlayerEvent::StatusChanged(PlayerStatus::Stopped)));
                         self.player_status = LibrespotPlayerStatus::Stopped;
                     }
-                    Some(LibrespotPlayerEvent::EndOfTrack { .. }) => {
-                        self.events.send(Event::Player(PlayerEvent::FinishedTrack));
-                    }
+                    Some(LibrespotPlayerEvent::EndOfTrack { .. }) => {}
                     Some(LibrespotPlayerEvent::TimeToPreloadNextTrack { .. }) => {
                         self.events
                             .send(Event::Queue(QueueEvent::PreloadTrackRequest));
@@ -241,6 +239,12 @@ impl Worker {
                     Some(LibrespotPlayerEvent::VolumeChanged { volume }) => {
                         let event = PlayerEvent::VolumeChanged(volume);
                         self.events.send(Event::Player(event));
+                    }
+                    Some(LibrespotPlayerEvent::TrackChanged { audio_item }) => {
+                        match audio_item.track_id.to_uri() {
+                            Ok(uri) => self.events.send(Event::Player(PlayerEvent::TrackChanged(uri))),
+                            Err(e) => error!("error formatting changed track uri: {e:?}"),
+                        }
                     }
                     Some(event) => {
                         debug!("Unhandled player event: {event:?}");

--- a/src/spotify_worker.rs
+++ b/src/spotify_worker.rs
@@ -2,7 +2,7 @@ use crate::events::{Event, EventManager};
 use crate::model::playable::Playable;
 use crate::queue::QueueEvent;
 use crate::spotify::{PlayerEvent, PlayerStatus};
-use librespot_connect::{ConnectConfig, LoadRequest, LoadRequestOptions, Spirc};
+use librespot_connect::{ConnectConfig, LoadRequest, LoadRequestOptions, PlayingTrack, Spirc};
 use librespot_core::SpotifyUri;
 use librespot_core::session::Session;
 use librespot_playback::mixer::Mixer;
@@ -20,7 +20,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 
 #[derive(Debug)]
 pub(crate) enum WorkerCommand {
-    Load(Playable, bool, u32),
+    Load(Vec<Playable>, usize, bool, u32),
     Play,
     Pause,
     Stop,
@@ -74,6 +74,61 @@ impl Worker {
         }
     }
 
+    fn load_request(
+        tracks: &[Playable],
+        index: usize,
+        start_playing: bool,
+        position_ms: u32,
+    ) -> Result<LoadRequest, PlayerEvent> {
+        let mut uris = Vec::new();
+        let mut playing_track = None;
+
+        for (track_index, playable) in tracks.iter().enumerate() {
+            match SpotifyUri::from_uri(&playable.uri()) {
+                Ok(uri) if uri.is_playable() => {
+                    if track_index == index {
+                        playing_track = Some(uris.len());
+                    }
+                    match uri.to_uri() {
+                        Ok(uri) => uris.push(uri),
+                        Err(e) => {
+                            error!("error formatting uri: {e:?}");
+                            if track_index == index {
+                                return Err(PlayerEvent::FinishedTrack);
+                            }
+                        }
+                    }
+                }
+                Ok(uri) => {
+                    warn!("track is not playable: {uri:?}");
+                    if track_index == index {
+                        return Err(PlayerEvent::FinishedTrack);
+                    }
+                }
+                Err(e) => {
+                    error!("error parsing uri: {e:?}");
+                    if track_index == index {
+                        return Err(PlayerEvent::FinishedTrack);
+                    }
+                }
+            }
+        }
+
+        let Some(playing_track) = playing_track else {
+            warn!("selected queue item is not part of the playable Spirc context");
+            return Err(PlayerEvent::FinishedTrack);
+        };
+
+        let options = LoadRequestOptions {
+            start_playing,
+            seek_to: position_ms,
+            context_options: None,
+            playing_track: Some(PlayingTrack::Index(playing_track as u32)),
+        };
+
+        Ok(LoadRequest::from_tracks(uris, options))
+    }
+
     pub async fn run_loop(&mut self) {
         let mut ui_refresh = time::interval(Duration::from_millis(400));
 
@@ -88,35 +143,19 @@ impl Worker {
 
             tokio::select! {
                 cmd = self.commands.next() => match cmd {
-                    Some(WorkerCommand::Load(playable, start_playing, position_ms)) => {
+                    Some(WorkerCommand::Load(tracks, index, start_playing, position_ms)) => {
                         if let Err(e) = self.spirc.activate() {
                             warn!("error activating spirc: {e:?}");
                         }
-                        match SpotifyUri::from_uri(&playable.uri()) {
-                            Ok(uri) => {
-                                info!("player loading track: {uri:?}");
-                                if !uri.is_playable() {
-                                    warn!("track is not playable");
+                        match Self::load_request(&tracks, index, start_playing, position_ms) {
+                            Ok(req) => {
+                                info!("player loading queue context at index {index}");
+                                if let Err(e) = self.spirc.load(req) {
+                                    error!("error loading track into spirc: {e:?}");
                                     self.events.send(Event::Player(PlayerEvent::FinishedTrack));
-                                } else {
-                                    let options = LoadRequestOptions {
-                                        start_playing,
-                                        seek_to: position_ms,
-                                        context_options: None,
-                                        playing_track: None,
-                                    };
-                                    let req =
-                                        LoadRequest::from_tracks(vec![uri.to_uri().expect("uri")], options);
-                                    if let Err(e) = self.spirc.load(req) {
-                                        error!("error loading track into spirc: {e:?}");
-                                        self.events.send(Event::Player(PlayerEvent::FinishedTrack));
-                                    }
                                 }
                             }
-                            Err(e) => {
-                                error!("error parsing uri: {e:?}");
-                                self.events.send(Event::Player(PlayerEvent::FinishedTrack));
-                            }
+                            Err(event) => self.events.send(Event::Player(event)),
                         }
                     }
                     Some(WorkerCommand::Play) => {

--- a/src/ui/contextmenu.rs
+++ b/src/ui/contextmenu.rs
@@ -14,7 +14,7 @@ use crate::model::track::Track;
 use crate::queue::Queue;
 #[cfg(feature = "share_clipboard")]
 use crate::sharing::write_share;
-use crate::spotify::PlayerEvent;
+use crate::spotify::PlayerStatus;
 use crate::traits::{ListItem, ViewExt};
 use crate::ui::layout::Layout;
 use crate::ui::modal::Modal;
@@ -205,7 +205,7 @@ impl ContextMenu {
         if item.is_playable() {
             if item.is_playing(&queue)
                 && queue.get_spotify().get_current_status()
-                    == PlayerEvent::Paused(queue.get_spotify().get_current_progress())
+                    == PlayerStatus::Paused(queue.get_spotify().get_current_progress())
             {
                 // the item is the current track, but paused
                 content.insert_item(0, "Resume", ContextMenuAction::TogglePlayback);

--- a/src/ui/statusbar.rs
+++ b/src/ui/statusbar.rs
@@ -11,7 +11,7 @@ use unicode_width::UnicodeWidthStr;
 use crate::library::Library;
 use crate::model::playable::Playable;
 use crate::queue::{Queue, RepeatSetting};
-use crate::spotify::{PlayerEvent, Spotify};
+use crate::spotify::{PlayerStatus, Spotify};
 use crate::utils::ms_to_hms;
 
 pub struct StatusBar {
@@ -58,9 +58,9 @@ impl StatusBar {
         };
 
         match status {
-            PlayerEvent::Playing(_) => indicators.0,
-            PlayerEvent::Paused(_) => indicators.1,
-            PlayerEvent::Stopped | PlayerEvent::FinishedTrack => indicators.2,
+            PlayerStatus::Playing(_) => indicators.0,
+            PlayerStatus::Paused(_) => indicators.1,
+            PlayerStatus::Stopped => indicators.2,
         }
     }
 
@@ -240,7 +240,7 @@ impl View for StatusBar {
                         .volume()
                         .saturating_add(crate::spotify::VOLUME_PERCENT);
 
-                    self.spotify.set_volume(volume, true);
+                    self.spotify.set_volume(volume);
                 }
 
                 if event == MouseEvent::WheelDown {
@@ -249,7 +249,7 @@ impl View for StatusBar {
                         .volume()
                         .saturating_sub(crate::spotify::VOLUME_PERCENT);
 
-                    self.spotify.set_volume(volume, true);
+                    self.spotify.set_volume(volume);
                 }
             } else if event == MouseEvent::Press(MouseButton::Left) {
                 self.queue.toggleplayback();


### PR DESCRIPTION
**Heavily WIP, only does basic playback so far.**

## Todo
- [ ] Update player context via [LoadRequest](https://docs.rs/librespot-connect/0.7.0/librespot_connect/struct.LoadRequest.html)
- [ ] Handle `TrackChanged` events
- [X] Handle `VolumeChanged` events
- [ ] Implement debouncing for volume updates to prevent rate limit exhaustion

## Describe your changes
The idea is to use librespot `Spirc` instead of handling the player logic within ncspot. This should reduce complexity a bit, but also allows us to integrate with Spotify Connect, which in turn would enable ncspot to be controlled via Spotify Apps.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [ ] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
