### PR TITLE
feat: improve status_format and track_format

### DIFF
--- a/src/model/playable.rs
+++ b/src/model/playable.rs
@@ -53,6 +53,22 @@ impl Playable {
                 .as_str(),
             )
             .replace(
+                "%track_number",
+                match playable.clone() {
+                    Self::Episode(episode) => episode.list_index.to_string(),
+                    Self::Track(track) => track.track_number.to_string(),
+                }
+                .as_str(),
+            )
+            .replace(
+                "%disc_number",
+                match playable.clone() {
+                    Self::Track(track) => track.disc_number.to_string(),
+                    Self::Episode(_episode) => String::new(),
+                }
+                .as_str(),
+            )
+            .replace(
                 "%album",
                 match playable.clone() {
                     Self::Track(track) => track.album.unwrap_or_default(),


### PR DESCRIPTION
This PR adds `%track_number` and `%disc_number` to the available options to format status and track.

## Describe your changes

`status_format` and `track_format` gain two additional options: the `%track_number` and `%disc_number`.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [ ] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
