### PR TITLE
Fix crash when shift amount is greater than queue length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Playlist retrieval crashing when list contains podcast episodes
+- Crash when shifting a song by an amount greater than the queue's length
 
 ## [1.3.1]
 

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -162,13 +162,21 @@ impl ViewExt for QueueView {
                     _ => 1,
                 };
 
+                let mode = match mode {
+                    &ShiftMode::Up if amount.is_negative() => &ShiftMode::Down,
+                    &ShiftMode::Down if amount.is_negative() => &ShiftMode::Up,
+                    m => m,
+                };
+
+                let amount = amount.abs();
+
                 let selected = self.list.get_selected_index();
                 let len = self.queue.len();
 
                 match mode {
                     ShiftMode::Up if selected > 0 => {
                         self.queue
-                            .shift(selected, (selected as i32).saturating_sub(amount) as usize);
+                            .shift(selected, selected.saturating_sub(amount as usize));
                         self.list.move_focus(-amount);
                         return Ok(CommandResult::Consumed(None));
                     }


### PR DESCRIPTION
## Describe your changes

Removed the cast to an `i32`, then back to a `usize` as it caused an unintentional integer overflow when subtracting. Instead, `amount` is cast as a `usize`.

As this breaks negative number inputs, these are first checked for, and the `ShiftMode` flipped accordingly. The amount value is then set to its absolute value, ensuring correct behaviour regardless.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] Documentation was updated (i.e. due to changes in keybindings, commands, etc.) -- *N/A*
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
