### PR TITLE
test: add queue unit tests, fix shuffle append bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix crashing when attempting to add a song to a playlist
+- Fix incorrect shuffle order after appending a track while shuffle is enabled
 
 ## [1.3.3]
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -183,6 +183,16 @@ pub struct Config {
 }
 
 impl Config {
+    /// Create a default configuration from in-memory defaults, without touching the filesystem.
+    #[cfg(test)]
+    pub fn new_for_test() -> std::sync::Arc<Self> {
+        std::sync::Arc::new(Self {
+            filename: String::new(),
+            values: RwLock::new(ConfigValues::default()),
+            state: RwLock::new(UserState::default()),
+        })
+    }
+
     /// Generate the configuration from the user configuration file and the runtime state file.
     /// `filename` can be used to look for a differently named configuration file.
     pub fn new(filename: Option<String>) -> Self {

--- a/src/events.rs
+++ b/src/events.rs
@@ -21,6 +21,14 @@ pub struct EventManager {
 }
 
 impl EventManager {
+    /// Create an EventManager backed by a discarded crossbeam channel, for use in tests where no
+    /// events need to be processed.
+    #[cfg(test)]
+    pub fn new_for_test() -> Self {
+        let (cb_sink, _): (CbSink, _) = crossbeam_channel::unbounded();
+        Self::new(cb_sink)
+    }
+
     pub fn new(cursive_sink: CbSink) -> Self {
         let (tx, rx) = unbounded();
 

--- a/src/library.rs
+++ b/src/library.rs
@@ -51,6 +51,24 @@ pub struct Library {
 }
 
 impl Library {
+    /// Create an empty library for use in tests. No cache is loaded and no API calls are made.
+    #[cfg(test)]
+    pub fn new_for_test(ev: EventManager, spotify: Spotify, cfg: Arc<Config>) -> Arc<Self> {
+        Arc::new(Self {
+            tracks: Arc::new(RwLock::new(Vec::new())),
+            albums: Arc::new(RwLock::new(Vec::new())),
+            artists: Arc::new(RwLock::new(Vec::new())),
+            playlists: Arc::new(RwLock::new(Vec::new())),
+            shows: Arc::new(RwLock::new(Vec::new())),
+            is_done: Arc::new(RwLock::new(false)),
+            user_id: None,
+            display_name: None,
+            ev,
+            spotify,
+            cfg,
+        })
+    }
+
     pub fn new(ev: EventManager, spotify: Spotify, cfg: Arc<Config>) -> Self {
         let current_user = spotify.api.current_user().ok();
         let user_id = current_user.as_ref().map(|u| u.id.id().to_string());

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -100,6 +100,24 @@ impl Spotify {
         Ok(spotify)
     }
 
+    /// Create a disconnected Spotify instance for use in tests. No worker thread is started and
+    /// no network connections are made.
+    #[cfg(test)]
+    pub fn new_for_test(cfg: Arc<config::Config>, events: EventManager) -> Self {
+        Self {
+            events,
+            #[cfg(feature = "mpris")]
+            mpris: Default::default(),
+            credentials: Credentials::with_password("test_user", "test_pass"),
+            cfg,
+            status: Arc::new(RwLock::new(PlayerEvent::Stopped)),
+            api: WebApi::new(),
+            elapsed: Arc::new(RwLock::new(None)),
+            since: Arc::new(RwLock::new(None)),
+            channel: Arc::new(RwLock::new(None)),
+        }
+    }
+
     /// Start the worker thread. If `user_tx` is given, it will receive the username of the logged
     /// in user.
     pub fn start_worker(


### PR DESCRIPTION
Add 27 tests covering queue navigation, insertion, removal, shifting, and shuffle logic. Lightweight #[cfg(test)] constructors for Config, EventManager, Spotify, and Library let the queue be tested without any network or filesystem access.

The tests caught a real bug: Queue::append() was adding the wrong index to random_order when shuffle was on, producing duplicates like [0, 1, 1] instead of [0, 1, 2]. Tracks appended while shuffling were therefore unreachable or mapped to the wrong position.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [X] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
