### PR TITLE
fix: let escape close search screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Draw cover art directly in supported terminals using terminal image
   protocols, falling back to block rendering when unsupported
 
+### Fixed
+
+- Close the Search screen with the Escape key
+
 ## [1.3.4]
 
 ### Changed

--- a/doc/users.md
+++ b/doc/users.md
@@ -75,7 +75,7 @@ playback depending on your desktop environment settings. Have a look at the
 | <kbd>F8</kbd>     | Album Art (if built with the `cover` feature).                                |
 | <kbd>/</kbd>      | Open a Vim-like search bar (See [specific commands](#vim-like-search-bar)).   |
 | <kbd>:</kbd>      | Open a Vim-like command prompt (See [specific commands](#vim-like-commands)). |
-| <kbd>Escape</kbd> | Close Vim-like search bar or command prompt.                                  |
+| <kbd>Escape</kbd> | Close Vim-like search bar, command prompt, or Search screen.                  |
 | <kbd>Q</kbd>      | Quit `ncspot`.                                                                |
 | <kbd>g</kbd>      | Go to the top of the current view (Vim motion).                               |
 | <kbd>G</kbd>      | Go to the bottom of the current view (Vim motion).                            |

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -473,6 +473,7 @@ impl CommandManager {
         #[cfg(feature = "cover")]
         kb.insert("F8".into(), vec![Command::Focus("cover".into())]);
         kb.insert("?".into(), vec![Command::Help]);
+        kb.insert("Esc".into(), vec![Command::Back]);
         kb.insert("Backspace".into(), vec![Command::Back]);
 
         kb.insert("o".into(), vec![Command::Open(TargetMode::Selected)]);

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -26,6 +26,7 @@ pub struct Layout {
     stack: HashMap<String, Vec<Box<dyn ViewExt>>>,
     statusbar: Box<dyn View>,
     focus: Option<String>,
+    previous_focus: Option<String>,
     cmdline: EditView,
     cmdline_focus: bool,
     result: Result<Option<String>, String>,
@@ -94,6 +95,7 @@ impl Layout {
             stack: HashMap::new(),
             statusbar: status.into_boxed_view(),
             focus: None,
+            previous_focus: None,
             cmdline: command_line_input,
             cmdline_focus: false,
             result: Ok(None),
@@ -145,6 +147,11 @@ impl Layout {
         }
 
         let s = id.into();
+        if let Some(current_focus) = &self.focus
+            && current_focus != &s
+        {
+            self.previous_focus = Some(current_focus.clone());
+        }
         self.focus = Some(s);
         self.cmdline_focus = false;
 
@@ -189,6 +196,20 @@ impl Layout {
         }
 
         self.get_focussed_stack_mut().map(|stack| stack.pop());
+    }
+
+    fn back(&mut self) {
+        if !self.is_current_stack_empty() {
+            self.pop_view();
+            return;
+        }
+
+        if self.focus.as_deref() == Some("search")
+            && let Some(previous_focus) = self.previous_focus.clone()
+            && self.screens.contains_key(&previous_focus)
+        {
+            self.set_screen(previous_focus);
+        }
     }
 
     #[allow(clippy::borrowed_box)]
@@ -484,7 +505,7 @@ impl ViewExt for Layout {
                 Ok(CommandResult::Consumed(None))
             }
             Command::Back => {
-                self.pop_view();
+                self.back();
                 Ok(CommandResult::Consumed(None))
             }
             _ => {


### PR DESCRIPTION
Bind Escape to the existing back command and teach back to leave the Search screen when there is no nested view to pop.

This keeps custom Escape bindings overridable while making F2 search behave like users expect.

Fixes #1724
Fixes #1391

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [X] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [X] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
