### PR TITLE
num-bigint-dig: future incompatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2486,9 +2486,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c79c15c05d4bf82b6f5ef163104cc81a760d8e874d38ac50ab67c8877b647b"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
  "lazy_static",
  "libm",


### PR DESCRIPTION
The following packages contain code that will be rejected by a future version of Rust: num-bigint-dig v0.8.5 help: update to a newer version to see if the issue has been fixed
        - num-bigint-dig v0.8.5 has the following newer
	  versions available: 0.8.6, 0.9.0, 0.9.1
help: ensure the maintainers know of this problem (e.g. creating a
      bug report if needed)
      or even helping with a fix (e.g. by creating a pull request)
        - num-bigint-dig@0.8.5
        - repository: https://github.com/dignifiedquire/num-bigint - detailed warning command: `cargo report future-incompatibilities --id 1 --package num-bigint-dig@0.8.5`

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [ ] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
