### PR TITLE
docs: fix default keybindings value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Draw cover art directly in supported terminals using terminal image
   protocols, falling back to block rendering when unsupported
 
+### Fixed
+
+- Correct the documented default value for `default_keybindings`
+
 ## [1.3.4]
 
 ### Changed

--- a/doc/users.md
+++ b/doc/users.md
@@ -253,7 +253,7 @@ Possible configuration values are:
 | `audio_cache_size`              | Maximum size of audio cache in MiB                             | Number                                                                                |                     |
 | `volnorm`                       | Enable volume normalization                                    | `true`, `false`                                                                       | `false`             |
 | `volnorm_pregain`               | Normalization pregain to apply in dB (if enabled)              | Number                                                                                | `0.0`               |
-| `default_keybindings`           | Enable default keybindings                                     | `true`, `false`                                                                       | `false`             |
+| `default_keybindings`           | Enable default keybindings                                     | `true`, `false`                                                                       | `true`              |
 | `notify`<sup>[4]</sup>          | Enable desktop notifications                                   | `true`, `false`                                                                       | `false`             |
 | `bitrate`                       | Audio bitrate to use for streaming                             | `96`, `160`, `320`                                                                    | `320`               |
 | `gapless`                       | Enable gapless playback                                        | `true`, `false`                                                                       | `true`              |


### PR DESCRIPTION
The configuration table listed `default_keybindings` as false, but the code enables default keybindings when the option is omitted.

Update the documented default so users do not think they need to opt in to the built-in bindings.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [X] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [X] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
