### PR TITLE
removed ConsoleOnly from Caregories

### DIFF
--- a/misc/ncspot.desktop
+++ b/misc/ncspot.desktop
@@ -6,5 +6,5 @@ TryExec=ncspot
 Exec=ncspot
 Icon=ncspot
 Terminal=true
-Categories=AudioVideo;Audio;Player;ConsoleOnly
+Categories=AudioVideo;Audio;Player
 Keywords=spotify;music;player


### PR DESCRIPTION
Including ConsoleOnly prevents application finder from showing desktop file

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [ ] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
