### PR TITLE
feat: add 10-band software equalizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- 10-band software equalizer with config, runtime commands, and `:eqview` screen
 - Draw cover art directly in supported terminals using terminal image
   protocols, falling back to block rendering when unsupported
 

--- a/doc/users.md
+++ b/doc/users.md
@@ -253,6 +253,7 @@ Possible configuration values are:
 | `audio_cache_size`              | Maximum size of audio cache in MiB                             | Number                                                                                |                     |
 | `volnorm`                       | Enable volume normalization                                    | `true`, `false`                                                                       | `false`             |
 | `volnorm_pregain`               | Normalization pregain to apply in dB (if enabled)              | Number                                                                                | `0.0`               |
+| `[equalizer]`                   | Equalizer settings                                             | See [equalizer](#equalizer)                                                           | disabled            |
 | `default_keybindings`           | Enable default keybindings                                     | `true`, `false`                                                                       | `false`             |
 | `notify`<sup>[4]</sup>          | Enable desktop notifications                                   | `true`, `false`                                                                       | `false`             |
 | `bitrate`                       | Audio bitrate to use for streaming                             | `96`, `160`, `320`                                                                    | `320`               |
@@ -276,6 +277,31 @@ Possible configuration values are:
    is reversed.
 3. Run `ncspot -h` for a list of devices.
 4. If built with the `notify` feature.
+
+### Equalizer
+
+10-band peaking EQ applied in software before audio output.
+
+```toml
+[equalizer]
+enabled = true
+preset = "bass_boost"
+# bands = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+```
+
+Presets: `flat`, `bass_boost`, `treble_boost`, `vocal`.
+
+Runtime commands (command mode `:`):
+
+| Command | Description |
+|---------|-------------|
+| `eq on` / `eq off` / `eq toggle` | Enable or disable EQ |
+| `eq show` | Print current bands |
+| `eq reset` | Reset all bands to 0 dB |
+| `eq preset <name>` | Apply a preset |
+| `eq band <name\|index> <dB>` | Set band gain (-12 .. 12) |
+| `eq band bass +2` | Adjust band by delta |
+| `eqview` | Open equalizer view |
 
 ### Custom Keybindings
 Keybindings can be configured in `[keybindings]` section in `config.toml`.

--- a/src/application.rs
+++ b/src/application.rs
@@ -115,7 +115,7 @@ impl Application {
 
         let event_manager = EventManager::new(cursive.cb_sink().clone());
 
-        let mut spotify =
+        let spotify =
             spotify::Spotify::new(event_manager.clone(), credentials, configuration.clone())?;
 
         let library = Arc::new(Library::new(

--- a/src/audio/eq.rs
+++ b/src/audio/eq.rs
@@ -1,0 +1,270 @@
+use std::sync::{Arc, RwLock};
+
+pub const EQ_NUM_BANDS: usize = 10;
+pub const EQ_MIN_GAIN_DB: f32 = -12.0;
+pub const EQ_MAX_GAIN_DB: f32 = 12.0;
+pub const EQ_SAMPLE_RATE: f32 = 44100.0;
+
+pub const EQ_FREQUENCIES_HZ: [f32; EQ_NUM_BANDS] = [
+    60.0, 170.0, 310.0, 600.0, 1000.0, 3000.0, 6000.0, 9000.0, 12000.0, 14000.0,
+];
+
+pub const EQ_BAND_NAMES: [&str; EQ_NUM_BANDS] = [
+    "sub",
+    "bass",
+    "low_mid",
+    "mid",
+    "high_mid",
+    "presence",
+    "brilliance",
+    "air",
+    "upper",
+    "super",
+];
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct EqState {
+    pub enabled: bool,
+    pub bands: [f32; EQ_NUM_BANDS],
+}
+
+impl Default for EqState {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            bands: [0.0; EQ_NUM_BANDS],
+        }
+    }
+}
+
+impl EqState {
+    pub fn clamp_gain(gain_db: f32) -> f32 {
+        gain_db.clamp(EQ_MIN_GAIN_DB, EQ_MAX_GAIN_DB)
+    }
+
+    pub fn set_band(&mut self, index: usize, gain_db: f32) {
+        if index < EQ_NUM_BANDS {
+            self.bands[index] = Self::clamp_gain(gain_db);
+        }
+    }
+
+    pub fn adjust_band(&mut self, index: usize, delta_db: f32) {
+        if index < EQ_NUM_BANDS {
+            self.bands[index] = Self::clamp_gain(self.bands[index] + delta_db);
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.bands = [0.0; EQ_NUM_BANDS];
+    }
+
+    pub fn resolve_band(name_or_index: &str) -> Option<usize> {
+        if let Ok(index) = name_or_index.parse::<usize>() {
+            return (index < EQ_NUM_BANDS).then_some(index);
+        }
+        EQ_BAND_NAMES.iter().position(|name| *name == name_or_index)
+    }
+
+    pub fn apply_preset(&mut self, name: &str) -> bool {
+        if let Some(bands) = EQ_PRESETS
+            .iter()
+            .find(|(preset_name, _)| *preset_name == name)
+            .map(|(_, bands)| *bands)
+        {
+            self.bands = bands;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+pub const EQ_PRESETS: &[(&str, [f32; EQ_NUM_BANDS])] = &[
+    ("flat", [0.0; EQ_NUM_BANDS]),
+    (
+        "bass_boost",
+        [4.0, 5.0, 3.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    ),
+    (
+        "treble_boost",
+        [0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 4.0, 5.0, 4.0, 3.0],
+    ),
+    (
+        "vocal",
+        [-2.0, -1.0, 0.0, 2.0, 3.0, 2.0, 0.0, -1.0, -2.0, -2.0],
+    ),
+];
+
+pub type SharedEqState = Arc<RwLock<EqState>>;
+
+pub fn shared_eq_state(state: EqState) -> SharedEqState {
+    Arc::new(RwLock::new(state))
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Biquad {
+    b0: f64,
+    b1: f64,
+    b2: f64,
+    a1: f64,
+    a2: f64,
+    z1: f64,
+    z2: f64,
+}
+
+impl Biquad {
+    fn peaking(freq_hz: f32, gain_db: f32, q: f32, sample_rate: f32) -> Self {
+        let a = 10_f64.powf(gain_db as f64 / 40.0);
+        let w0 = 2.0 * std::f64::consts::PI * freq_hz as f64 / sample_rate as f64;
+        let alpha = w0.sin() / (2.0 * q as f64);
+        let cos_w0 = w0.cos();
+
+        let b0 = 1.0 + alpha * a;
+        let b1 = -2.0 * cos_w0;
+        let b2 = 1.0 - alpha * a;
+        let a0 = 1.0 + alpha / a;
+        let a1 = -2.0 * cos_w0;
+        let a2 = 1.0 - alpha / a;
+
+        Self {
+            b0: b0 / a0,
+            b1: b1 / a0,
+            b2: b2 / a0,
+            a1: a1 / a0,
+            a2: a2 / a0,
+            z1: 0.0,
+            z2: 0.0,
+        }
+    }
+
+    fn process(&mut self, x: f64) -> f64 {
+        let y = self.b0 * x + self.z1;
+        self.z1 = self.b1 * x - self.a1 * y + self.z2;
+        self.z2 = self.b2 * x - self.a2 * y;
+        y
+    }
+
+    fn reset(&mut self) {
+        self.z1 = 0.0;
+        self.z2 = 0.0;
+    }
+}
+
+pub struct EqProcessor {
+    filters: Vec<[Biquad; 2]>,
+    last_bands: [f32; EQ_NUM_BANDS],
+}
+
+impl EqProcessor {
+    pub fn new() -> Self {
+        Self {
+            filters: vec![[Biquad::peaking(1000.0, 0.0, 1.0, EQ_SAMPLE_RATE); 2]; EQ_NUM_BANDS],
+            last_bands: [f32::NAN; EQ_NUM_BANDS],
+        }
+    }
+
+    fn sync_coefficients(&mut self, bands: &[f32; EQ_NUM_BANDS]) {
+        if self.last_bands == *bands {
+            return;
+        }
+        for (i, gain) in bands.iter().enumerate() {
+            let freq = EQ_FREQUENCIES_HZ[i];
+            self.filters[i] = [
+                Biquad::peaking(freq, *gain, 1.0, EQ_SAMPLE_RATE),
+                Biquad::peaking(freq, *gain, 1.0, EQ_SAMPLE_RATE),
+            ];
+        }
+        self.last_bands = *bands;
+    }
+
+    pub fn process_samples(&mut self, samples: &mut [f64], bands: &[f32; EQ_NUM_BANDS]) {
+        self.sync_coefficients(bands);
+        for frame in samples.chunks_mut(2) {
+            if frame.len() == 2 {
+                for (channel, sample) in frame.iter_mut().enumerate() {
+                    for filter in &mut self.filters {
+                        *sample = filter[channel].process(*sample);
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn reset(&mut self) {
+        for band in &mut self.filters {
+            band[0].reset();
+            band[1].reset();
+        }
+    }
+}
+
+pub fn process_samples_if_enabled(
+    processor: &mut EqProcessor,
+    samples: &mut [f64],
+    state: &EqState,
+) {
+    if !state.enabled {
+        return;
+    }
+    if state.bands.iter().all(|g| g.abs() < f32::EPSILON) {
+        return;
+    }
+    processor.process_samples(samples, &state.bands);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clamp_gain_limits_range() {
+        assert_eq!(EqState::clamp_gain(-20.0), EQ_MIN_GAIN_DB);
+        assert_eq!(EqState::clamp_gain(20.0), EQ_MAX_GAIN_DB);
+        assert_eq!(EqState::clamp_gain(3.5), 3.5);
+    }
+
+    #[test]
+    fn resolve_band_by_name_and_index() {
+        assert_eq!(EqState::resolve_band("bass"), Some(1));
+        assert_eq!(EqState::resolve_band("3"), Some(3));
+        assert_eq!(EqState::resolve_band("unknown"), None);
+        assert_eq!(EqState::resolve_band("10"), None);
+    }
+
+    #[test]
+    fn apply_preset_updates_bands() {
+        let mut state = EqState::default();
+        assert!(state.apply_preset("bass_boost"));
+        assert_eq!(state.bands[1], 5.0);
+        assert!(!state.apply_preset("nope"));
+    }
+
+    #[test]
+    fn process_samples_changes_nonzero_input_when_enabled() {
+        let mut processor = EqProcessor::new();
+        let mut samples = vec![0.5, 0.5, -0.5, -0.5];
+        let state = EqState {
+            enabled: true,
+            bands: {
+                let mut b = [0.0; EQ_NUM_BANDS];
+                b[1] = 6.0;
+                b
+            },
+        };
+        process_samples_if_enabled(&mut processor, &mut samples, &state);
+        assert_ne!(samples, vec![0.5, 0.5, -0.5, -0.5]);
+    }
+
+    #[test]
+    fn disabled_eq_leaves_samples_unchanged() {
+        let mut processor = EqProcessor::new();
+        let original = vec![0.25, -0.25, 0.1, -0.1];
+        let mut samples = original.clone();
+        let state = EqState {
+            enabled: false,
+            bands: [6.0; EQ_NUM_BANDS],
+        };
+        process_samples_if_enabled(&mut processor, &mut samples, &state);
+        assert_eq!(samples, original);
+    }
+}

--- a/src/audio/eq_sink.rs
+++ b/src/audio/eq_sink.rs
@@ -1,0 +1,82 @@
+use librespot_playback::audio_backend::{Sink, SinkResult};
+use librespot_playback::convert::Converter;
+use librespot_playback::decoder::AudioPacket;
+
+use super::{EqProcessor, SharedEqState, process_samples_if_enabled};
+
+pub struct EqSink {
+    inner: Box<dyn Sink>,
+    state: SharedEqState,
+    processor: EqProcessor,
+}
+
+impl EqSink {
+    pub fn new(inner: Box<dyn Sink>, state: SharedEqState) -> Self {
+        Self {
+            inner,
+            state,
+            processor: EqProcessor::new(),
+        }
+    }
+}
+
+impl Sink for EqSink {
+    fn start(&mut self) -> SinkResult<()> {
+        self.inner.start()
+    }
+
+    fn stop(&mut self) -> SinkResult<()> {
+        self.processor.reset();
+        self.inner.stop()
+    }
+
+    fn write(&mut self, packet: AudioPacket, converter: &mut Converter) -> SinkResult<()> {
+        match packet {
+            AudioPacket::Samples(mut samples) => {
+                let state = self.state.read().unwrap();
+                process_samples_if_enabled(&mut self.processor, &mut samples, &state);
+                self.inner.write(AudioPacket::Samples(samples), converter)
+            }
+            other => self.inner.write(other, converter),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, RwLock};
+
+    use crate::audio::EqState;
+
+    struct RecordingSink {
+        last_len: usize,
+    }
+
+    impl Sink for RecordingSink {
+        fn write(&mut self, packet: AudioPacket, _converter: &mut Converter) -> SinkResult<()> {
+            if let AudioPacket::Samples(samples) = packet {
+                self.last_len = samples.len();
+            }
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn write_forwards_samples_to_inner_sink() {
+        let state = Arc::new(RwLock::new(EqState::default()));
+        let mut rec = RecordingSink { last_len: 0 };
+        let mut converter = Converter::new(None);
+        let samples = vec![0.1, -0.1, 0.2, -0.2];
+        rec.write(AudioPacket::Samples(samples), &mut converter)
+            .unwrap();
+        assert_eq!(rec.last_len, 4);
+
+        let mut sink = EqSink::new(Box::new(RecordingSink { last_len: 0 }), state);
+        sink.write(
+            AudioPacket::Samples(vec![0.1, -0.1, 0.2, -0.2]),
+            &mut Converter::new(None),
+        )
+        .unwrap();
+    }
+}

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -1,0 +1,8 @@
+mod eq;
+mod eq_sink;
+
+pub use eq::{
+    EQ_BAND_NAMES, EQ_MAX_GAIN_DB, EQ_MIN_GAIN_DB, EQ_NUM_BANDS, EqProcessor, EqState,
+    SharedEqState, process_samples_if_enabled, shared_eq_state,
+};
+pub use eq_sink::EqSink;

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,3 +1,4 @@
+use crate::audio::EqState;
 use crate::queue::RepeatSetting;
 use crate::spotify_url::SpotifyUrl;
 use std::collections::HashMap;
@@ -113,6 +114,33 @@ impl fmt::Display for InsertSource {
     }
 }
 
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub enum EqSubcommand {
+    On,
+    Off,
+    Toggle,
+    Reset,
+    Preset(String),
+    Set { band: usize, gain_db: f32 },
+    Adjust { band: usize, delta: f32 },
+    Show,
+}
+
+impl fmt::Display for EqSubcommand {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::On => write!(f, "on"),
+            Self::Off => write!(f, "off"),
+            Self::Toggle => write!(f, "toggle"),
+            Self::Reset => write!(f, "reset"),
+            Self::Show => write!(f, "show"),
+            Self::Preset(name) => write!(f, "preset {name}"),
+            Self::Set { band, gain_db } => write!(f, "band {band} {gain_db}"),
+            Self::Adjust { band, delta } => write!(f, "band {band} {delta:+}"),
+        }
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub enum Command {
     Quit,
@@ -157,6 +185,8 @@ pub enum Command {
     Redraw,
     Execute(String),
     Reconnect,
+    Equalizer(EqSubcommand),
+    EqualizerView,
 }
 
 impl fmt::Display for Command {
@@ -199,6 +229,7 @@ impl fmt::Display for Command {
             Self::Sort(key, direction) => vec![key.to_string(), direction.to_string()],
             Self::ShowRecommendations(mode) => vec![mode.to_string()],
             Self::Execute(cmd) => vec![cmd.to_owned()],
+            Self::Equalizer(sub) => vec![sub.to_string()],
             Self::Quit
             | Self::TogglePlay
             | Self::Stop
@@ -221,6 +252,7 @@ impl fmt::Display for Command {
             | Self::Noop
             | Self::Logout
             | Self::Reconnect
+            | Self::EqualizerView
             | Self::Redraw => vec![],
         };
         repr_tokens.append(&mut extras_args);
@@ -275,6 +307,8 @@ impl Command {
             Self::Redraw => "redraw",
             Self::Execute(_) => "exec",
             Self::Reconnect => "reconnect",
+            Self::Equalizer(_) => "eq",
+            Self::EqualizerView => "eqview",
         }
     }
 }
@@ -780,6 +814,87 @@ pub fn parse(input: &str) -> Result<Vec<Command>, CommandParseError> {
                 "redraw" => Command::Redraw,
                 "exec" => Command::Execute(args.join(" ")),
                 "reconnect" => Command::Reconnect,
+                "eqview" => Command::EqualizerView,
+                "eq" => {
+                    let sub = args.first().copied().unwrap_or("show");
+                    match sub {
+                        "on" => Command::Equalizer(EqSubcommand::On),
+                        "off" => Command::Equalizer(EqSubcommand::Off),
+                        "toggle" => Command::Equalizer(EqSubcommand::Toggle),
+                        "reset" => Command::Equalizer(EqSubcommand::Reset),
+                        "show" => Command::Equalizer(EqSubcommand::Show),
+                        "preset" => {
+                            let name = args.get(1).ok_or(E::InsufficientArgs {
+                                cmd: "eq preset".into(),
+                                hint: Some("a preset name".into()),
+                            })?;
+                            Command::Equalizer(EqSubcommand::Preset((*name).into()))
+                        }
+                        "band" => {
+                            let band_raw = args.get(1).ok_or(E::InsufficientArgs {
+                                cmd: "eq band".into(),
+                                hint: Some("band name or index".into()),
+                            })?;
+                            let band = EqState::resolve_band(band_raw).ok_or(E::ArgParseError {
+                                arg: (*band_raw).into(),
+                                err: "unknown EQ band".into(),
+                            })?;
+                            let value_raw = args.get(2).ok_or(E::InsufficientArgs {
+                                cmd: "eq band".into(),
+                                hint: Some("gain in dB".into()),
+                            })?;
+                            if let Some(stripped) = value_raw.strip_prefix('+') {
+                                let delta =
+                                    stripped.parse::<f32>().map_err(|e| E::ArgParseError {
+                                        arg: (*value_raw).into(),
+                                        err: e.to_string(),
+                                    })?;
+                                Command::Equalizer(EqSubcommand::Adjust { band, delta })
+                            } else if let Some(stripped) = value_raw.strip_prefix('-') {
+                                if stripped.is_empty() {
+                                    let gain_db =
+                                        value_raw.parse::<f32>().map_err(|e| E::ArgParseError {
+                                            arg: (*value_raw).into(),
+                                            err: e.to_string(),
+                                        })?;
+                                    Command::Equalizer(EqSubcommand::Set { band, gain_db })
+                                } else {
+                                    let delta =
+                                        stripped.parse::<f32>().map_err(|e| E::ArgParseError {
+                                            arg: (*value_raw).into(),
+                                            err: e.to_string(),
+                                        })?;
+                                    Command::Equalizer(EqSubcommand::Adjust {
+                                        band,
+                                        delta: -delta,
+                                    })
+                                }
+                            } else {
+                                let gain_db =
+                                    value_raw.parse::<f32>().map_err(|e| E::ArgParseError {
+                                        arg: (*value_raw).into(),
+                                        err: e.to_string(),
+                                    })?;
+                                Command::Equalizer(EqSubcommand::Set { band, gain_db })
+                            }
+                        }
+                        other => {
+                            return Err(E::BadEnumArg {
+                                arg: other.into(),
+                                accept: vec![
+                                    "on".into(),
+                                    "off".into(),
+                                    "toggle".into(),
+                                    "reset".into(),
+                                    "show".into(),
+                                    "preset".into(),
+                                    "band".into(),
+                                ],
+                                optional: false,
+                            });
+                        }
+                    }
+                }
                 _ => {
                     return Err(E::NoSuchCommand {
                         cmd: command.into(),
@@ -790,4 +905,42 @@ pub fn parse(input: &str) -> Result<Vec<Command>, CommandParseError> {
         };
     }
     Ok(commands)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(cmd: &str) -> Command {
+        crate::command::parse(cmd).expect("parse failed")[0].clone()
+    }
+
+    #[test]
+    fn parse_eq_on_off() {
+        assert!(matches!(
+            parse("eq on"),
+            Command::Equalizer(EqSubcommand::On)
+        ));
+        assert!(matches!(
+            parse("eq off"),
+            Command::Equalizer(EqSubcommand::Off)
+        ));
+    }
+
+    #[test]
+    fn parse_eq_preset() {
+        assert!(matches!(
+            parse("eq preset bass_boost"),
+            Command::Equalizer(EqSubcommand::Preset(name)) if name == "bass_boost"
+        ));
+    }
+
+    #[test]
+    fn parse_eq_band_adjust() {
+        assert!(matches!(
+            parse("eq band bass +2"),
+            Command::Equalizer(EqSubcommand::Adjust { band, delta })
+            if band == 1 && (delta - 2.0).abs() < f32::EPSILON
+        ));
+    }
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -4,7 +4,8 @@ use std::time::Duration;
 
 use crate::application::UserData;
 use crate::command::{
-    Command, GotoMode, JumpMode, MoveAmount, MoveMode, SeekDirection, ShiftMode, TargetMode, parse,
+    Command, EqSubcommand, GotoMode, JumpMode, MoveAmount, MoveMode, SeekDirection, ShiftMode,
+    TargetMode, parse,
 };
 use crate::config::{Config, user_configuration_directory};
 use crate::events::EventManager;
@@ -16,6 +17,7 @@ use crate::traits::{IntoBoxedViewExt, ListItem, ViewExt};
 use crate::ui::contextmenu::{
     AddToPlaylistMenu, ContextMenu, SelectArtistActionMenu, SelectArtistMenu,
 };
+use crate::ui::equalizer::EqualizerView;
 use crate::ui::help::HelpView;
 use crate::ui::layout::Layout;
 use crate::ui::modal::Modal;
@@ -205,6 +207,54 @@ impl CommandManager {
                 self.spotify.set_volume(volume, true);
                 Ok(None)
             }
+            Command::Equalizer(sub) => match sub {
+                EqSubcommand::On => {
+                    self.spotify.set_eq_enabled(true);
+                    Ok(None)
+                }
+                EqSubcommand::Off => {
+                    self.spotify.set_eq_enabled(false);
+                    Ok(None)
+                }
+                EqSubcommand::Toggle => {
+                    let enabled = !self.spotify.eq_state().enabled;
+                    self.spotify.set_eq_enabled(enabled);
+                    Ok(None)
+                }
+                EqSubcommand::Reset => {
+                    self.spotify.reset_eq();
+                    Ok(None)
+                }
+                EqSubcommand::Preset(name) => self.spotify.apply_eq_preset(name).map(|_| None),
+                EqSubcommand::Set { band, gain_db } => {
+                    self.spotify.set_eq_band(*band, *gain_db);
+                    Ok(None)
+                }
+                EqSubcommand::Adjust { band, delta } => {
+                    self.spotify.adjust_eq_band(*band, *delta);
+                    Ok(None)
+                }
+                EqSubcommand::Show => {
+                    let state = self.spotify.eq_state();
+                    let bands: Vec<String> = state
+                        .bands
+                        .iter()
+                        .enumerate()
+                        .map(|(i, g)| format!("{}:{g:.1}", crate::audio::EQ_BAND_NAMES[i]))
+                        .collect();
+                    let msg = format!(
+                        "eq {} [{}]",
+                        if state.enabled { "on" } else { "off" },
+                        bands.join(" ")
+                    );
+                    Ok(Some(msg))
+                }
+            },
+            Command::EqualizerView => {
+                let view = Box::new(EqualizerView::new(&self.spotify));
+                s.call_on_name("main", move |v: &mut Layout| v.push_view(view));
+                Ok(None)
+            }
             Command::Help => {
                 let view = Box::new(HelpView::new(self.bindings.borrow().clone()));
                 s.call_on_name("main", move |v: &mut Layout| v.push_view(view));
@@ -231,6 +281,10 @@ impl CommandManager {
                 self.unregister_keybindings(s);
                 self.bindings.replace(Self::get_bindings(&self.config));
                 self.register_keybindings(s);
+
+                let fresh = self.config.initial_eq_state();
+                *self.spotify.eq_state_ref().write().unwrap() = fresh;
+
                 Ok(None)
             }
             Command::NewPlaylist(name) => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,7 @@ use log::{debug, error};
 use ncspot::{CONFIGURATION_FILE_NAME, USER_STATE_FILE_NAME};
 use platform_dirs::AppDirs;
 
+use crate::audio::{EQ_NUM_BANDS, EqState};
 use crate::command::{SortDirection, SortKey};
 use crate::model::playable::Playable;
 use crate::queue;
@@ -101,6 +102,38 @@ pub struct ConfigValues {
     pub library_tabs: Option<Vec<LibraryTab>>,
     pub hide_display_names: Option<bool>,
     pub ap_port: Option<u16>,
+    pub equalizer: Option<EqualizerConfig>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, Default, PartialEq)]
+pub struct EqualizerState {
+    pub enabled: bool,
+    pub bands: [f32; EQ_NUM_BANDS],
+}
+
+impl From<EqState> for EqualizerState {
+    fn from(value: EqState) -> Self {
+        Self {
+            enabled: value.enabled,
+            bands: value.bands,
+        }
+    }
+}
+
+impl From<EqualizerState> for EqState {
+    fn from(value: EqualizerState) -> Self {
+        Self {
+            enabled: value.enabled,
+            bands: value.bands,
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, Default)]
+pub struct EqualizerConfig {
+    pub enabled: Option<bool>,
+    pub bands: Option<Vec<f32>>,
+    pub preset: Option<String>,
 }
 
 /// The ncspot theme.
@@ -153,6 +186,7 @@ pub struct UserState {
     pub playlist_orders: HashMap<String, SortingOrder>,
     pub cache_version: u16,
     pub playback_state: PlaybackState,
+    pub equalizer: EqualizerState,
 }
 
 impl Default for UserState {
@@ -165,6 +199,7 @@ impl Default for UserState {
             playlist_orders: HashMap::new(),
             cache_version: 0,
             playback_state: PlaybackState::Default,
+            equalizer: EqualizerState::default(),
         }
     }
 }
@@ -285,6 +320,31 @@ impl Config {
         *self.values.write().unwrap() = cfg;
         Ok(())
     }
+
+    pub fn initial_eq_state(&self) -> EqState {
+        let mut state: EqState = self.state().equalizer.clone().into();
+        if let Some(cfg) = &self.values().equalizer {
+            if let Some(enabled) = cfg.enabled {
+                state.enabled = enabled;
+            }
+            if let Some(bands) = &cfg.bands {
+                for (i, gain) in bands.iter().take(EQ_NUM_BANDS).enumerate() {
+                    state.bands[i] = EqState::clamp_gain(*gain);
+                }
+            }
+            if let Some(preset) = &cfg.preset {
+                state.apply_preset(preset);
+            }
+        }
+        state
+    }
+
+    pub fn save_equalizer(&self, state: &EqState) {
+        self.with_state_mut(|s| {
+            s.equalizer = EqualizerState::from(state.clone());
+        });
+        self.save_state();
+    }
 }
 
 /// Parse the configuration file with name `filename` at the configuration base path.
@@ -364,5 +424,30 @@ pub fn set_configuration_base_path(base_path: Option<PathBuf>) {
             fs::create_dir_all(&basepath).expect("could not create basepath directory");
         }
         *BASE_PATH.write().unwrap() = Some(basepath);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn equalizer_state_defaults_disabled() {
+        let state = UserState::default();
+        assert!(!state.equalizer.enabled);
+        assert_eq!(state.equalizer.bands, [0.0; EQ_NUM_BANDS]);
+    }
+
+    #[test]
+    fn equalizer_config_parses_from_toml() {
+        let raw = r#"
+            [equalizer]
+            enabled = true
+            bands = [1.0, 2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        "#;
+        let cfg: ConfigValues = toml::from_str(raw).unwrap();
+        let eq = cfg.equalizer.unwrap();
+        assert_eq!(eq.enabled, Some(true));
+        assert_eq!(eq.bands.as_ref().unwrap().len(), 10);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use log::error;
 use ncspot::program_arguments;
 
 mod application;
+mod audio;
 mod authentication;
 mod cli;
 mod command;

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -21,6 +21,7 @@ use tokio::sync::mpsc;
 use url::Url;
 
 use crate::application::ASYNC_RUNTIME;
+use crate::audio::{EqSink, EqState, SharedEqState, shared_eq_state};
 use crate::authentication::SPOTIFY_CLIENT_ID;
 use crate::config;
 use crate::events::{Event, EventManager};
@@ -62,6 +63,7 @@ pub struct Spotify {
     since: Arc<RwLock<Option<SystemTime>>>,
     /// Channel to send commands to the worker thread.
     channel: Arc<RwLock<Option<mpsc::UnboundedSender<WorkerCommand>>>>,
+    eq_state: SharedEqState,
 }
 
 impl Spotify {
@@ -70,6 +72,7 @@ impl Spotify {
         credentials: Credentials,
         cfg: Arc<config::Config>,
     ) -> Result<Self, Box<dyn Error>> {
+        let eq_state = shared_eq_state(cfg.initial_eq_state());
         let mut spotify = Self {
             events,
             #[cfg(feature = "mpris")]
@@ -81,6 +84,7 @@ impl Spotify {
             elapsed: Arc::new(RwLock::new(None)),
             since: Arc::new(RwLock::new(None)),
             channel: Arc::new(RwLock::new(None)),
+            eq_state,
         };
 
         let (user_tx, user_rx) = oneshot::channel();
@@ -115,6 +119,7 @@ impl Spotify {
             elapsed: Arc::new(RwLock::new(None)),
             since: Arc::new(RwLock::new(None)),
             channel: Arc::new(RwLock::new(None)),
+            eq_state: shared_eq_state(EqState::default()),
         }
     }
 
@@ -133,6 +138,7 @@ impl Spotify {
         let credentials = self.credentials.clone();
         let backend_name = cfg.values().backend.clone();
         let backend = Self::init_backend(backend_name)?;
+        let eq_state = self.eq_state.clone();
         ASYNC_RUNTIME.get().unwrap().spawn(Self::worker(
             worker_channel,
             events,
@@ -142,6 +148,7 @@ impl Spotify {
             user_tx,
             volume,
             backend,
+            eq_state,
         ));
         Ok(())
     }
@@ -246,6 +253,7 @@ impl Spotify {
         user_tx: Option<oneshot::Sender<String>>,
         volume: u16,
         backend: SinkBuilder,
+        eq_state: SharedEqState,
     ) {
         let bitrate_str = cfg.values().bitrate.unwrap_or(320).to_string();
         let bitrate = Bitrate::from_str(&bitrate_str);
@@ -277,7 +285,11 @@ impl Spotify {
             player_config,
             session.clone(),
             mixer.get_soft_volume(),
-            move || (backend)(cfg.values().backend_device.clone(), audio_format),
+            move || {
+                let inner = (backend)(cfg.values().backend_device.clone(), audio_format);
+                Box::new(EqSink::new(inner, eq_state.clone()))
+                    as Box<dyn librespot_playback::audio_backend::Sink>
+            },
         );
         let player_events = player.get_player_event_channel();
 
@@ -484,6 +496,59 @@ impl Spotify {
         if notify {
             #[cfg(feature = "mpris")]
             self.send_mpris(MprisCommand::EmitVolumeStatus)
+        }
+    }
+
+    pub fn eq_state(&self) -> EqState {
+        self.eq_state.read().unwrap().clone()
+    }
+
+    pub fn eq_state_ref(&self) -> &SharedEqState {
+        &self.eq_state
+    }
+
+    pub fn set_eq_enabled(&self, enabled: bool) {
+        {
+            let mut state = self.eq_state.write().unwrap();
+            state.enabled = enabled;
+        }
+        self.cfg.save_equalizer(&self.eq_state.read().unwrap());
+    }
+
+    pub fn set_eq_band(&self, index: usize, gain_db: f32) {
+        {
+            let mut state = self.eq_state.write().unwrap();
+            state.set_band(index, gain_db);
+        }
+        self.cfg.save_equalizer(&self.eq_state.read().unwrap());
+    }
+
+    pub fn adjust_eq_band(&self, index: usize, delta_db: f32) {
+        {
+            let mut state = self.eq_state.write().unwrap();
+            state.adjust_band(index, delta_db);
+        }
+        self.cfg.save_equalizer(&self.eq_state.read().unwrap());
+    }
+
+    pub fn reset_eq(&self) {
+        {
+            let mut state = self.eq_state.write().unwrap();
+            state.reset();
+        }
+        self.cfg.save_equalizer(&self.eq_state.read().unwrap());
+    }
+
+    pub fn apply_eq_preset(&self, name: &str) -> Result<(), String> {
+        let ok = {
+            let mut state = self.eq_state.write().unwrap();
+            state.apply_preset(name)
+        };
+        if ok {
+            self.cfg.save_equalizer(&self.eq_state.read().unwrap());
+            Ok(())
+        } else {
+            Err(format!("unknown equalizer preset: {name}"))
         }
     }
 

--- a/src/ui/equalizer.rs
+++ b/src/ui/equalizer.rs
@@ -1,0 +1,103 @@
+use cursive::theme::Effect;
+use cursive::utils::markup::StyledString;
+use cursive::view::{ViewWrapper, scroll::Scroller};
+use cursive::views::{ScrollView, TextView};
+
+use crate::audio::{EQ_BAND_NAMES, EQ_MAX_GAIN_DB, EQ_MIN_GAIN_DB};
+use crate::command::{Command, MoveAmount, MoveMode};
+use crate::commands::CommandResult;
+use crate::spotify::Spotify;
+use crate::traits::ViewExt;
+
+pub struct EqualizerView {
+    view: ScrollView<TextView>,
+}
+
+impl EqualizerView {
+    pub fn new(spotify: &Spotify) -> Self {
+        let state = spotify.eq_state();
+        let mut text = StyledString::styled("Equalizer\n\n", Effect::Bold);
+        text.append(format!(
+            "Status: {}\n\n",
+            if state.enabled { "on" } else { "off" }
+        ));
+        text.append("Commands:\n");
+        text.append("  :eq on | off | toggle\n");
+        text.append("  :eq preset <name>\n");
+        text.append("  :eq band <name|index> <dB>\n");
+        text.append("  :eq band bass +1\n");
+        text.append("  :eq reset\n\n");
+        text.append(format!(
+            "Gain range: {EQ_MIN_GAIN_DB} .. {EQ_MAX_GAIN_DB} dB\n\n"
+        ));
+        for (i, gain) in state.bands.iter().enumerate() {
+            text.append(format!(
+                "{:>2} {:>10} {:>5.1} dB\n",
+                i, EQ_BAND_NAMES[i], gain
+            ));
+        }
+        Self {
+            view: ScrollView::new(TextView::new(text)),
+        }
+    }
+}
+
+impl ViewWrapper for EqualizerView {
+    wrap_impl!(self.view: ScrollView<TextView>);
+}
+
+impl ViewExt for EqualizerView {
+    fn title(&self) -> String {
+        "Equalizer".to_string()
+    }
+
+    fn on_command(
+        &mut self,
+        _s: &mut cursive::Cursive,
+        cmd: &Command,
+    ) -> Result<CommandResult, String> {
+        match cmd {
+            Command::EqualizerView => Ok(CommandResult::Consumed(None)),
+            Command::Move(mode, amount) => {
+                let scroller = self.view.get_scroller_mut();
+                let viewport = scroller.content_viewport();
+                match mode {
+                    MoveMode::Up => {
+                        match amount {
+                            MoveAmount::Extreme => {
+                                self.view.scroll_to_top();
+                            }
+                            MoveAmount::Float(scale) => {
+                                let scroll = (viewport.height() as f32) * scale;
+                                scroller
+                                    .scroll_to_y(viewport.top().saturating_sub(scroll as usize));
+                            }
+                            MoveAmount::Integer(n) => {
+                                scroller.scroll_to_y(viewport.top().saturating_sub(*n as usize));
+                            }
+                        };
+                        Ok(CommandResult::Consumed(None))
+                    }
+                    MoveMode::Down => {
+                        match amount {
+                            MoveAmount::Extreme => {
+                                self.view.scroll_to_bottom();
+                            }
+                            MoveAmount::Float(scale) => {
+                                let scroll = (viewport.height() as f32) * scale;
+                                scroller
+                                    .scroll_to_y(viewport.bottom().saturating_add(scroll as usize));
+                            }
+                            MoveAmount::Integer(n) => {
+                                scroller.scroll_to_y(viewport.bottom().saturating_add(*n as usize));
+                            }
+                        };
+                        Ok(CommandResult::Consumed(None))
+                    }
+                    _ => Ok(CommandResult::Consumed(None)),
+                }
+            }
+            _ => Ok(CommandResult::Ignored),
+        }
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -5,6 +5,7 @@ pub mod album;
 pub mod artist;
 pub mod browse;
 pub mod contextmenu;
+pub mod equalizer;
 pub mod help;
 pub mod layout;
 pub mod library;


### PR DESCRIPTION
## Describe your changes

Adds a 10-band software equalizer applied in the audio pipeline before output. Includes runtime commands (`:eq`, `:eqview`), config persistence, and presets (`flat`, `bass_boost`, `treble_boost`, `vocal`).

## Issue ticket number and link

N/A

## Checklist before requesting a review
- [x] Documentation was updated (i.e. due to changes in keybindings, commands, etc.)
- [x] Changelog was updated with relevant user-facing changes (eg. not dependency updates,
  not performance improvements, etc.)

Made with [Cursor](https://cursor.com)