### PR TITLE
fix(mpris): prevent volume update before instance created

### DIFF
--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -87,7 +87,7 @@ impl Spotify {
         spotify.start_worker(Some(user_tx))?;
         let user = ASYNC_RUNTIME.get().unwrap().block_on(user_rx).ok();
         let volume = cfg.state().volume;
-        spotify.set_volume(volume, true);
+        spotify.set_volume(volume, false);
 
         spotify.api.set_worker_channel(spotify.channel.clone());
         spotify


### PR DESCRIPTION
We now try to update the MPRIS volume before an MPRIS instance exists, which show an error message (with the DEBUG priority for some reason) in the logs. This just ensures we don't do that, preventing that message.

## Describe your changes

- Don't send an MPRIS volume update when initializing volume in the `Spotify` struct.

## Issue ticket number and link

\/

## Checklist before requesting a review
- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)
