### PR TITLE
feat: Replace ueberzug cover drawing with viuer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Draw cover art directly in supported terminals using terminal image
+  protocols, falling back to block rendering when unsupported
+
 ## [1.3.4]
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_colours"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14eec43e0298190790f41679fe69ef7a829d2a2ddd78c8c00339e84710e435fe"
+dependencies = [
+ "rgb",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,6 +610,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,6 +780,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.10.0",
+ "crossterm_winapi",
+ "document-features",
+ "parking_lot",
+ "rustix 1.1.2",
+ "winapi",
+]
+
+[[package]]
 name = "crossterm_winapi"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,7 +836,7 @@ dependencies = [
  "ahash",
  "cfg-if",
  "crossbeam-channel",
- "crossterm",
+ "crossterm 0.28.1",
  "cursive_core",
  "lazy_static",
  "libc",
@@ -1060,6 +1094,12 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -1855,6 +1895,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "icy_sixel"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccc0a9c4770bc47b0a933256a496cfb8b6531f753ea9bccb19c6dff0ff7273fc"
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1899,6 +1945,8 @@ dependencies = [
  "num-traits",
  "png",
  "tiff",
+ "zune-core",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -2423,6 +2471,7 @@ dependencies = [
  "cursive",
  "fern",
  "futures",
+ "image",
  "ioctl-rs",
  "libc",
  "librespot-core",
@@ -2450,6 +2499,7 @@ dependencies = [
  "toml",
  "unicode-width 0.2.2",
  "url",
+ "viuer",
  "zbus",
 ]
 
@@ -3642,6 +3692,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4438,6 +4497,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "termion"
 version = "4.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4983,6 +5051,22 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "viuer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3a696d8afebb0cae4b263ff8cae3286b20ea88df0a82187b13ee6fe8398dce"
+dependencies = [
+ "ansi_colours",
+ "base64",
+ "console",
+ "crossterm 0.29.0",
+ "icy_sixel",
+ "image",
+ "tempfile",
+ "termcolor",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ crossbeam-channel = "0.5"
 zbus = {version = "5.16.0", default-features = false, features = ["tokio"], optional = true}
 fern = "0.7"
 futures = "0.3"
+image = {version = "0.25", default-features = false, features = ["jpeg", "png"], optional = true}
 ioctl-rs = {version = "0.2", optional = true}
 libc = "0.2.186"
 librespot-core = "0.8.0"
@@ -74,6 +75,7 @@ tokio-stream = {version = "0.1.18", features = ["sync"]}
 toml = "1.1"
 unicode-width = "0.2.2"
 url = "2.5"
+viuer = {version = "0.11", default-features = false, features = ["icy_sixel"], optional = true}
 
 [target.'cfg(unix)'.dependencies]
 signal-hook = "0.4.4"
@@ -96,7 +98,7 @@ optional = true
 
 [features]
 alsa_backend = ["librespot-playback/alsa-backend"]
-cover = ["ioctl-rs"] # Support displaying the album cover
+cover = ["image", "ioctl-rs", "viuer"] # Support displaying the album cover
 default = ["share_clipboard", "pulseaudio_backend", "mpris", "notify", "crossterm_backend"]
 mpris = ["zbus"] # Allow ncspot to be controlled via MPRIS API
 ncurses_backend = ["cursive/ncurses-backend"]

--- a/doc/users.md
+++ b/doc/users.md
@@ -40,7 +40,6 @@ here are the runtime dependencies:
 - `dbus`, `libncurses`, `libssl`
 - `libpulse` (or `portaudio`, if built using the PortAudio backend)
 - `libxcb` (if built with the `clipboard` feature)
-- `ueberzug` or a compatible implementation (e.g. `ueberzugpp`) (if built with the `cover` feature)
 
 ### On BSD's
 Your distribution may have packaged `ncspot` in its package repository.
@@ -262,7 +261,7 @@ Possible configuration values are:
 | `repeat`                        | Set default repeat mode                                        | `"off"`, `"track"`, `"playlist"`                                                      | `"off"`             |
 | `playback_state`                | Set default playback state                                     | `"Stopped"`, `"Paused"`, `"Playing"`, `"Default"`                                     | `"Paused"`          |
 | `library_tabs`                  | Tabs to show in library screen                                 | Array of `"tracks"`, `"albums"`, `"artists"`, `"playlists"`, `"podcasts"`, `"browse"` | All tabs            |
-| `cover_max_scale`<sup>[1]</sup> | Set maximum scaling ratio for cover art                        | Number                                                                                | `1.0`               |
+| `cover_max_scale`<sup>[1]</sup> | Set maximum scaling ratio for cover art                        | Number                                                                                | No limit            |
 | `hide_display_names`            | Hides spotify usernames in the library header and on playlists | `true`, `false`                                                                       | `false`             |
 | `statusbar_format`              | Formatting for tracks in the statusbar                         | See [track_formatting](#track-formatting)                                             | `%artists - %track` |
 | `[track_format]`                | Set active fields shown in Library/Queue views                 | See [track formatting](#track-formatting)                                             |                     |
@@ -440,14 +439,13 @@ body = "%artists"
 ### Cover Drawing
 When compiled with the `cover` feature, `ncspot` can draw the album art of the
 current track in a dedicated view (`:focus cover` or <kbd>F8</kbd> by default)
-using Überzug. The original project has been abandoned, therefore using a
-compatible implementation such as [Überzug++](https://github.com/jstkdng/ueberzugpp)
-is recommended. For more information on installation and terminal
-compatibility, consult that repository.
+using terminal image protocols supported by your terminal, such as Kitty,
+iTerm2, or Sixel. If no supported graphics protocol is detected, `ncspot`
+falls back to colored terminal blocks.
 
-To allow scaling up the album art beyond its native resolution (640x640 for
-Spotify covers), use the config key `cover_max_scale`. This is especially useful
-for HiDPI displays:
+By default, cover art scales to fit the available terminal view. To limit
+scaling beyond the image's native resolution, use the config key
+`cover_max_scale`:
 
 ```toml
 cover_max_scale = 2

--- a/src/application.rs
+++ b/src/application.rs
@@ -245,6 +245,11 @@ impl Application {
         // cursive event loop
         while self.cursive.is_running() {
             self.cursive.step();
+            #[cfg(feature = "cover")]
+            self.cursive
+                .call_on_name("cover", |view: &mut ui::cover::CoverView| {
+                    view.render_to_terminal();
+                });
             #[cfg(unix)]
             for signal in signals.pending() {
                 if signal == SIGTERM || signal == SIGHUP {

--- a/src/ui/cover.rs
+++ b/src/ui/cover.rs
@@ -1,7 +1,6 @@
 use std::collections::HashSet;
 use std::io::Write;
 use std::path::PathBuf;
-use std::process::{Child, Stdio};
 
 use std::sync::{Arc, RwLock};
 
@@ -23,16 +22,24 @@ pub struct CoverView {
     queue: Arc<Queue>,
     library: Arc<Library>,
     loading: Arc<RwLock<HashSet<String>>>,
-    last_size: RwLock<Vec2>,
-    drawn_url: RwLock<Option<String>>,
-    ueberzug: RwLock<Option<Child>>,
+    desired_cover: RwLock<Option<CoverRequest>>,
+    rendered_cover: RwLock<Option<CoverRequest>>,
+    cover_max_scale: Option<f32>,
     font_size: Vec2,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct CoverRequest {
+    url: String,
+    path: PathBuf,
+    offset: Vec2,
+    size: Vec2,
 }
 
 impl CoverView {
     pub fn new(queue: Arc<Queue>, library: Arc<Library>, config: &Config) -> Self {
         // Determine size of window both in pixels and chars
-        let (rows, cols, mut xpixels, mut ypixels) = unsafe {
+        let (rows, cols, xpixels, ypixels) = unsafe {
             let mut query: (u16, u16, u16, u16) = (0, 0, 0, 0);
             ioctl(1, TIOCGWINSZ, &mut query);
             query
@@ -40,22 +47,26 @@ impl CoverView {
 
         debug!("Determined window dimensions: {xpixels}x{ypixels}, {cols}x{rows}");
 
-        // Determine font size, considering max scale to prevent tiny covers on HiDPI screens
-        let scale = config.values().cover_max_scale.unwrap_or(1.0);
-        xpixels = ((xpixels as f32) / scale) as u16;
-        ypixels = ((ypixels as f32) / scale) as u16;
-
-        let font_size = Vec2::new((xpixels / cols) as usize, (ypixels / rows) as usize);
+        // Determine font size. Some terminals report physical pixels here, but
+        // the aspect ratio is still useful when mapping images to terminal cells.
+        let font_size = if cols == 0 || rows == 0 || xpixels == 0 || ypixels == 0 {
+            Vec2::new(8, 16)
+        } else {
+            Vec2::new(
+                std::cmp::max(1, xpixels / cols) as usize,
+                std::cmp::max(1, ypixels / rows) as usize,
+            )
+        };
 
         debug!("Determined font size: {}x{}", font_size.x, font_size.y);
 
         Self {
             queue,
             library,
-            ueberzug: RwLock::new(None),
             loading: Arc::new(RwLock::new(HashSet::new())),
-            last_size: RwLock::new(Vec2::new(0, 0)),
-            drawn_url: RwLock::new(None),
+            desired_cover: RwLock::new(None),
+            rendered_cover: RwLock::new(None),
+            cover_max_scale: config.values().cover_max_scale,
             font_size,
         }
     }
@@ -65,44 +76,16 @@ impl CoverView {
             return;
         }
 
-        let needs_redraw = {
-            let last_size = self.last_size.read().unwrap();
-            let drawn_url = self.drawn_url.read().unwrap();
-            *last_size != draw_size || drawn_url.as_ref() != Some(&url)
-        };
-
-        if !needs_redraw {
-            return;
-        }
-
         let path = match self.cache_path(url.clone()) {
             Some(p) => p,
             None => return,
         };
 
-        let mut img_size = Vec2::new(640, 640);
-
-        let draw_size_pxls = draw_size * self.font_size;
-        let ratio = f32::min(
-            f32::min(
-                draw_size_pxls.x as f32 / img_size.x as f32,
-                draw_size_pxls.y as f32 / img_size.y as f32,
-            ),
-            1.0,
-        );
-
-        img_size = Vec2::new(
-            (ratio * img_size.x as f32) as usize,
-            (ratio * img_size.y as f32) as usize,
-        );
-
-        // Ueberzug takes an area given in chars and fits the image to
-        // that area (from the top left). Since we want to center the
-        // image at least horizontally, we need to fiddle around a bit.
-        let mut size = img_size / self.font_size;
+        let image_size = image::image_dimensions(&path).unwrap_or((640, 640));
+        let mut size = self.cover_size(draw_size, image_size);
 
         // Make sure there is equal space in chars on either side
-        if size.x % 2 != draw_size.x % 2 {
+        if size.x > 1 && size.x % 2 != draw_size.x % 2 {
             size.x -= 1;
         }
 
@@ -114,54 +97,37 @@ impl CoverView {
         draw_offset.x += (draw_size.x - size.x) / 2;
         draw_offset.y += (draw_size.y - size.y) - (draw_size.y - size.y) / 2;
 
-        let cmd = format!(
-            "{{\"action\":\"add\",\"scaler\":\"fit_contain\",\"identifier\":\"cover\",\"x\":{},\"y\":{},\"width\":{},\"height\":{},\"path\":\"{}\"}}\n",
-            draw_offset.x,
-            draw_offset.y,
-            size.x,
-            size.y,
-            path.to_str().unwrap()
-        );
-
-        if let Err(e) = self.run_ueberzug_cmd(&cmd) {
-            error!("Failed to run Ueberzug: {e}");
-            return;
-        }
-
-        let mut last_size = self.last_size.write().unwrap();
-        *last_size = draw_size;
-
-        let mut drawn_url = self.drawn_url.write().unwrap();
-        *drawn_url = Some(url);
+        let mut desired_cover = self.desired_cover.write().unwrap();
+        *desired_cover = Some(CoverRequest {
+            url,
+            path,
+            offset: draw_offset,
+            size,
+        });
     }
 
     fn clear_cover(&self) {
-        let mut drawn_url = self.drawn_url.write().unwrap();
-        *drawn_url = None;
-
-        let cmd = "{\"action\": \"remove\", \"identifier\": \"cover\"}\n";
-        if let Err(e) = self.run_ueberzug_cmd(cmd) {
-            error!("Failed to run Ueberzug: {e}");
-        }
+        let mut desired_cover = self.desired_cover.write().unwrap();
+        *desired_cover = None;
     }
 
-    fn run_ueberzug_cmd(&self, cmd: &str) -> Result<(), std::io::Error> {
-        let mut ueberzug = self.ueberzug.write().unwrap();
-
-        if ueberzug.is_none() {
-            *ueberzug = Some(
-                std::process::Command::new("ueberzug")
-                    .args(["layer", "--silent"])
-                    .stdin(Stdio::piped())
-                    .stdout(Stdio::piped())
-                    .spawn()?,
-            );
+    fn cover_size(&self, draw_size: Vec2, image_size: (u32, u32)) -> Vec2 {
+        let (image_width, image_height) = image_size;
+        if image_width == 0 || image_height == 0 {
+            return draw_size;
         }
 
-        let stdin = (*ueberzug).as_mut().unwrap().stdin.as_mut().unwrap();
-        stdin.write_all(cmd.as_bytes())?;
+        let mut available_size = draw_size;
+        if let Some(scale) = self.cover_max_scale {
+            let max_size = Vec2::new(
+                ((image_width as f32 * scale) / self.font_size.x as f32) as usize,
+                ((image_height as f32 * scale) / self.font_size.y as f32) as usize,
+            );
+            available_size.x = std::cmp::min(available_size.x, std::cmp::max(1, max_size.x));
+            available_size.y = std::cmp::min(available_size.y, std::cmp::max(1, max_size.y));
+        }
 
-        Ok(())
+        fit_image_to_cells(available_size, self.font_size, image_width, image_height)
     }
 
     fn cache_path(&self, url: String) -> Option<PathBuf> {
@@ -189,6 +155,117 @@ impl CoverView {
 
         None
     }
+
+    pub fn render_to_terminal(&self) {
+        let desired_cover = self.desired_cover.read().unwrap().clone();
+        let mut rendered_cover = self.rendered_cover.write().unwrap();
+
+        if *rendered_cover == desired_cover {
+            return;
+        }
+
+        if let Some(rendered) = rendered_cover.as_ref() {
+            clear_terminal_area(rendered.offset, rendered.size);
+        }
+
+        if let Some(cover) = desired_cover.as_ref()
+            && let Err(e) = render_cover_to_terminal(cover)
+        {
+            error!("Failed to draw cover: {e}");
+            return;
+        }
+
+        *rendered_cover = desired_cover;
+    }
+}
+
+fn render_cover_to_terminal(cover: &CoverRequest) -> Result<(), viuer::ViuError> {
+    let config = viuer::Config {
+        x: to_u16(cover.offset.x)?,
+        y: to_i16(cover.offset.y)?,
+        width: Some(cover.size.x as u32),
+        height: Some(cover.size.y as u32),
+        absolute_offset: true,
+        restore_cursor: true,
+        use_kitty: can_use_kitty_graphics(),
+        use_sixel: !is_iterm_terminal(),
+        ..Default::default()
+    };
+
+    let image = image::ImageReader::open(&cover.path)?
+        .with_guessed_format()?
+        .decode()?;
+
+    viuer::print(&image, &config).map(|_| ())
+}
+
+fn is_iterm_terminal() -> bool {
+    std::env::var("TERM_PROGRAM").is_ok_and(|term| term.contains("iTerm"))
+        || std::env::var("LC_TERMINAL").is_ok_and(|term| term.contains("iTerm"))
+}
+
+fn is_apple_terminal() -> bool {
+    std::env::var("TERM_PROGRAM").is_ok_and(|term| term == "Apple_Terminal")
+}
+
+fn can_use_kitty_graphics() -> bool {
+    !is_apple_terminal()
+}
+
+fn fit_image_to_cells(
+    available_size: Vec2,
+    font_size: Vec2,
+    image_width: u32,
+    image_height: u32,
+) -> Vec2 {
+    if available_size.x == 0 || available_size.y == 0 || font_size.x == 0 || font_size.y == 0 {
+        return Vec2::new(0, 0);
+    }
+
+    let image_aspect = image_width as f32 / image_height as f32;
+    let cell_aspect = font_size.x as f32 / font_size.y as f32;
+    let width_for_full_height =
+        (available_size.y as f32 * image_aspect / cell_aspect).floor() as usize;
+
+    if width_for_full_height <= available_size.x {
+        Vec2::new(std::cmp::max(1, width_for_full_height), available_size.y)
+    } else {
+        let height_for_full_width =
+            (available_size.x as f32 * cell_aspect / image_aspect).floor() as usize;
+        Vec2::new(available_size.x, std::cmp::max(1, height_for_full_width))
+    }
+}
+
+fn clear_terminal_area(offset: Vec2, size: Vec2) {
+    let mut stdout = std::io::stdout();
+
+    // Remove stateful Kitty graphics where that protocol is available, then
+    // overwrite the cells used by other protocols/fallbacks.
+    if can_use_kitty_graphics() {
+        let _ = stdout.write_all(b"\x1b_Ga=d,d=A\x1b\\");
+    }
+    for y in offset.y..offset.y + size.y {
+        let _ = write!(
+            stdout,
+            "\x1b[{};{}H{}",
+            y + 1,
+            offset.x + 1,
+            " ".repeat(size.x)
+        );
+    }
+    let _ = stdout.flush();
+}
+
+fn to_u16(value: usize) -> Result<u16, viuer::ViuError> {
+    u16::try_from(value).map_err(|_| {
+        viuer::ViuError::InvalidConfiguration("cover coordinate is too large".to_string())
+    })
+}
+
+fn to_i16(value: usize) -> Result<i16, viuer::ViuError> {
+    i16::try_from(value).map_err(|_| {
+        viuer::ViuError::InvalidConfiguration("cover coordinate is too large".to_string())
+    })
 }
 
 impl View for CoverView {
@@ -225,6 +302,7 @@ impl ViewExt for CoverView {
 
     fn on_leave(&self) {
         self.clear_cover();
+        self.render_to_terminal();
     }
 
     fn on_command(&mut self, _s: &mut Cursive, cmd: &Command) -> Result<CommandResult, String> {


### PR DESCRIPTION
Render cover art directly in the terminal with viuer instead of spawning ueberzug. This uses terminal graphics protocols where available and falls back to block rendering when unsupported.

Rendering happens after the Cursive frame has flushed so the UI does not overwrite the image. Cover sizing follows the available terminal view, guards terminals that report zero pixels, avoids unsupported Kitty probe/clear output in Apple Terminal, and forces iTerm onto its native image protocol.

Fixes #989

Fixes #1777

Fixes #860

Fixes #638

Fixes #590

Fixes #580

Refs #481

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
