### PR TITLE
Add playlist startup autoplay CLI option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Draw cover art directly in supported terminals using terminal image
   protocols, falling back to block rendering when unsupported
+- Add `--playlist` to start the TUI and automatically play a Spotify playlist
+  from a playlist URL or ID
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Snapcraft) and the BSD's. Detailed installation instructions for each platform c
 
 ## Configuration
 A configuration file can be provided. The default location is `~/.config/ncspot`. Detailed
-configuration information can be found [here](/doc/users.md#configuration).
+configuration information can be found [here](/doc/users.md#configuration). Command line options
+are documented [here](/doc/users.md#command-line-options).
 
 ## Building
 Building ncspot requires a working [Rust installation](https://www.rust-lang.org/tools/install) and

--- a/doc/users.md
+++ b/doc/users.md
@@ -59,6 +59,29 @@ recent version is available for your OS, you can use the following command to in
 cargo install --locked ncspot
 ```
 
+## Command Line Options
+`ncspot` starts the TUI by default. The following top-level options are available:
+
+| Option | Description |
+|--------|-------------|
+| `-d`, `--debug` \<FILE\> | Enable debug logging to the specified file. |
+| `-b`, `--basepath` \<PATH\> | Use a custom base path for configuration and cache files. |
+| `-c`, `--config` \<FILE\> | Use a config file name relative to the base path. Defaults to `config.toml`. |
+| `--playlist` \<URL_OR_ID\> | Start the TUI and automatically play the specified Spotify playlist. Accepts a Spotify playlist URL or playlist ID. |
+
+Examples:
+
+```zsh
+ncspot --playlist 'https://open.spotify.com/playlist/6UUCMxk575eDTwSWa0qQhB?si=fa799fec9a404660'
+ncspot --playlist '6UUCMxk575eDTwSWa0qQhB?si=fa799fec9a404660'
+```
+
+The `info` subcommand prints the platform-specific configuration, cache, and runtime directories:
+
+```zsh
+ncspot info
+```
+
 ## Key Bindings
 The keybindings listed below are configured by default. Additionally, if you
 built `ncspot` with MPRIS support, you may be able to use media keys to control

--- a/src/application.rs
+++ b/src/application.rs
@@ -15,6 +15,7 @@ use crate::commands::CommandManager;
 use crate::config::{Config, PlaybackState};
 use crate::events::{Event, EventManager};
 use crate::library::Library;
+use crate::model::playlist::Playlist;
 use crate::queue::Queue;
 use crate::spotify::{PlayerEvent, Spotify};
 use crate::ui::create_cursive;
@@ -80,7 +81,10 @@ impl Application {
     /// # Arguments
     ///
     /// * `configuration_file_path` - Relative path to the configuration file inside the base path
-    pub fn new(configuration_file_path: Option<String>) -> Result<Self, Box<dyn Error>> {
+    pub fn new(
+        configuration_file_path: Option<String>,
+        startup_playlist_id: Option<String>,
+    ) -> Result<Self, Box<dyn Error>> {
         // Things here may cause the process to abort; we must do them before creating curses
         // windows otherwise the error message will not be seen by a user
 
@@ -141,23 +145,27 @@ impl Application {
         #[cfg(feature = "mpris")]
         spotify.set_mpris(mpris_manager.clone());
 
-        // Load the last played track into the player
-        let playback_state = configuration.state().playback_state.clone();
-        let queue_state = configuration.state().queuestate.clone();
+        if let Some(playlist_id) = startup_playlist_id.as_deref() {
+            Self::play_startup_playlist(playlist_id, &spotify, &queue)?;
+        } else {
+            // Load the last played track into the player
+            let playback_state = configuration.state().playback_state.clone();
+            let queue_state = configuration.state().queuestate.clone();
 
-        if let Some(playable) = queue.get_current() {
-            spotify.load(
-                &playable,
-                playback_state == PlaybackState::Playing,
-                queue_state.track_progress.as_millis() as u32,
-            );
-            spotify.update_track();
-            match playback_state {
-                PlaybackState::Stopped => {
-                    spotify.stop();
-                }
-                PlaybackState::Paused | PlaybackState::Playing | PlaybackState::Default => {
-                    spotify.pause();
+            if let Some(playable) = queue.get_current() {
+                spotify.load(
+                    &playable,
+                    playback_state == PlaybackState::Playing,
+                    queue_state.track_progress.as_millis() as u32,
+                );
+                spotify.update_track();
+                match playback_state {
+                    PlaybackState::Stopped => {
+                        spotify.stop();
+                    }
+                    PlaybackState::Paused | PlaybackState::Playing | PlaybackState::Default => {
+                        spotify.pause();
+                    }
                 }
             }
         }
@@ -234,6 +242,35 @@ impl Application {
             ipc,
             cursive,
         })
+    }
+
+    fn play_startup_playlist(
+        playlist_id: &str,
+        spotify: &Spotify,
+        queue: &Queue,
+    ) -> Result<(), Box<dyn Error>> {
+        let full_playlist = spotify
+            .api
+            .playlist(playlist_id)
+            .map_err(|()| format!("could not fetch playlist \"{playlist_id}\""))?;
+        let mut playlist = Playlist::from(&full_playlist);
+        playlist.load_tracks(spotify);
+        let tracks = playlist
+            .tracks
+            .as_ref()
+            .ok_or_else(|| format!("could not load tracks from playlist \"{}\"", playlist.name))?;
+
+        if tracks.is_empty() {
+            return Err(format!("playlist \"{}\" has no tracks", playlist.name).into());
+        }
+
+        queue.clear();
+        for track in tracks {
+            queue.append(track.clone());
+        }
+        queue.play(0, true, true);
+
+        Ok(())
     }
 
     /// Start the application and run the event loop.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,5 +44,32 @@ pub fn program_arguments() -> clap::Command {
                 .help("Filename of config file in basepath")
                 .default_value(CONFIGURATION_FILE_NAME),
         )
+        .arg(
+            clap::Arg::new("playlist")
+                .long("playlist")
+                .value_name("URL_OR_ID")
+                .help("Start playback from the Spotify playlist URL or ID"),
+        )
         .subcommands([clap::Command::new("info").about("Print platform information like paths")])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::program_arguments;
+
+    #[test]
+    fn test_program_arguments_accepts_playlist() {
+        let matches = program_arguments()
+            .try_get_matches_from([
+                "ncspot",
+                "--playlist",
+                "https://open.spotify.com/playlist/6UUCMxk575eDTwSWa0qQhB?si=fa799fec9a404660",
+            ])
+            .unwrap();
+
+        assert_eq!(
+            matches.get_one::<String>("playlist").map(String::as_str),
+            Some("https://open.spotify.com/playlist/6UUCMxk575eDTwSWa0qQhB?si=fa799fec9a404660")
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,16 +60,31 @@ fn main() -> Result<(), String> {
         Some(("info", _subcommand_matches)) => cli::info(),
         Some((_, _)) => unreachable!(),
         None => {
-            // Create the application.
-            let mut application =
-                match Application::new(matches.get_one::<String>("config").cloned()) {
-                    Ok(application) => application,
-                    Err(error) => {
+            let startup_playlist_id = match matches.get_one::<String>("playlist") {
+                Some(input) => match spotify_url::SpotifyUrl::playlist_id_from_input(input) {
+                    Some(id) => Some(id),
+                    None => {
+                        let error = format!("invalid Spotify playlist URL or ID: {input}");
                         eprintln!("{error}");
                         error!("{error}");
                         exit(-1);
                     }
-                };
+                },
+                None => None,
+            };
+
+            // Create the application.
+            let mut application = match Application::new(
+                matches.get_one::<String>("config").cloned(),
+                startup_playlist_id,
+            ) {
+                Ok(application) => application,
+                Err(error) => {
+                    eprintln!("{error}");
+                    error!("{error}");
+                    exit(-1);
+                }
+            };
 
             // Start the application event loop.
             application.run()

--- a/src/spotify_url.rs
+++ b/src/spotify_url.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use crate::spotify::UriType;
 
+use rspotify::model::PlaylistId;
 use url::{Host, Url};
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -76,6 +77,39 @@ impl SpotifyUrl {
 
         Some(Self::new(id, uri_type))
     }
+
+    /// Extract a playlist id from a Spotify playlist URL or a raw playlist id.
+    pub fn playlist_id_from_input<S: AsRef<str>>(s: S) -> Option<String> {
+        let input = s.as_ref().trim();
+        if input.is_empty() {
+            return None;
+        }
+
+        if let Some(url) = Self::from_url(input) {
+            if url.uri_type != UriType::Playlist {
+                return None;
+            }
+
+            return Self::validated_playlist_id(&url.id);
+        }
+
+        let id = input
+            .split(['?', '#'])
+            .next()
+            .unwrap_or_default()
+            .trim_end_matches('/');
+
+        Self::validated_playlist_id(id)
+    }
+
+    fn validated_playlist_id(id: &str) -> Option<String> {
+        if id.is_empty() {
+            return None;
+        }
+
+        PlaylistId::from_id(id).ok()?;
+        Some(id.to_string())
+    }
 }
 
 #[cfg(test)]
@@ -122,5 +156,85 @@ mod tests {
             assert_eq!(result.id, case.1.id);
             assert_eq!(result.uri_type, case.1.uri_type);
         }
+    }
+
+    #[test]
+    fn test_playlist_id_from_input_accepts_playlist_url() {
+        assert_eq!(
+            SpotifyUrl::playlist_id_from_input(
+                "https://open.spotify.com/playlist/6UUCMxk575eDTwSWa0qQhB?si=fa799fec9a404660"
+            ),
+            Some("6UUCMxk575eDTwSWa0qQhB".to_string())
+        );
+    }
+
+    #[test]
+    fn test_playlist_id_from_input_accepts_raw_id() {
+        assert_eq!(
+            SpotifyUrl::playlist_id_from_input("6UUCMxk575eDTwSWa0qQhB"),
+            Some("6UUCMxk575eDTwSWa0qQhB".to_string())
+        );
+    }
+
+    #[test]
+    fn test_playlist_id_from_input_accepts_raw_id_with_query() {
+        assert_eq!(
+            SpotifyUrl::playlist_id_from_input("6UUCMxk575eDTwSWa0qQhB?si=fa799fec9a404660"),
+            Some("6UUCMxk575eDTwSWa0qQhB".to_string())
+        );
+    }
+
+    #[test]
+    fn test_playlist_id_from_input_accepts_international_playlist_url() {
+        assert_eq!(
+            SpotifyUrl::playlist_id_from_input(
+                "https://open.spotify.com/intl-pt/playlist/6UUCMxk575eDTwSWa0qQhB"
+            ),
+            Some("6UUCMxk575eDTwSWa0qQhB".to_string())
+        );
+    }
+
+    #[test]
+    fn test_playlist_id_from_input_accepts_legacy_user_playlist_url() {
+        assert_eq!(
+            SpotifyUrl::playlist_id_from_input(
+                "https://open.spotify.com/user/example/playlist/6UUCMxk575eDTwSWa0qQhB"
+            ),
+            Some("6UUCMxk575eDTwSWa0qQhB".to_string())
+        );
+    }
+
+    #[test]
+    fn test_playlist_id_from_input_rejects_non_playlist_url() {
+        assert_eq!(
+            SpotifyUrl::playlist_id_from_input(
+                "https://open.spotify.com/track/6fRJg3R90w0juYoCJXxj2d"
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn test_playlist_id_from_input_rejects_invalid_playlist_url_id() {
+        assert_eq!(
+            SpotifyUrl::playlist_id_from_input("https://open.spotify.com/playlist/invalid_id"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_playlist_id_from_input_rejects_invalid_raw_id() {
+        assert_eq!(
+            SpotifyUrl::playlist_id_from_input("not a playlist id"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_playlist_id_from_input_rejects_empty_normalized_id() {
+        assert_eq!(
+            SpotifyUrl::playlist_id_from_input("?si=fa799fec9a404660"),
+            None
+        );
     }
 }


### PR DESCRIPTION
## Describe your changes

- Added --playlist <URL_OR_ID> to start ncspot and automatically play a Spotify playlist.
  - Accepts full Spotify playlist URLs and raw playlist IDs.
  - Supports shared playlist IDs with ?si=... suffixes.
  - Rejects invalid or non-playlist inputs before startup.

- Updated startup playback behavior.
  - Loads the requested playlist into the queue.
  - Replaces restored queue state when --playlist is provided.
  - Keeps the configured initial TUI screen.

- Added parser and CLI test coverage.
- Updated user-facing documentation and changelog.

## Issue ticket number and link

N/A

## Checklist before requesting a review

- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
not performance improvements, etc.)