### PR TITLE
Change notification urgency to make the notification pop-up appear

### DIFF
--- a/src/queue.rs
+++ b/src/queue.rs
@@ -502,7 +502,7 @@ pub fn send_notification(summary_txt: &str, body_txt: &str, cover_url: Option<St
 
     // XDG desktop entry hints
     #[cfg(all(unix, not(target_os = "macos")))]
-    n.urgency(notify_rust::Urgency::Low)
+    n.urgency(notify_rust::Urgency::Normal)
         .hint(notify_rust::Hint::Transient(true))
         .hint(notify_rust::Hint::DesktopEntry("ncspot".into()));
 


### PR DESCRIPTION
## Describe your changes

I've noticed that the notification urgency level is set to "low", which makes the notification pop-up not appear in Gnome. Changed to "normal". 

## Issue ticket number and link

## Checklist before requesting a review
- [ ] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [ ] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
