### PR TITLE
feat: make list search accent-insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Draw cover art directly in supported terminals using terminal image
   protocols, falling back to block rendering when unsupported
+- Match accented characters in the Vim-like list search
 
 ## [1.3.4]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2497,6 +2497,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "toml",
+ "unicode-normalization",
  "unicode-width 0.2.2",
  "url",
  "viuer",
@@ -4910,6 +4911,15 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ tokio = {version = "1", features = ["rt-multi-thread", "sync", "time", "net"]}
 tokio-util = {version = "0.7.18", features = ["codec"]}
 tokio-stream = {version = "0.1.18", features = ["sync"]}
 toml = "1.1"
+unicode-normalization = "0.1.25"
 unicode-width = "0.2.2"
 url = "2.5"
 viuer = {version = "0.11", default-features = false, features = ["icy_sixel"], optional = true}

--- a/src/ui/listview.rs
+++ b/src/ui/listview.rs
@@ -31,6 +31,7 @@ use crate::ui::album::AlbumView;
 use crate::ui::artist::ArtistView;
 use crate::ui::contextmenu::ContextMenu;
 use crate::ui::pagination::Pagination;
+use crate::utils::{normalize_search_text, normalized_match_ranges};
 
 pub enum MouseHandleResult {
     Handled(EventResult),
@@ -141,14 +142,11 @@ impl<I: ListItem + Clone> ListView<I> {
 
     pub fn get_indexes_of(&self, query: &str) -> Vec<usize> {
         let content = self.content.read().unwrap();
+        let query = normalize_search_text(query);
         content
             .iter()
             .enumerate()
-            .filter(|(_, i)| {
-                i.display_left(&self.library)
-                    .to_lowercase()
-                    .contains(&query[..].to_lowercase())
-            })
+            .filter(|(_, i)| normalize_search_text(&i.display_left(&self.library)).contains(&query))
             .map(|(i, _)| i)
             .collect()
     }
@@ -397,11 +395,7 @@ impl<I: ListItem + Clone> View for ListView<I> {
                     let fg = *printer.theme.palette.custom("search_match").unwrap();
                     let matched_style = ColorStyle::new(fg, style.back);
 
-                    let matches: Vec<(usize, usize)> = left
-                        .to_lowercase()
-                        .match_indices(&self.search_query)
-                        .map(|i| (i.0, i.0 + i.1.len()))
-                        .collect();
+                    let matches = normalized_match_ranges(&left, &self.search_query);
 
                     for m in matches {
                         printer.with_color(matched_style, |printer| {
@@ -588,7 +582,7 @@ impl<I: ListItem + Clone> ViewExt for ListView<I> {
             }
             Command::Jump(mode) => match mode {
                 JumpMode::Query(query) => {
-                    self.search_query = query.to_lowercase();
+                    self.search_query = normalize_search_text(query);
                     self.search_indexes = self.get_indexes_of(query);
                     self.search_selected_index = 0;
                     match self.search_indexes.first() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 use std::{fmt::Write, path::PathBuf};
+use unicode_normalization::{UnicodeNormalization, char::is_combining_mark};
 
 /// Returns a human readable String of a Duration
 ///
@@ -59,6 +60,65 @@ pub fn download(url: String, path: std::path::PathBuf) -> Result<(), std::io::Er
     Ok(())
 }
 
+pub fn normalize_search_text(text: &str) -> String {
+    text.chars()
+        .flat_map(char::to_lowercase)
+        .nfd()
+        .filter(|c| !is_combining_mark(*c))
+        .collect()
+}
+
+fn normalize_search_text_with_ranges(text: &str) -> (String, Vec<(usize, usize, usize, usize)>) {
+    let mut normalized = String::new();
+    let mut ranges = Vec::new();
+
+    for (original_start, character) in text.char_indices() {
+        let original_end = original_start + character.len_utf8();
+
+        for normalized_character in character
+            .to_lowercase()
+            .nfd()
+            .filter(|c| !is_combining_mark(*c))
+        {
+            let normalized_start = normalized.len();
+            normalized.push(normalized_character);
+            ranges.push((
+                normalized_start,
+                normalized.len(),
+                original_start,
+                original_end,
+            ));
+        }
+    }
+
+    (normalized, ranges)
+}
+
+pub fn normalized_match_ranges(text: &str, query: &str) -> Vec<(usize, usize)> {
+    let query = normalize_search_text(query);
+    if query.is_empty() {
+        return Vec::new();
+    }
+
+    let (normalized_text, ranges) = normalize_search_text_with_ranges(text);
+    normalized_text
+        .match_indices(&query)
+        .filter_map(|(match_start, matched)| {
+            let match_end = match_start + matched.len();
+            let mut matching_ranges = ranges
+                .iter()
+                .filter(|(start, end, _, _)| *start >= match_start && *end <= match_end);
+
+            let (_, _, original_start, mut original_end) = *matching_ranges.next()?;
+            for (_, _, _, range_end) in matching_ranges {
+                original_end = *range_end;
+            }
+
+            Some((original_start, original_end))
+        })
+        .collect()
+}
+
 /// Create the application specific runtime directory and return the path to it.
 ///
 /// If the directory already exists and has the correct permissions, this function just returns the
@@ -114,4 +174,30 @@ pub fn user_runtime_directory() -> Option<PathBuf> {
 #[cfg(unix)]
 fn xdg_runtime_directory() -> Option<PathBuf> {
     std::env::var("XDG_RUNTIME_DIR").ok().map(Into::into)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn search_normalization_ignores_accents_and_case() {
+        assert_eq!(
+            normalize_search_text("Tití Me Preguntó"),
+            "titi me pregunto"
+        );
+        assert_eq!(normalize_search_text("CAFÉ"), "cafe");
+    }
+
+    #[test]
+    fn normalized_match_ranges_map_back_to_original_text() {
+        let text = "Tití Me Preguntó";
+        let ranges = normalized_match_ranges(text, "pregunto");
+        let matches: Vec<&str> = ranges
+            .iter()
+            .map(|(start, end)| &text[*start..*end])
+            .collect();
+
+        assert_eq!(matches, vec!["Preguntó"]);
+    }
 }


### PR DESCRIPTION
Normalize list-search queries and displayed titles by lowercasing and stripping combining marks before matching.

Map highlighted matches back to the original string ranges so accented text is still rendered correctly in the UI.

Fixes #1800

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [X] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [X] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
