### PR TITLE
chore(toolchain): update

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.96.1"
+channel = "1.97.1"
 components = ["rustfmt", "clippy", "rust-analyzer"]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -387,7 +387,7 @@ impl CommandManager {
     pub fn unregister_keybindings(&self, cursive: &mut Cursive) {
         let kb = self.bindings.borrow();
 
-        for (k, _v) in kb.iter() {
+        for k in kb.keys() {
             if let Some(binding) = Self::parse_keybinding(k) {
                 cursive.clear_global_callbacks(binding);
             }

--- a/src/spotify_api.rs
+++ b/src/spotify_api.rs
@@ -510,7 +510,7 @@ impl WebApi {
         let spotify = self.clone();
         let show_id = show_id.to_string();
         let fetch_page = move |offset: u32| {
-            debug!("fetching show {} episodes, offset: {}", &show_id, offset);
+            debug!("fetching show {} episodes, offset: {}", show_id, offset);
             spotify.api_with_retry(|api| {
                 match api.get_shows_episodes_manual(
                     ShowId::from_id(&show_id).unwrap(),


### PR DESCRIPTION
Automatic change by the [update-rust-toolchain](https://github.com/a-kenji/update-rust-toolchain) Github Action.

Github Actions will not run workflows on pull requests which are opened by a GitHub Action.

For examples on how to run an workflows on this pr, please go to the [readme](https://github.com/a-kenji/update-rust-toolchain/blob/main/README.md#running-github-actions-on-the-action).