### PR TITLE
fix: prevent crash when song has no artist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Playlist retrieval crashing when list contains podcast episodes
 - Crash when shifting a song by an amount greater than the queue's length
+- Crash when displaying songs that do not have an (available) artist
 
 ## [1.3.1]
 

--- a/src/model/playable.rs
+++ b/src/model/playable.rs
@@ -38,7 +38,9 @@ impl Playable {
             .replace(
                 "%artist",
                 if let Some(artists) = playable.artists() {
-                    artists.first().unwrap().clone().name
+                    artists
+                        .first()
+                        .map_or(String::from(""), |artist| artist.name.clone())
                 } else {
                     String::new()
                 }


### PR DESCRIPTION
When loading this playlist
(https://open.spotify.com/playlist/2onE4ObADgp1NuBzciYF0Q), ncspot would crash. The exact cause is not clear, but it seems to be caused by the songs not being available and therefore not having a valid artist. Therefore ensure we have a default value for artists in case one isn't available.

## Describe your changes
- Prevent a crash when loading certain playlists that contain unavailable songs (e.g., [this one](https://open.spotify.com/playlist/2onE4ObADgp1NuBzciYF0Q) in Belgium)

## Issue ticket number and link
\/

## Checklist before requesting a review
- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
