### PR TITLE
feat: sort by added_at in albums list by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix crashing when attempting to add a song to a playlist
 - Fix incorrect shuffle order after appending a track while shuffle is enabled
 
+### Changed
+
+- Sort albums by date they were added in the library view, rather than lexically.
+
 ## [1.3.3]
 
 ### Fixed

--- a/src/library.rs
+++ b/src/library.rs
@@ -1,3 +1,4 @@
+use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::fs::File;
 use std::iter::Iterator;
@@ -465,12 +466,13 @@ impl Library {
                 .strip_prefix("The ")
                 .unwrap_or(&album.artists[0]);
             let album_title = album.title.strip_prefix("The ").unwrap_or(&album.title);
-            format!(
-                "{}{}{}",
+            Reverse(format!(
+                "{:?}{}{}{}",
+                album.added_at,
                 album_artist.to_lowercase(),
                 album.year,
                 album_title.to_lowercase()
-            )
+            ))
         });
 
         *self.albums.write().unwrap() = albums;
@@ -725,10 +727,8 @@ impl Library {
         {
             let mut store = self.albums.write().unwrap();
             if !store.iter().any(|a| a.id == album.id) {
+                // just insert at the beginning, since that's recency
                 store.insert(0, album.clone());
-
-                // resort list of albums
-                store.sort_unstable_by_key(|a| format!("{}{}{}", a.artists[0], a.year, a.title));
             }
         }
 


### PR DESCRIPTION
## Describe your changes

Changes the default behavior of the Albums list in the library view to sort by date the album was saved. Old behavior was a lexical ordering, which is in my opinion not useful, and deviates from the behavior of the Tracks and Playlists tabs. (Artists list should also probably follow.)

Disclaimer: I'm a Rust noob and just guessed. But it compiles and works. Note I just removed the resorting behavior from save_album, since inserting at the 0 index does what we want.

## Issue ticket number and link

https://github.com/hrkfdn/ncspot/issues/747

## Checklist before requesting a review
- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
